### PR TITLE
Update quickstart.adoc to inform that nvidia container toolkit still needs `modeset=1`

### DIFF
--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -134,6 +134,26 @@ services:
     network_mode: host
     restart: unless-stopped
 ....
+One last final check: we have to make sure that the `nvidia-drm` module has been loaded and that the module is loaded with the flag `modeset=1`.
+
+[source,bash]
+....
+sudo cat /sys/module/nvidia_drm/parameters/modeset
+Y
+....
+
+.I get `N` or the file is not present, how do I set the flag?
+[%collapsible]
+====
+
+If using Grub, the easiest way to make the change persistent is to add `nvidia-drm.modeset=1` to the `GRUB_CMDLINE_LINUX_DEFAULT` line in `/etc/default/grub` ex:
+
+....
+GRUB_CMDLINE_LINUX_DEFAULT="quiet nvidia-drm.modeset=1"
+....
+
+Then `sudo update-grub` and *reboot*.
+
 
 --
 Nvidia (Manual)::


### PR DESCRIPTION
Nvidia container toolkit still needs to have the nvidia driver on the host set to modeset=1 like the manual option. Just copied this across to the container toolkit