### PR TITLE
fix: app_state_folder is empty upon pairing

### DIFF
--- a/src/wolf/rest/endpoints.hpp
+++ b/src/wolf/rest/endpoints.hpp
@@ -175,7 +175,7 @@ void pair(const std::shared_ptr<typename SimpleWeb::Server<T>::Response> &respon
 
     auto is_paired = xml.template get<int>("root.paired");
     if (is_paired == 1) {
-      state::pair(state->config, state::PairedClient{.client_cert = client_cache.client_cert});
+      state::pair(state->config, state::PairedClient{.client_cert = client_cache.client_cert, .app_state_folder = std::to_string(std::hash<std::string>{}(client_cache.client_cert))});
       logs::log(logs::info, "Succesfully paired {}", client_ip);
     } else {
       logs::log(logs::warning, "Failed pairing with {}", client_ip);


### PR DESCRIPTION
Small fix to set `app_state_folder` to `sessionid` upon pairing new clients. Without setting this, `app_state_folder` defaults to empty, hence the state folder does not use `sessionid` for session separation.

fix #42 