### PR TITLE
Hidraw hotplug fix

### DIFF
--- a/.github/workflows/linux-build-test.yml
+++ b/.github/workflows/linux-build-test.yml
@@ -138,15 +138,15 @@ jobs:
       matrix:
         cxx:
           - g++-12
-          - clang++-16
+          - clang++
         build_type: [ Release ]
         shared: [ true, false ]
         std: [ 20 ]
         include:
           - cxx: g++-12
             other_pkgs: [ g++-12 ]
-          - cxx: clang++-16
-            other_pkgs: [ clang-16 ]
+          - cxx: clang++
+            other_pkgs: [ clang-18 ]
 
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,20 @@ if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
         add_compile_options("-fno-inline")
     endif ()
 
+    if(POLICY CMP0167)
+        cmake_policy(SET CMP0167 NEW)
+        set(CMAKE_POLICY_DEFAULT_CMP0167 NEW)
+    endif()
+
+    if(POLICY CMP0169)
+        cmake_policy(SET CMP0169 OLD)
+    endif()
+
+    if(POLICY CMP0077)
+        cmake_policy(SET CMP0077 NEW)
+        set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+    endif()
+
     # set(Boost_USE_STATIC_LIBS ON)
 
     # Testing only available if this is the main app

--- a/src/core/src/platforms/all/helpers/CMakeLists.txt
+++ b/src/core/src/platforms/all/helpers/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries_system(wolf_helpers INTERFACE range-v3::range-v3)
 FetchContent_Declare(
         fmtlib
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 11.0.1)
+        GIT_TAG 11.1.4)
 FetchContent_MakeAvailable(fmtlib)
 target_link_libraries_system(wolf_helpers INTERFACE fmt::fmt-header-only)
 

--- a/src/moonlight-server/CMakeLists.txt
+++ b/src/moonlight-server/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(PkgConfig)
 FetchContent_Declare(
         fmtlib
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 11.0.1)
+        GIT_TAG 11.1.4)
 FetchContent_MakeAvailable(fmtlib) # Download and build
 target_link_libraries_system(wolf_runner PUBLIC fmt::fmt-header-only)
 
@@ -30,21 +30,23 @@ FetchContent_Declare(
         tomlplusplus
         GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
         GIT_TAG        v3.4.0
+        OVERRIDE_FIND_PACKAGE
 )
 FetchContent_MakeAvailable(tomlplusplus)
-target_link_libraries(wolf_runner PUBLIC tomlplusplus::tomlplusplus)
 
 # Serialization
 FetchContent_Declare(
         reflect-cpp
         GIT_REPOSITORY https://github.com/getml/reflect-cpp
-        GIT_TAG 54c2a84
+        GIT_TAG c118963
 )
+set(REFLECTCPP_USE_VCPKG OFF)
+
 set(REFLECTCPP_BSON OFF)
 set(REFLECTCPP_CBOR OFF)
 set(REFLECTCPP_FLEXBUFFERS OFF)
-set(REFLECTCPP_MSGPACK OFF) # Only works with vcpkg, doing it manually
-set(REFLECTCPP_TOML OFF)
+set(REFLECTCPP_MSGPACK OFF)
+set(REFLECTCPP_TOML ON)
 set(REFLECTCPP_XML OFF)
 set(REFLECTCPP_YAML OFF)
 
@@ -56,7 +58,7 @@ target_link_libraries(wolf_runner PUBLIC reflectcpp)
 FetchContent_Declare(
         simplewebserver
         GIT_REPOSITORY https://gitlab.com/eidheim/Simple-Web-Server.git
-        GIT_TAG bdb1057)
+        GIT_TAG 4abe349)
 FetchContent_MakeAvailable(simplewebserver)
 target_link_libraries_system(wolf_runner PUBLIC simple-web-server)
 
@@ -73,7 +75,7 @@ set(CMAKE_PROJECT_INCLUDE_BEFORE "${PROJECT_SOURCE_DIR}/cmake/EnableCMP0048.cmak
 FetchContent_Declare(
         enet
         GIT_REPOSITORY https://github.com/cgutman/enet
-        GIT_TAG 47e42dbf422396ce308a03b5a95ec056f0f0180c)
+        GIT_TAG 44c85e16279553d9c052e572bcbfcd745fb74abf)
 FetchContent_MakeAvailable(enet)
 target_link_libraries_system(wolf_runner PUBLIC enet)
 unset(CMAKE_PROJECT_INCLUDE_BEFORE)
