### PR TITLE
Add NVIDIA AV1 encoding support

### DIFF
--- a/docker/gpu-drivers.Dockerfile
+++ b/docker/gpu-drivers.Dockerfile
@@ -24,11 +24,12 @@ RUN <<_ADD_NVRTC
 
     #Extra deps
     apt-get update -y
-    apt-get install -y unzip curl
+    apt-get install -y xz-utils curl
 
     cd /tmp
-    curl -fsSL -o nvidia_cuda_nvrtc_linux_x86_64.whl "https://developer.download.nvidia.com/compute/redist/nvidia-cuda-nvrtc/nvidia_cuda_nvrtc-11.0.221-cp36-cp36m-linux_x86_64.whl"
-    unzip -joq -d ./nvrtc nvidia_cuda_nvrtc_linux_x86_64.whl
+    mkdir nvrtc
+    curl -fsSL -o cuda_nvrtc-linux-x86_64-12.6.20-archive.tar.xz "https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/linux-x86_64/cuda_nvrtc-linux-x86_64-12.6.20-archive.tar.xz"
+    tar -xJf "cuda_nvrtc-linux-x86_64-12.6.20-archive.tar.xz" -C ./nvrtc --strip-components=2
     cd nvrtc
     chmod 755 libnvrtc*
     find . -maxdepth 1 -type f -name "*libnvrtc.so.*" -exec sh -c 'ln -snf $(basename {}) libnvrtc.so' \;
@@ -40,7 +41,7 @@ RUN <<_ADD_NVRTC
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
     # Cleanup
-    apt-get remove -y --purge unzip curl
+    apt-get remove -y --purge xz-utils curl
     rm -rf /var/lib/apt/lists/*
 _ADD_NVRTC
 

--- a/docker/gstreamer.Dockerfile
+++ b/docker/gstreamer.Dockerfile
@@ -42,7 +42,7 @@ RUN <<_GSTREAMER_INSTALL
     apt-get install -y --no-install-recommends $DEV_PACKAGES
 
     # Build gstreamer
-    git clone -b $GSTREAMER_VERSION --depth=1 https://gitlab.freedesktop.org/gstreamer/gstreamer.git $SOURCE_PATH/gstreamer
+    git clone -b main --depth=1 https://gitlab.freedesktop.org/gstreamer/gstreamer.git $SOURCE_PATH/gstreamer
     cd ${SOURCE_PATH}/gstreamer
     # see the list of possible options here: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/meson_options.txt \
     meson setup \

--- a/src/moonlight-protocol/moonlight/data-structures.hpp
+++ b/src/moonlight-protocol/moonlight/data-structures.hpp
@@ -9,7 +9,7 @@ struct DisplayMode {
   int height;
   int refreshRate;
   bool hevc_supported = true;
-  bool av1_supported = false;
+  bool av1_supported = true;
 };
 
 struct App {

--- a/src/moonlight-server/state/default/config.include.toml
+++ b/src/moonlight-server/state/default/config.include.toml
@@ -4,6 +4,7 @@ hostname = "Wolf"
 # The version of this config file
 config_version = 3
 
+support_av1 = true
 
 # A list of paired clients that will be allowed to stream
 paired_clients = []
@@ -333,6 +334,22 @@ video/x-h264, profile=high, stream-format=byte-stream
 ##############
 # AV1 encoders
 ###
+[[gstreamer.video.av1_encoders]]
+plugin_name = "nvcodec"
+check_elements = ["nvav1enc", "videoconvert"]
+video_params = """
+queue !
+videoconvert !
+video/x-raw, chroma-site={color_range}, width={width}, height={height}, format=NV12, colorimetry={color_space}
+\
+"""
+encoder_pipeline = """
+nvav1enc bitrate={bitrate} rc-mode=cbr gop-size=-1 strict-gop=True b-adapt=False rc-lookahead=0 bframes=0 zerolatency=True preset=p4 tune=ultra-low-latency multi-pass=two-pass-quarter !
+av1parse !
+video/x-av1, stream-format=obu-stream, alignment=frame, profile=main
+\
+"""
+
 [[gstreamer.video.av1_encoders]]
 plugin_name = "qsv"
 check_elements = ["qsvav1enc", "videoconvert"]

--- a/src/moonlight-server/state/default/config.v2.toml
+++ b/src/moonlight-server/state/default/config.v2.toml
@@ -3,6 +3,7 @@ hostname = "Wolf"
 # The version of this config file
 config_version = 3
 
+support_av1 = true
 
 # A list of paired clients that will be allowed to stream
 paired_clients = []
@@ -332,6 +333,22 @@ video/x-h264, profile=high, stream-format=byte-stream
 ##############
 # AV1 encoders
 ###
+[[gstreamer.video.av1_encoders]]
+plugin_name = "nvcodec"
+check_elements = ["nvav1enc", "videoconvert"]
+video_params = """
+queue !
+videoconvert !
+video/x-raw, chroma-site={color_range}, width={width}, height={height}, format=NV12, colorimetry={color_space}
+\
+"""
+encoder_pipeline = """
+nvav1enc bitrate={bitrate} rc-mode=cbr gop-size=-1 strict-gop=True b-adapt=False rc-lookahead=0 bframes=0 zerolatency=True preset=p4 tune=ultra-low-latency multi-pass=two-pass-quarter !
+av1parse !
+video/x-av1, stream-format=obu-stream, alignment=frame, profile=main
+\
+"""
+
 [[gstreamer.video.av1_encoders]]
 plugin_name = "qsv"
 check_elements = ["qsvav1enc", "videoconvert"]


### PR DESCRIPTION
Gstreamer finally supports NVIDIA hardware offloading for AV1, but it is not in the latest release so gstreamer must be build from main for now (verify with `gst-inspect-1.0 | grep AV1`).

Using the same nvav1enc settings as https://github.com/selkies-project/selkies-gstreamer/blob/main/src/selkies_gstreamer/gstwebrtc_app.py#L425 successfully works.  It will complain about the connection and crash if Moonlight's video bitrate is too high so adjust to something like 3 Mbps first.