### PR TITLE
DualSense adaptive trigger support

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -56,7 +56,7 @@ if (UNIX AND NOT APPLE)
         FetchContent_Declare(
                 inputtino
                 GIT_REPOSITORY https://github.com/games-on-whales/inputtino.git
-                GIT_TAG 311fd2d)
+                GIT_TAG fd136cf)
         FetchContent_MakeAvailable(inputtino)
     endif ()
 

--- a/src/moonlight-protocol/moonlight/control.hpp
+++ b/src/moonlight-protocol/moonlight/control.hpp
@@ -27,6 +27,7 @@ enum PACKET_TYPE : std::uint16_t {
   RUMBLE_TRIGGERS = boost::endian::little_to_native(0x5500),
   MOTION_EVENT = boost::endian::little_to_native(0x5501),
   RGB_LED_EVENT = boost::endian::little_to_native(0x5502),
+  ADAPTIVE_TRIGGER_EVENT = boost::endian::little_to_native(0x5503),
 };
 
 enum INPUT_TYPE : int {
@@ -343,6 +344,15 @@ struct ControlRGBLedPacket {
   std::uint8_t b;
 };
 
+static constexpr std::uint8_t DS_EFFECT_PAYLOAD_SIZE = 10;
+
+struct ControlAdaptiveTriggerPacket {
+  ControlPacket header;
+
+  std::uint16_t controller_number;
+  inputtino::PS5Joypad::TriggerEffect effect;
+};
+
 struct ControlEncryptedPacket {
   ControlPacket header; // Always 0x0001 (see PACKET_TYPE ENCRYPTED)
   std::uint32_t seq;    // Monotonically increasing sequence number (used as IV for AES-GCM)
@@ -441,6 +451,8 @@ static constexpr const char *packet_type_to_str(pkts::PACKET_TYPE p) noexcept {
     return "MOTION_EVENT";
   case pkts::RGB_LED_EVENT:
     return "RGB_LED_EVENT";
+  case pkts::ADAPTIVE_TRIGGER_EVENT:
+    return "ADAPTIVE_TRIGGER_EVENT";
   }
   return "Unrecognised";
 }

--- a/src/moonlight-server/control/input_handler.cpp
+++ b/src/moonlight-server/control/input_handler.cpp
@@ -48,6 +48,18 @@ std::shared_ptr<events::JoypadTypes> create_new_joypad(const events::StreamSessi
     encrypt_and_send(plaintext, aes_key, *clients, session_id);
   });
 
+  auto on_adaptive_trigger_fn = ([clients = &connected_clients,
+                                  controller_number,
+                                  session_id = session.session_id,
+                                  aes_key = session.aes_key](const inputtino::PS5Joypad::TriggerEffect &effect) {
+    auto rumble_pkt = ControlAdaptiveTriggerPacket{
+        .header{.type = ADAPTIVE_TRIGGER_EVENT, .length = sizeof(ControlAdaptiveTriggerPacket) - sizeof(ControlPacket)},
+        .controller_number = boost::endian::native_to_little((uint16_t)controller_number),
+        .effect = effect};
+    std::string plaintext = {(char *)&rumble_pkt, sizeof(rumble_pkt)};
+    encrypt_and_send(plaintext, aes_key, *clients, session_id);
+  });
+
   std::shared_ptr<events::JoypadTypes> new_pad;
   auto controllers_override = session.client_settings->controllers_override;
   auto final_type = controllers_override.size() > controller_number ? controllers_override[controller_number]
@@ -97,6 +109,7 @@ std::shared_ptr<events::JoypadTypes> create_new_joypad(const events::StreamSessi
     } else {
       (*result).set_on_rumble(on_rumble_fn);
       (*result).set_on_led(on_led_fn);
+      (*result).set_on_trigger_effect(on_adaptive_trigger_fn);
       new_pad = std::make_shared<events::JoypadTypes>(std::move(*result));
 
       // Let's wait for the kernel to pick it up and mount the /dev/ devices


### PR DESCRIPTION
This is part of a series of PRs, you'll need the updates in the Moonlight client in order to use this in Wolf.

## Moonlight client
 - https://github.com/moonlight-stream/moonlight-common-c/pull/102 to extend the Moonlight protocol for this new event
 - https://github.com/moonlight-stream/moonlight-qt/pull/1561 requires the changes in `moonlight-common-c` and exposes the adaptive trigger events via SDL

## Sunshine server
 - https://github.com/games-on-whales/inputtino/pull/26 to expose the adaptive triggers events in Linux
 - https://github.com/LizardByte/Sunshine/pull/3738  requires the changes in `moonlight-common-c` and `inputtino` and delivers the adaptive trigger events to Moonlight clients

https://github.com/user-attachments/assets/c403a181-bae7-4b79-a5b6-7278f5bba97e