### PR TITLE
doc: populate volume without error, mount /etc/wolf/cfg dir

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Make sure configure folder exists
+# as Wolf may try to create default config in non existing folder and crash.
+# See https://github.com/games-on-whales/wolf/pull/65#discussion_r1509235307
+# and https://github.com/games-on-whales/wolf/issues/64#issuecomment-1951479056
+mkdir -p $WOLF_CFG_FOLDER
+
 # Update fake-udev if missing from the path
 export WOLF_DOCKER_FAKE_UDEV_PATH=${WOLF_DOCKER_FAKE_UDEV_PATH:-$HOST_APPS_STATE_FOLDER/fake-udev}
 cp /wolf/fake-udev $WOLF_DOCKER_FAKE_UDEV_PATH

--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -77,17 +77,16 @@ curl https://raw.githubusercontent.com/games-on-whales/gow/master/images/nvidia-
 
 This will create `gow/nvidia-driver:latest` locally.
 
-Unfortunately, docker doesn't seem to support directly mounting images, but you can https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container[pre-polulate volumes]!
+Unfortunately, docker doesn't seem to support directly mounting images, but you can https://docs.docker.com/storage/volumes/#populate-a-volume-using-a-container[pre-polulate volumes] by running:
 
 [source,bash]
 ....
-docker run --name nvidia-driver-container --rm --mount source=nvidia-driver-vol,destination=/usr/nvidia gow/nvidia-driver:latest sh
-
-docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "sh": executable file not found in $PATH: unknown.
-ERRO[0003] error waiting for container:
+docker create --rm --mount source=nvidia-driver-vol,destination=/usr/nvidia gow/nvidia-driver:latest sh
 ....
 
-As you can see, the command will fail because the image contains no binary, but it'll create a new volume nevertheless.
+It will create a Docker container, populate `nvidia-driver-vol` with Nvidia driver if it wasn't already done and remove the container.
+
+Check volume exists with:
 
 [source,bash]
 ....


### PR DESCRIPTION
Hi there, I played a bit with Wolf and followed through the getting started documentation. Here's a few update suggestions for a better flow:

It's possible to create a Docker container to populate nvidia volume with `docker create` rather than use `docker run` which will exit with error - same result with a slightly better UX :)

Also Wolf expect a `/etc/wolf/cfg` directory to exists on startup and fails otherwise. This directory does not exists by default as only `/etc/wolf` is mounted. By mouting both `/etc/wolf` and `/etc/wolf/cfg` Docker will create both directories if they do not already exists, hence Wolf won't crash (as suggested here: https://github.com/games-on-whales/wolf/issues/64#issuecomment-1951479056)