@@ -82,7 +84,7 @@ unset(CMAKE_PROJECT_INCLUDE_BEFORE)
 FetchContent_Declare(
         cpptrace
         GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-        GIT_TAG 448c325
+        GIT_TAG v0.8.2
 )
 
 pkg_check_modules(LIBUNWIND QUIET libunwind)
@@ -91,6 +93,12 @@ if (LIBUNWIND_FOUND)
 else ()
     message(WARNING "Missing libunwind, stacktraces will not be available.")
 endif ()
+set(ZSTD_BUILD_SHARED ${BUILD_SHARED_LIBS})
+set(ZSTD_BUILD_STATIC OFF)
+
+if(NOT BUILD_SHARED_LIBS)
+    set(ZSTD_BUILD_STATIC ON)
+endif()
 FetchContent_MakeAvailable(cpptrace)
 
 ##############################

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -35,8 +35,8 @@ void UnixSocketServer::endpoint_Pair(const HTTPRequest &req, std::shared_ptr<Uni
       send_http(socket, 500, rfl::json::write(res));
     }
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error()->what());
-    auto res = GenericErrorResponse{.error = event.error()->what()};
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());
+    auto res = GenericErrorResponse{.error = event.error().what()};
     send_http(socket, 500, rfl::json::write(res));
   }
 }
@@ -109,8 +109,8 @@ void UnixSocketServer::endpoint_AddApp(const HTTPRequest &req, std::shared_ptr<U
     auto res = GenericSuccessResponse{.success = true};
     send_http(socket, 200, rfl::json::write(res));
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, app.error()->what());
-    auto res = GenericErrorResponse{.error = app.error()->what()};
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, app.error().what());
+    auto res = GenericErrorResponse{.error = app.error().what()};
     send_http(socket, 500, rfl::json::write(res));
   }
 }
@@ -126,8 +126,8 @@ void UnixSocketServer::endpoint_RemoveApp(const HTTPRequest &req, std::shared_pt
     auto res = GenericSuccessResponse{.success = true};
     send_http(socket, 200, rfl::json::write(res));
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, app.error()->what());
-    auto res = GenericErrorResponse{.error = app.error()->what()};
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, app.error().what());
+    auto res = GenericErrorResponse{.error = app.error().what()};
     send_http(socket, 500, rfl::json::write(res));
   }
 }
@@ -180,8 +180,8 @@ void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::sh
     auto res = StreamSessionCreated{.success = true, .session_id = std::to_string(new_session->session_id)};
     send_http(socket, 200, rfl::json::write(res));
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, session.error()->what());
-    auto res = GenericErrorResponse{.error = session.error()->what()};
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, session.error().what());
+    auto res = GenericErrorResponse{.error = session.error().what()};
     send_http(socket, 500, rfl::json::write(res));
   }
 }
@@ -208,8 +208,8 @@ void UnixSocketServer::endpoint_StreamSessionStart(const HTTPRequest &req, std::
       send_http(socket, 500, rfl::json::write(res));
     }
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, start_req.error()->what());
-    auto res = GenericErrorResponse{.error = start_req.error()->what()};
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, start_req.error().what());
+    auto res = GenericErrorResponse{.error = start_req.error().what()};
     send_http(socket, 500, rfl::json::write(res));
   }
 }
@@ -230,8 +230,8 @@ void UnixSocketServer::endpoint_StreamSessionPause(const HTTPRequest &req, std::
       send_http(socket, 500, rfl::json::write(res));
     }
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, session.error()->what());
-    auto res = GenericErrorResponse{.error = session.error()->what()};
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, session.error().what());
+    auto res = GenericErrorResponse{.error = session.error().what()};
     send_http(socket, 500, rfl::json::write(res));
   }
 }
@@ -253,8 +253,8 @@ void UnixSocketServer::endpoint_StreamSessionStop(const HTTPRequest &req, std::s
       send_http(socket, 500, rfl::json::write(res));
     }
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, session.error()->what());
-    auto res = GenericErrorResponse{.error = session.error()->what()};
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, session.error().what());
+    auto res = GenericErrorResponse{.error = session.error().what()};
     send_http(socket, 500, rfl::json::write(res));
   }
 }
@@ -276,8 +276,8 @@ void UnixSocketServer::endpoint_StreamSessionHandleInput(const HTTPRequest &req,
       send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = "Invalid session_id"}));
     }
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, input_request.error()->what());
-    send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = input_request.error()->what()}));
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, input_request.error().what());
+    send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = input_request.error().what()}));
   }
 }
 
@@ -301,8 +301,8 @@ void UnixSocketServer::endpoint_RunnerStart(const wolf::api::HTTPRequest &req, s
                             .runner = runner,
                             .stream_session = std::make_shared<events::StreamSession>(*session)}));
   } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error()->what());
