### PR TITLE
Fix compilation on GCC 13

### DIFF
--- a/src/crypto/src/aes.hpp
+++ b/src/crypto/src/aes.hpp
@@ -4,6 +4,7 @@
 #include <openssl/aes.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
+#include <cstdint>
 
 namespace aes {
 using CIPHER_CTX_ptr = std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)>;

--- a/src/moonlight/moonlight/data-structures.hpp
+++ b/src/moonlight/moonlight/data-structures.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <cstdint>
 
 namespace moonlight {
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.1.1
+        GIT_TAG v3.3.2
 )
 
 FetchContent_MakeAvailable(Catch2)


### PR DESCRIPTION
This patch fix compilation with GCC 13.

Wolf doesn't seem to work on my machine, I'm getting some `HTTPS error during request at /launch error code: 125 - Operation canceled` while launching an app. But at least this patch fix compilation.