### PR TITLE
feat: add support for appassets

### DIFF
--- a/docs/modules/user/pages/configuration.adoc
+++ b/docs/modules/user/pages/configuration.adoc
@@ -161,28 +161,30 @@ You can re-define parts of the Gstreamer pipeline easily, ex:
 title = "Test ball" #<1>
 start_virtual_compositor = false #<2>
 app_state_folder = "some/folder" #<3>
+asset = "ball.png" #<4>
 
-[apps.runner] #<4>
+[apps.runner] #<5>
 type = "process"
 run_cmd = "sh -c \"while :; do echo 'running...'; sleep 10; done\""
 
-[apps.video] #<5>
+[apps.video] #<6>
 source = """
 videotestsrc pattern=ball flip=true is-live=true !
 video/x-raw, framerate={fps}/1
 \
 """
 
-[apps.audio] #<6>
+[apps.audio] #<7>
 source = "audiotestsrc wave=ticks is-live=true"
 ....
 
 <1> *title*: this is the name that will be displayed in Moonlight
 <2> *start_virtual_compositor*: set to True if this app needs our custom virtual compositor (TODO: document this better)
 <3> *app_state_folder*: the folder where the app will store permanent data, see: xref:data_setup[]
-<4> *runner*: the type of process to run in order to start this app, see: xref:_app_runner[]
-<5> *video*: here it's possible to override the default video pipeline variables defined in: xref:_gstreamer[]
-<6> *audio*: here it's possible to override the default audio pipeline variables defined in: xref:_gstreamer[]
+<4> *asset*: this is the box art that will be displayed in Moonlight (PNG, ideally 200x266 or 628x888 pixels)
+<5> *runner*: the type of process to run in order to start this app, see: xref:_app_runner[]
+<6> *video*: here it's possible to override the default video pipeline variables defined in: xref:_gstreamer[]
+<7> *audio*: here it's possible to override the default audio pipeline variables defined in: xref:_gstreamer[]
 
 See more examples in the xref:gstreamer.adoc[] page.
 

--- a/src/moonlight-protocol/moonlight/data-structures.hpp
+++ b/src/moonlight-protocol/moonlight/data-structures.hpp
@@ -16,6 +16,7 @@ struct App {
   const std::string title;
   const std::string id;
   const bool support_hdr;
+  const std::string asset;
 };
 
 #define FLAG_EXTENSION 0x10

--- a/src/moonlight-server/rest/servers.cpp
+++ b/src/moonlight-server/rest/servers.cpp
@@ -157,8 +157,13 @@ void startServer(HttpsServer *server, const immer::box<state::AppState> state, i
     }
   };
 
-  // TODO: add missing
-  // https_server.resource["^/appasset$"]["GET"]
+  server->resource["^/appasset$"]["GET"] = [&state](auto resp, auto req) {
+      if (get_client_if_paired(state, req)) {
+        endpoints::https::appasset(resp, req, state);
+      } else {
+        reply_unauthorized(req, resp);
+      }
+  };
 
   server->start([](unsigned short port) { logs::log(logs::info, "HTTPS server listening on port: {} ", port); });
 }

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -327,7 +327,8 @@ Config load_or_default(const std::string &source, const std::shared_ptr<dp::even
 
         return state::App{.base = {.title = app_title,
                                    .id = std::to_string(idx + 1),
-                                   .support_hdr = toml::find_or<bool>(item, "support_hdr", false)},
+                                   .support_hdr = toml::find_or<bool>(item, "support_hdr", false),
+                                   .asset = toml::find_or<std::string>(item, "asset", "")},
                           .h264_gst_pipeline = h264_gst_pipeline,
                           .hevc_gst_pipeline = hevc_gst_pipeline,
                           .av1_gst_pipeline = av1_gst_pipeline,

--- a/tests/assets/config.test.toml
+++ b/tests/assets/config.test.toml
@@ -20,6 +20,7 @@ app_state_folder = "some/folder"
 [[apps]]
 title = "Firefox"
 start_virtual_compositor = true
+asset = "firefox.png"
 
 [apps.runner]
 type = "docker"
@@ -126,4 +127,3 @@ default_source = "audio_source"
 default_audio_params = "audio_params"
 default_opus_encoder = "audio_encoder"
 default_sink = "audio_sink"
-

--- a/tests/testMoonlight.cpp
+++ b/tests/testMoonlight.cpp
@@ -30,6 +30,7 @@ TEST_CASE("LocalState load TOML", "[LocalState]") {
     auto first_app = state.apps[0];
     REQUIRE_THAT(first_app.base.title, Equals("Firefox"));
     REQUIRE_THAT(first_app.base.id, Equals("1"));
+    REQUIRE_THAT(first_app.base.asset, Equals("firefox.png"));
     REQUIRE_THAT(first_app.h264_gst_pipeline, Equals("video_source !\ndefault !\nh264_pipeline !\nvideo_sink"));
     REQUIRE_THAT(first_app.hevc_gst_pipeline, Equals("video_source !\ndefault !\nhevc_pipeline !\nvideo_sink"));
     REQUIRE_THAT(first_app.av1_gst_pipeline, Equals("video_source !\nparams !\nav1_pipeline !\nvideo_sink"));
@@ -41,6 +42,7 @@ TEST_CASE("LocalState load TOML", "[LocalState]") {
     auto second_app = state.apps[1];
     REQUIRE_THAT(second_app.base.title, Equals("Test ball"));
     REQUIRE_THAT(second_app.base.id, Equals("2"));
+    REQUIRE_THAT(second_app.base.asset, Equals(""));
     REQUIRE_THAT(second_app.h264_gst_pipeline,
                  Equals("override DEFAULT SOURCE !\ndefault !\nh264_pipeline !\nvideo_sink"));
     REQUIRE_THAT(second_app.hevc_gst_pipeline,


### PR DESCRIPTION
Fixes https://github.com/games-on-whales/wolf/issues/13 and displays box art in Moonlight.

I'm not sure where we should store these assets? Or if `asset` is even the preferred term?
Right now it's just stored relative to `HOST_APPS_STATE_FOLDER`.