### PR TITLE
Input updates and horizontal scrolling

### DIFF
--- a/.github/workflows/linux-build-test.yml
+++ b/.github/workflows/linux-build-test.yml
@@ -38,7 +38,7 @@ jobs:
           sudo apt-get install -y libunwind-dev
           sudo apt-get install -y \
               ninja-build \
-              libboost-thread-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev \
+              libboost-locale-dev libboost-thread-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev \
               libssl-dev \
               libgstreamer1.0-dev \
               libevdev-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update -y && \
     ccache \
     git \
     clang \
-    libboost-thread-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev \
+    libboost-thread-dev libboost-locale-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev \
     libssl-dev \
     libevdev-dev \
     libunwind-dev \

--- a/docs/modules/protocols/pages/control-specs.adoc
+++ b/docs/modules/protocols/pages/control-specs.adoc
@@ -74,6 +74,8 @@ The first two bytes of the decrypted payload represent the *type* of the message
 * PERIODIC_PING (`0x0200`)
 * IDR_FRAME (`0x0302`)
 
+The next two bytes indicate the size of the decrypted payload.  The format of the remaining data depends on the message type.
+
 [WARNING,caption=TODO]
 ====
 Add details of all the message types

--- a/docs/modules/protocols/pages/input-data.adoc
+++ b/docs/modules/protocols/pages/input-data.adoc
@@ -3,28 +3,66 @@
 
 Moonlight will send all user inputs via the xref:protocols:control-specs.adoc[control stream].
 
