### PR TITLE
scroll amount is sent big-endian

### DIFF
--- a/src/input/platforms/linux/uinput.cpp
+++ b/src/input/platforms/linux/uinput.cpp
@@ -164,7 +164,7 @@ void mouse_press(libevdev_uinput *mouse, const data::MOUSE_BUTTON_PACKET &btn_pk
 }
 
 void mouse_scroll(libevdev_uinput *mouse, const data::MOUSE_SCROLL_PACKET &scroll_pkt) {
-  int high_res_distance = scroll_pkt.scroll_amt1;
+  int high_res_distance = boost::endian::big_to_native(scroll_pkt.scroll_amt1);
   int distance = high_res_distance / 120;
 
   libevdev_uinput_write_event(mouse, EV_REL, REL_WHEEL, distance);


### PR DESCRIPTION
I noticed that scrolling with the mouse wheel resulted in very choppy scrolling in large chunks, so I did some digging. It looks like the scroll amount needs to be converted from big endian (compare to sunshine here: https://github.com/LizardByte/Sunshine/blob/09dff341056a26c1a41121a068327a3f8d9616df/src/input.cpp#L470).