-    auto res = GenericErrorResponse{.error = event.error()->what()};
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());
+    auto res = GenericErrorResponse{.error = event.error().what()};
     send_http(socket, 500, rfl::json::write(res));
   }
 }

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -13,6 +13,26 @@ void create_udev_hw_files(std::filesystem::path base_hw_db_path,
   }
 }
 
+/**
+ * @brief returns the major number associated with the requested device type (if found)
+ * Internally will read /proc/devices line by line and return the first match
+ */
+static std::optional<std::string> get_device_major(std::string_view type) {
+  std::ifstream devices_file("/proc/devices");
+  std::string line;
+  while (std::getline(devices_file, line)) {
+    if (line.find(type) != std::string::npos) {
+      // Example line: "244 hidraw" or " 13 input" (note the leading space)
+      line.erase(line.begin(),
+                 std::find_if(line.begin(), line.end(), [](unsigned char ch) {
+                   return ch >= '0' && ch <= '9';
+ }));
+      return line.substr(0, line.find(' '));
+    }
+  }
+  return std::nullopt;
+}
+
 void RunDocker::run(std::size_t session_id,
                     std::string_view app_state_folder,
                     std::shared_ptr<events::devices_atom_queue> plugged_devices_queue,
@@ -110,6 +130,43 @@ void RunDocker::run(std::size_t session_id,
       }
     }
   }
+
+  // when creating a virtual DualSense device we need to also mount a `/dev/hidraw*` device.
+  // unfortunately hidraw devices use dynamically assigned major numbers rather than static ones
+  // so we'll get the major number from reading `/proc/devices` for `hidraw` and `input`
+  // and set the right entries in `DeviceCgroupRules`
+  {
+    auto hidraw_major = get_device_major("hidraw");
+    auto input_major = get_device_major("input");
+    if (hidraw_major && input_major) {
+      logs::log(logs::debug,
+                "[DOCKER] Setting DeviceCgroupRules for hidraw:{} and input:{}",
+                *hidraw_major,
+                *input_major);
+      auto parsed_json = utils::parse_json(final_json_opts).as_object();
+      if (auto host_config_ptr = parsed_json.if_contains("HostConfig")) {
+        auto host_config = host_config_ptr->as_object();
+        host_config["DeviceCgroupRules"] = json::array{
+            fmt::format("c {}:* rwm", *hidraw_major),
+            fmt::format("c {}:* rwm", *input_major),
+        };
+        parsed_json["HostConfig"] = host_config;
+      } else {
+        parsed_json["HostConfig"] = json::object{
+            {"DeviceCgroupRules",
+             json::array{
+                 fmt::format("c {}:* rwm", *hidraw_major),
+                 fmt::format("c {}:* rwm", *input_major),
+             }},
+        };
+      }
+      final_json_opts = boost::json::serialize(parsed_json);
+    } else {
+      logs::log(logs::warning, "[DOCKER] Failed to get major numbers for hidraw and input");
+    }
+  }
+
+  logs::log(logs::debug, "[DOCKER] Container options: {}", final_json_opts);
 
   Container new_container = {.id = "",
                              .name = fmt::format("{}_{}", this->container.name, session_id),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16...3.24)
 FetchContent_Declare(
         Catch2
         GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.3.2
+        GIT_TAG v3.8.0
 )
 
 FetchContent_MakeAvailable(Catch2)
@@ -105,6 +105,7 @@ target_link_libraries_system(wolftests PRIVATE
 
 ## Test assets
 configure_file(assets/config.test.toml ${CMAKE_CURRENT_BINARY_DIR}/config.test.toml COPYONLY)
+configure_file(assets/config.test.toml ${CMAKE_CURRENT_BINARY_DIR}/config.test.EDITED.toml COPYONLY)
 
 # See: https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)


### PR DESCRIPTION
Thanks to all reports in #187 and after a bit of digging, I've found out that there was a mismatch in the `major` number that would be assigned for `hidraw` devices; for example `244` on Arch whilst `246` on Debian. When the mismatch occurs, our hot plugging code (`mknod /dev/hidraw* ...`) will silently fail resulting in 
```
root@77d4bf4b9ff0:/dev# cat hidraw8 
cat: hidraw8: Operation not permitted
```
which in turn will end up in mismatched inputs between the client and the server as originally reported.

Turns out that `hidraw` devices use dynamically assigned major numbers rather than static ones. You can easily check which number you get assigned with
```
grep hidraw /proc/devices
```

So, we could do the unsafe way of defaulting to `c *:* rmw`, instead I've added the code for dynamically grab those values and set the right `DeviceCgroupRules` instead.