-The first 4 bytes of a packet of type `INPUT_DATA` will determine the type of input and the format of the packet itself (big endian):
+.General format of an `INPUT_DATA` message
+[bytefield,format=svg,align="center"]
+....
+(defn draw-group-label-header
+  [span label]
+  (draw-box (text label [:math {:font-size 12}]) {:span span :borders nil :height 14}))
+
+(defn draw-input-header
+  []
+  (draw-column-headers)
+  (draw-group-label-header 4 "Header")
+  (draw-group-label-header 12 "Payload")
+  (next-row 18))
+
+(draw-input-header)
+
+(draw-box 0x0206 [:box-first {:span 2}])
+(draw-box "length" [:box-related {:span 2}])
+(draw-box "input size" [:box-first {:span 4}])
+(draw-box "input type" [:box-related {:span 4}])
+(draw-box "data" {:span 2 :borders #{:left :top :bottom}})
+(draw-gap-inline)
+(draw-box nil {:borders #{:top :bottom :right}})
+....
+
+The first 4 bytes (big endian) following the header of a packet of type
+`INPUT_DATA` indicate the size of the message, which varies depending on the
+input type.  The next 4 bytes (little endian) specify the input type, which
+can be any of the values in the following table.
 
 |===
-|Input type |HEX code
+|Input type name|Value
 
 |MOUSE_MOVE_REL
-|`0x08`
+|`0x00000007`
 
 |MOUSE_MOVE_ABS
-|`0x0E`
+|`0x00000005`
 
-|MOUSE_BUTTON
-|`0x05`
+|MOUSE_BUTTON_DOWN
+|`0x00000008`
 
-|KEYBOARD_OR_SCROLL
-|`0x0A`
+|MOUSE_BUTTON_UP
+|`0x00000009`
+
+|KEY_DOWN
+|`0x00000003`
+
+|KEY_UP
+|`0x00000004`
+
+|MOUSE_SCROLL
+|`0x0000000A`
+
+|MOUSE_HSCROLL
+|`0x55000001`
 
 |CONTROLLER_MULTI
-|`0x1E`
+|`0x0000000C`
 
-|CONTROLLER
-|`0x18`
 |===
 
 == Mouse: relative move
@@ -32,19 +70,30 @@ The first 4 bytes of a packet of type `INPUT_DATA` will determine the type of in
 Moonlight will send mouse relative coordinates when the option "Optimize mouse for remote desktop instead of games" is turned `OFF`.
 
 .The full format of a `MOUSE_MOVE_REL` packet
-[packetdiag,format=svg,align="center"]
+[bytefield,format=svg,align="center"]
 ....
-{
-  colwidth = 8
-  node_height = 50
-  node_width = 70
+(defn draw-group-label-header
+  [span label]
+  (draw-box (text label [:math {:font-size 12}]) {:span span :borders nil :height 14}))
 
-  0-1: Packet Type
-  2-5: Input Type
-  6-9: unknown
-  10-11: Delta X
-  12-13: Delta Y
-}
+(defn draw-input-header
+  []
+  (draw-column-headers)
+  (draw-group-label-header 4 "Header")
+  (draw-group-label-header 12 "Payload")
+  (next-row 18))
+
+(draw-input-header)
+(draw-row-header "format")
+(draw-box 0x0206 [:box-first {:span 2}])
+(draw-box 0xc [:box-related {:span 2}])
+(draw-box 0x8 [:box-first {:span 4}])
+(draw-box 0x7 [:box-related {:span 4}])
+(draw-box "delta X" [:box-related {:span 2}])
+(draw-box "delta Y" [:box-related {:span 2}])
+(next-row)
+(draw-row-header "network")
+(draw-boxes [0x6 0x2 0xC 0x0 0x0 0x0 0x0 0x8 0x7 0x0 0x0 0x0 0xFF 0xFF 0x0 0x0])
 ....
 
 `Delta X` and `Delta Y` defines the relative movement that the mouse must perform.
@@ -57,22 +106,35 @@ Moonlight will send mouse relative coordinates when the option "Optimize mouse f
 Moonlight will send mouse absolute coordinates when the option "Optimize mouse for remote desktop instead of games" is turned `ON`.
 
 .The full format of a `MOUSE_MOVE_ABS` packet
-[packetdiag,format=svg,align="center"]
+[bytefield,format=svg,align="center"]
 ....
-{
-  colwidth = 8
-  node_height = 50
-  node_width = 70
+(defn draw-group-label-header
+  [span label]
+  (draw-box (text label [:math {:font-size 12}]) {:span span :borders nil :height 14}))
 
-  0-1: Packet Type
-  2-5: Input Type
-  6-9: unknown
-  10-11: X
-  12-13: Y
-  14-15: unknown
-  16-17: width
-  18-19: height
-}
+(defn draw-input-header
+  []
+  (draw-column-headers)
+  (draw-group-label-header 4 "Header")
+  (draw-group-label-header 12 "Payload")
+  (next-row 18))
+
+(draw-input-header)
+(draw-row-header "format")
+(draw-box 0x0206 [:box-first {:span 2}])
+(draw-box 0x12 [:box-related {:span 2}])
+(draw-box 0xe [:box-first {:span 4}])
+(draw-box 0x5 [:box-related {:span 4}])
+(draw-box "X" [:box-related {:span 2}])
+(draw-box "Y" [:box-last {:span 2}])
+(draw-boxes [nil nil])
+(draw-box "width" [:box-related {:span 2}])
+(draw-box "height" [:box-last {:span 2}])
+(next-row)
+(next-row)
+(draw-row-header "network")
+(draw-boxes [0x06 0x02 0x12 0x00 0x00 0x00 0x00 0x0E 0x05 0x00 0x00 0x00 0x05 0xB8 0x02 0x10 0x00 0x00 0x07 0x7F 0x04 0x37
+])
 ....
 
 In order to define an absolute position Moonlight will send both:
@@ -85,19 +147,31 @@ In order to define an absolute position Moonlight will send both:
 
 == Mouse: button
 
-.The full format of a `MOUSE_BUTTON` packet
-[packetdiag,format=svg,align="center"]
+.The full format of a `MOUSE_BUTTON_DOWN` or `MOUSE_BUTTON_UP` packet
+[bytefield,format=svg,align="center"]
 ....
-{
-  colwidth = 8
-  node_height = 50
-  node_width = 70
+(defn draw-group-label-header
+  [span label]
+  (draw-box (text label [:math {:font-size 12}]) {:span span :borders nil :height 14}))
 
-  0-1: Packet Type
-  2-5: Input Type
-  6-6: Action
-  7-10: Button
-}
+(defn draw-input-header
+  []
+  (draw-column-headers)
+  (draw-group-label-header 4 "Header")
+  (draw-group-label-header 9 "Payload")
+  (next-row 18))
+
+(draw-input-header)
+(draw-row-header "format")
+(draw-box 0x0206 [:box-first {:span 2}])
+(draw-box 0x9 [:box-related {:span 2}])
+(draw-box 0x5 [:box-first {:span 4}])
+(draw-box "action" [:box-related {:span 4}])
+(draw-box "btn" [:box-last])
+(next-row)
+(next-row)
+(draw-row-header "network")
+(draw-boxes [0x06 0x02 0x09 0x00 0x00 0x00 0x00 0x05 0x08 0x00 0x00 0x00 0x01])
 ....
 
 `Action` can have the following values:
@@ -133,66 +207,57 @@ In order to define an absolute position Moonlight will send both:
 |Button extra
 |===
 
-== Keyboard or mouse scroll
+== Keyboard
 
-Unfortunately an input packet of type: `0x0A` can be either a keyboard packet or a mouse scroll packet. +
-In order to discriminate between the two you can check the next byte after the `Input Type`, if it's `0x0A` the packet will be parsed as a `MOUSE_SCROLL` otherwise it's a `KEYBOARD`.
-
-=== Mouse scroll
-
-.The full format of a `MOUSE_SCROLL` packet
-[packetdiag,format=svg,align="center"]
+.The full format of a `KEY_DOWN` or `KEY_UP` packet
+[bytefield,format=svg,align="center"]
 ....
-{
-  colwidth = 8
-  node_height = 50
-  node_width = 70
+(defn draw-group-label-header
+  [span label]
+  (draw-box (text label [:math {:font-size 12}]) {:span span :borders nil :height 14}))
 
-  0-1: Packet Type
-  2-5: Input Type
-  6-6: 0x0A
-  7-9: zeros
-  10-11: Scroll amount 1
-  12-13: Scroll amount 2
-  14-15: zeros
-}
+(defn draw-input-header
+  []
+  (draw-column-headers)
+  (draw-group-label-header 4 "Header")
+  (draw-group-label-header 9 "Payload")
+  (next-row 18))
+
+(draw-input-header)
+(draw-row-header "format")
+(draw-box 0x0206 [:box-first {:span 2}])
+(draw-box 0xe [:box-related {:span 2}])
+(draw-box 0xa [:box-first {:span 4}])
+(draw-box "action" [:box-related {:span 4}])
+(draw-box "flags" [:box-related])
+(draw-box "key code" [:box-related {:span 2}])
+(draw-box "mod" [:box-last])
+(draw-box 0 [{:span 2}])
+(next-row)
+(next-row)
+(draw-row-header "network")
+(draw-boxes [0x06 0x02 0x0E 0x00 0x00 0x00 0x00 0x0A 0x03 0x00 0x00 0x00 0x00 0xA4 0x80 0x04 0x00 0x00
+])
 ....
 
-We only use `Scroll amount 1` to determine the amount of scroll to be applied.
+`Action` can have the following values:
 
-[WARNING,caption=TODO]
-====
-What's `Scroll amount 2`?
-====
+|===
+|Action data |Meaning
 
-=== Keyboard
+|`0x04`
+|Button released
 
-.The full format of a `KEYBOARD` packet
-[packetdiag,format=svg,align="center"]
-....
-{
-  colwidth = 8
-  node_height = 50
-  node_width = 70
-
-  0-1: Packet Type
-  2-5: Input Type
-  6-6: Action
-  7-8: zeros
-  9-10: Key code
-  11-12: unknown
-  13-13: modifiers
-  14-15: zeros
-}
-....
+|`0x03`
+|Button pressed
+|===
 
 [WARNING,caption=TODO]
 ====
 What's `modifiers`?
 ====
 
-* *Action*: will have the value `0x04` when a button is pressed
-* *Key code* represent the corresponding keyboard code of the pressed input, see the following table:
+`Key code` represent the corresponding keyboard code of the pressed input, see the following table:
 
 |===
 | Moonlight code | Keyboard button
@@ -549,38 +614,125 @@ What's `modifiers`?
 
 |===
 
+== Mouse scroll
+
+.The full format of a `MOUSE_SCROLL` packet
+[bytefield,format=svg,align="center"]
+....
+(defn draw-group-label-header
+  [span label]
+  (draw-box (text label [:math {:font-size 12}]) {:span span :borders nil :height 14}))
+
+(defn draw-input-header
+  []
+  (draw-column-headers)
+  (draw-group-label-header 4 "Header")
+  (draw-group-label-header 9 "Payload")
+  (next-row 18))
+
+(draw-input-header)
+(draw-row-header "format")
+(draw-box 0x0206 [:box-first {:span 2}])
+(draw-box 0xe [:box-related {:span 2}])
+(draw-box 0xa [:box-first {:span 4}])
+(draw-box 0xa [:box-related {:span 4}])
+(draw-box (text "amount" [:math] [:sub 1]) [:box-related {:span 2}])
+(draw-box (text "amount" [:math] [:sub 2]) [:box-related {:span 2}])
+(draw-box 0 [{:span 2}])
+(next-row)
+(next-row)
+(draw-row-header "network")
+(draw-boxes [0x06 0x02 0x0E 0x00 0x00 0x00 0x00 0x0A 0x0A 0x00 0x00 0x00 0xFF 0x88 0xFF 0x88 0x00 0x00
+])
+....
+
+We only use `amount 1` to determine the amount of scroll to be applied.
+
+[WARNING,caption=TODO]
+====
+What's `amount 2`?
+====
+
+== Mouse horizontal scroll
+
+.The full format of a `MOUSE_HSCROLL` packet
+[bytefield,format=svg,align="center"]
+....
+(defn draw-group-label-header
+  [span label]
+  (draw-box (text label [:math {:font-size 12}]) {:span span :borders nil :height 14}))
+
+(defn draw-input-header
+  []
+  (draw-column-headers)
+  (draw-group-label-header 4 "Header")
+  (draw-group-label-header 9 "Payload")
+  (next-row 18))
+
+(draw-input-header)
+(draw-row-header "format")
+(draw-box 0x0206 [:box-first {:span 2}])
+(draw-box 0xa [:box-related {:span 2}])
+(draw-box 0x6 [:box-first {:span 4}])
+(draw-box 0x55000001 [:box-related {:span 4}])
+(draw-box "amount" [:box-last {:span 2}])
+(next-row)
+(next-row)
+(draw-row-header "network")
+(draw-boxes [0x06 0x02 0x0A 0x00 0x00 0x00 0x00 0x06 0x01 0x00 0x00 0x55 0x00 0x1E
+])
+....
+
 == Controller multi
 
 .The full format of a `CONTROLLER_MULTI` packet
-[packetdiag,format=svg,align="center"]
+[bytefield,format=svg,align="center"]
 ....
-{
-  colwidth = 8
-  node_height = 50
-  node_width = 70
+(defn draw-group-label-header
+  [span label]
+  (draw-box (text label [:math {:font-size 12}]) {:span span :borders nil :height 14}))
 
-  0-1: Packet Type
-  2-5: Input Type
-  6-9: Unknown
-  10-11: Unknown
-  12-13: Controller #
-  14-15: Mask
-  16-17: Unknown
-  18-19: Button Flags
-  20-20: L2
-  21-21: R2
-  22-23: LS-X
-  24-25: LS-Y
-  26-27: RS-X
-  28-29: RS-Y
-  30-33: Unknown
-  34-35: Unknown
-}
+(defn draw-input-header
+  []
+  (draw-column-headers)
+  (draw-group-label-header 4 "Header")
+  (draw-group-label-header 9 "Payload")
+  (next-row 18))
+
+(draw-input-header)
+(draw-row-header "format")
+(draw-box 0x0206 [:box-first {:span 2}])
+(draw-box 0x22 [:box-related {:span 2}])
+(draw-box 0x1e [:box-first {:span 4}])
+(draw-box 0xc [:box-related {:span 4}])
+(draw-box 0x1a [:box-related {:span 2}])
+(draw-box "controller" [:box-last {:span 2}])
+(draw-box "active" [:box-first {:span 2}])
+(draw-box 0x14 [:box-related {:span 2}])
+(draw-box "buttons" [:box-related {:span 2}])
+(draw-box "LT" [:box-related {:span 1}])
+(draw-box "RT" [:box-related {:span 1}])
+(draw-box "left X" [:box-related {:span 2}])
+(draw-box "left Y" [:box-related {:span 2}])
+(draw-box "right X" [:box-related {:span 2}])
+(draw-box "right Y" [:box-last {:span 2}])
+(draw-box 0x9c [:box-first {:span 4}])
+(draw-box 0x55 [:box-last {:span 2}])
+
+(next-row)
+(next-row)
+(draw-row-header "network")
+(draw-boxes [0x06 0x02 0x22 0x00 0x00 0x00 0x00 0x1E 0x0C 0x00 0x00 0x00 0x1A 0x00 0x00 0x00 0x01 0x00 0x14 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x98 0xFF 0x9C 0x00 0x00 0x00 0x55 0x00
+])
 ....
+
+`LT` and `RT` refer to the left and right triggers, respectively. `Left X` and
+the following fields refer to the values of the left and right sticks.
+
 
 === Button flags
 
-The `button_flag` element encodes the currently pressed buttons in the joypad.
+The `buttons` element encodes the currently pressed buttons in the joypad.
 
 |===
 |Button type | Flag (HEX)

--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -12,7 +12,7 @@ The only way to run Wolf right now is to manually compile it.
 .Build dependencies
 [source,bash]
 ....
-apt install -y ninja-build cmake clang libboost-thread-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev libssl-dev libgstreamer1.0-dev  libgstreamer-plugins-base1.0-dev libevdev-dev
+apt install -y ninja-build cmake clang libboost-locale-dev libboost-thread-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev libssl-dev libgstreamer1.0-dev  libgstreamer-plugins-base1.0-dev libevdev-dev
 ....
 
 .Compile

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -40,9 +40,12 @@ target_include_directories(wolf_input PUBLIC .)
 set_target_properties(wolf_input PROPERTIES PUBLIC_HEADER .)
 set_target_properties(wolf_input PROPERTIES OUTPUT_NAME "input")
 
+find_package(Boost REQUIRED COMPONENTS locale)
+include_directories(${Boost_INCLUDE_DIRS})
 
 # This library depends on:
 target_link_libraries(wolf_input PUBLIC
+        ${Boost_LIBRARIES}
         wolf::helpers
         wolf::moonlight
         dp::eventbus)

--- a/src/input/CMakeLists.txt
+++ b/src/input/CMakeLists.txt
@@ -20,6 +20,9 @@ if (UNIX AND NOT APPLE)
     message(STATUS "Adding input implementation for LINUX")
     list(APPEND SRC_LIST "platforms/linux/uinput.cpp")
     list(APPEND HEADER_LIST "platforms/linux/keyboard.hpp" "platforms/linux/uinput.hpp")
+
+    find_package(ICU 61.0 COMPONENTS uc REQUIRED)
+    target_link_libraries(wolf_input PRIVATE ICU::uc)
 else () # TODO: other platforms??
     message(WARNING "Missing virtual input implementation for the current platform")
     list(APPEND SRC_LIST "platforms/unknown/input.cpp")

--- a/src/input/platforms/linux/uinput.cpp
+++ b/src/input/platforms/linux/uinput.cpp
@@ -508,7 +508,7 @@ InputReady setup_handlers(std::size_t session_id,
             break;
           }
           case data::UTF8_TEXT:
-			logs::log(logs::warning, "[INPUT] UTF-8 text input is not yet supported on Linux");
+            logs::log(logs::warning, "[INPUT] UTF-8 text input is not yet supported on Linux");
             break;
           }
         }

--- a/src/input/platforms/linux/uinput.hpp
+++ b/src/input/platforms/linux/uinput.hpp
@@ -1,9 +1,9 @@
 #include "input/input.hpp"
+#include <immer/array.hpp>
 #include <libevdev/libevdev-uinput.h>
 #include <libevdev/libevdev.h>
 #include <memory>
 #include <optional>
-#include <immer/array.hpp>
 
 namespace input {
 
@@ -45,6 +45,8 @@ struct Action {
 };
 
 std::optional<Action> keyboard_handle(libevdev_uinput *keyboard, const data::KEYBOARD_PACKET &key_pkt);
+void paste_utf(libevdev_uinput *kb, const data::UTF8_TEXT_PACKET &pkt);
+std::string to_hex(const std::basic_string<char32_t> &str);
 
 } // namespace keyboard
 

--- a/src/input/platforms/linux/uinput.hpp
+++ b/src/input/platforms/linux/uinput.hpp
@@ -31,6 +31,8 @@ void move_mouse_abs(libevdev_uinput *mouse, const data::MOUSE_MOVE_ABS_PACKET &m
 void mouse_press(libevdev_uinput *mouse, const data::MOUSE_BUTTON_PACKET &btn_pkt);
 
 void mouse_scroll(libevdev_uinput *mouse, const data::MOUSE_SCROLL_PACKET &scroll_pkt);
+
+void mouse_scroll_horizontal(libevdev_uinput *mouse, const data::MOUSE_HSCROLL_PACKET &scroll_pkt);
 } // namespace mouse
 
 namespace keyboard {

--- a/src/moonlight/moonlight/protocol.hpp
+++ b/src/moonlight/moonlight/protocol.hpp
@@ -11,7 +11,7 @@ namespace moonlight {
 namespace pt = boost::property_tree;
 using XML = pt::ptree;
 
-constexpr auto M_VERSION = "7.1.431.0";
+constexpr auto M_VERSION = "7.1.431.-1";
 constexpr auto M_GFE_VERSION = "3.23.0.74";
 
 /**

--- a/tests/testMoonlight.cpp
+++ b/tests/testMoonlight.cpp
@@ -157,7 +157,7 @@ TEST_CASE("Mocked serverinfo", "[MoonlightProtocol]") {
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
             "<root status_code=\"200\">"
             "<hostname>Wolf</hostname>"
-            "<appversion>7.1.431.0</appversion>"
+            "<appversion>7.1.431.-1</appversion>"
             "<GfeVersion>3.23.0.74</GfeVersion>"
             "<uniqueid>16510e3e-61fd-4a85-97fa-0db82058b27a</uniqueid>"
             "<MaxLumaPixelsHEVC>1869449984</MaxLumaPixelsHEVC>"


### PR DESCRIPTION
The changes in this PR are analogous to these from Sunshine, which were a _huge_ help in understanding how this stuff works 😄:
 - https://github.com/LizardByte/Sunshine/pull/511
 - https://github.com/LizardByte/Sunshine/pull/793

Previously, input packets were actually being distinguished based on packet size rather than the actual packet type fields. This worked reasonably well because nearly all packets had distinct sizes, with the notable exception of keyboard input and mouse scrolling.  This PR switches to using the correct type field instead.

In addition, there's are two new packet types: `MOUSE_HSCROLL_PACKET` for horizontal scrollwheel events, and `UTF8_TEXT_PACKET` for text events.  Horizontal scroll events are fully implemented and tested, but UTF-8 text events currently only log a warning.

Moonlight sends UTF-8 text events when it receives pasted text. On Windows, this is straightforward to implement because there is a `SendInput` API that can take Unicode text; unfortunately on Linux, there is no such API.  Instead, we'd have to "manually" convert the text to a series of key events -- I'm leaving that as an exercise for the future :grin: