### PR TITLE
Moonlight patches and upgrades

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -9,7 +9,7 @@ on:
       - "docker/**"
       - ".github/**"
   pull_request:
-    paths:
+    paths-ignore:
       - "docs/**"
       - "docker/**"
       - ".github/**"
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - uses: DoozyX/clang-format-lint-action@v0.14
         with:

--- a/.github/workflows/linux-build-test.yml
+++ b/.github/workflows/linux-build-test.yml
@@ -40,13 +40,15 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.1
 
       - name: Setup gst-wayland-display
         run: |
           git clone https://github.com/games-on-whales/gst-wayland-display
           cd gst-wayland-display
           git checkout a31f5a0
-          cargo install cargo-c
+          cargo install --locked cargo-c
           cargo cinstall -p c-bindings --prefix=/usr/local
 
       - name: Archive libgstwaylanddisplay-aarch64
@@ -111,13 +113,15 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.85.1
 
       - name: Setup gst-wayland-display
         run: |
           git clone https://github.com/games-on-whales/gst-wayland-display
           cd gst-wayland-display
           git checkout a31f5a0
-          cargo install cargo-c
+          cargo install --locked cargo-c
           cargo cinstall -p c-bindings --prefix=/usr/local --destdir=${{runner.workspace}}
 
       - name: Archive libgstwaylanddisplay-x86_64

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -30,6 +30,10 @@ RUN apt-get update -y && \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="$HOME/.cargo/bin:${PATH}"
 
+ARG RUST_VERSION=1.85.1
+ENV RUST_VERSION=$RUST_VERSION
+RUN rustup install $RUST_VERSION && rustup default $RUST_VERSION
+
 WORKDIR /tmp/
 RUN <<_GST_WAYLAND_DISPLAY
     #!/bin/bash
@@ -38,7 +42,7 @@ RUN <<_GST_WAYLAND_DISPLAY
     git clone https://github.com/games-on-whales/gst-wayland-display
     cd gst-wayland-display
     git checkout a31f5a0
-    cargo install cargo-c
+    cargo install --locked cargo-c
     cargo cinstall -p c-bindings --prefix=/usr/local --libdir=/usr/local/lib/
 _GST_WAYLAND_DISPLAY
 

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -131,10 +131,10 @@ EXPOSE 47989/tcp
 EXPOSE 47999/udp
 # RTSP
 EXPOSE 48010/tcp
-# Video (up to 10 users)
-EXPOSE 48100-48110/udp
-# Audio (up to 10 users)
-EXPOSE 48200-48210/udp
+# Video
+EXPOSE 48100/udp
+# Audio
+EXPOSE 48200/udp
 
 LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
 LABEL org.opencontainers.image.description="Wolf: stream virtual desktops and games in Docker"

--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -540,11 +540,21 @@ EXPOSE 47989/tcp
 EXPOSE 47999/udp
 # RTSP
 EXPOSE 48010/tcp
-# Video (up to 10 users, you can open more ports if needed)
-EXPOSE 48100-48110/udp
-# Audio (up to 10 users, you can open more ports if needed)
-EXPOSE 48200-48210/udp
+# Video
+EXPOSE 48100/udp
+# Audio
+EXPOSE 48200/udp
 ....
+
+These are the default values, if you want to assign custom ports you can set the env variables:
+
+* `WOLF_HTTP_PORT`
+* `WOLF_HTTPS_PORT`
+* `WOLF_CONTROL_PORT`
+* `WOLF_RTSP_SETUP_PORT`
+* `WOLF_VIDEO_PING_PORT`
+* `WOLF_AUDIO_PING_PORT`
+
 ====
 
 == Moonlight pairing

--- a/src/moonlight-protocol/moonlight.cpp
+++ b/src/moonlight-protocol/moonlight.cpp
@@ -184,13 +184,22 @@ XML applist(const immer::vector<App> &apps) {
 }
 
 XML launch_success(const std::string &local_ip, const std::string &rtsp_port) {
-  // TODO: implement resume
   // TODO: implement error on launch
   XML resp;
 
   resp.put("root.<xmlattr>.status_code", 200);
   resp.put("root.sessionUrl0", "rtsp://" + local_ip + ":" + rtsp_port);
   resp.put("root.gamesession", 1);
+
+  return resp;
+}
+
+XML launch_resume(const std::string &local_ip, const std::string &rtsp_port) {
+  XML resp;
+
+  resp.put("root.<xmlattr>.status_code", 200);
+  resp.put("root.sessionUrl0", "rtsp://" + local_ip + ":" + rtsp_port);
+  resp.put("root.resume", 1);
 
   return resp;
 }

--- a/src/moonlight-protocol/moonlight/data-structures.hpp
+++ b/src/moonlight-protocol/moonlight/data-structures.hpp
@@ -34,7 +34,7 @@ struct App {
 #define ML_FF_SESSION_ID_V1 0x02 // Client supports X-SS-Ping-Payload and X-SS-Connect-Data
 
 struct SS_PING {
-  std::array<uint8_t, 16> payload;
+  std::array<char, 16> payload;
   uint32_t sequenceNumber;
 };
 

--- a/src/moonlight-protocol/moonlight/data-structures.hpp
+++ b/src/moonlight-protocol/moonlight/data-structures.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -27,6 +28,15 @@ struct App {
 #define FLAG_SOF 0x4
 
 #define MAX_RTP_HEADER_SIZE 16
+
+// Client feature flags for x-ml-general.featureFlags SDP attribute
+#define ML_FF_FEC_STATUS 0x01    // Client sends SS_FRAME_FEC_STATUS for frame losses
+#define ML_FF_SESSION_ID_V1 0x02 // Client supports X-SS-Ping-Payload and X-SS-Connect-Data
+
+struct SS_PING {
+  std::array<char, 16> payload;
+  uint32_t sequenceNumber;
+};
 
 typedef struct _NV_VIDEO_PACKET {
   uint32_t streamPacketIndex;

--- a/src/moonlight-protocol/moonlight/data-structures.hpp
+++ b/src/moonlight-protocol/moonlight/data-structures.hpp
@@ -34,7 +34,7 @@ struct App {
 #define ML_FF_SESSION_ID_V1 0x02 // Client supports X-SS-Ping-Payload and X-SS-Connect-Data
 
 struct SS_PING {
-  std::array<char, 16> payload;
+  std::array<uint8_t, 16> payload;
   uint32_t sequenceNumber;
 };
 

--- a/src/moonlight-protocol/moonlight/protocol.hpp
+++ b/src/moonlight-protocol/moonlight/protocol.hpp
@@ -154,4 +154,6 @@ XML applist(const immer::vector<App> &apps);
  */
 XML launch_success(const std::string &local_ip, const std::string &rtsp_port);
 // TODO: launch_error()
+
+XML launch_resume(const std::string &local_ip, const std::string &rtsp_port);
 } // namespace moonlight

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -1,8 +1,8 @@
 #include <api/api.hpp>
 #include <control/input_handler.hpp>
+#include <rtp/udp-ping.hpp>
 #include <state/config.hpp>
 #include <state/sessions.hpp>
-#include <rtp/udp-ping.hpp>
 
 namespace wolf::api {
 
@@ -90,7 +90,7 @@ void UnixSocketServer::endpoint_Apps(const HTTPRequest &req, std::shared_ptr<Uni
 }
 
 void UnixSocketServer::endpoint_AddApp(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
-  auto app = rfl::json::read<rfl::Reflector<wolf::core::events::App>::ReflType>(req.body);
+  auto app = rfl::json::read<rfl::Reflector<events::App>::ReflType>(req.body);
   if (app) {
     state_->app_state->config->apps->update([app = app.value(), this](auto &apps) {
       auto runner =
@@ -142,27 +142,8 @@ void UnixSocketServer::endpoint_StreamSessions(const HTTPRequest &req, std::shar
   send_http(socket, 200, rfl::json::write(res));
 }
 
-void start_rtp_ping(const wolf::core::events::StreamSession &session) {
-
-  // Video RTP Ping
-  rtp::wait_for_ping(session.video_stream_port,
-                     [ev_bus = session.event_bus](unsigned short client_port, const std::string &client_ip) {
-                       logs::log(logs::trace, "[PING] video from {}:{}", client_ip, client_port);
-                       auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = client_ip, .client_port = client_port};
-                       ev_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
-                     });
-
-  // Audio RTP Ping
-  rtp::wait_for_ping(session.audio_stream_port,
-                     [ev_bus = session.event_bus](unsigned short client_port, const std::string &client_ip) {
-                       logs::log(logs::trace, "[PING] audio from {}:{}", client_ip, client_port);
-                       auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = client_ip, .client_port = client_port};
-                       ev_bus->fire_event(immer::box<wolf::core::events::RTPAudioPingEvent>(ev));
-                     });
-}
-
 void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
-  auto session = rfl::json::read<rfl::Reflector<wolf::core::events::StreamSession>::ReflType>(req.body);
+  auto session = rfl::json::read<rfl::Reflector<events::StreamSession>::ReflType>(req.body);
   if (session) {
     auto ss = session.value();
     auto app = state::get_app_by_id(this->state_->app_state->config, ss.app_id);
@@ -200,7 +181,7 @@ void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::sh
         [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
     state_->app_state->event_bus->fire_event(immer::box<events::StreamSession>(*new_session));
 
-    start_rtp_ping(*new_session);
+    rtp::start_rtp_ping(*new_session);
 
     auto res = StreamSessionCreated{.success = true, .session_id = std::to_string(new_session->session_id)};
     send_http(socket, 200, rfl::json::write(res));

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -181,7 +181,7 @@ void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::sh
         [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
     state_->app_state->event_bus->fire_event(immer::box<events::StreamSession>(*new_session));
 
-    rtp::start_rtp_ping(*new_session);
+    rtp::start_rtp_ping(new_session->video_stream_port, new_session->audio_stream_port, new_session->event_bus);
 
     auto res = StreamSessionCreated{.success = true, .session_id = std::to_string(new_session->session_id)};
     send_http(socket, 200, rfl::json::write(res));

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -193,6 +193,9 @@ void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::sh
         ss.audio_channel_count);
     new_session->ip = ss.client_ip; // Needed in order to match `/serverinfo`
 
+    new_session->aes_key = ss.aes_key;
+    new_session->aes_iv = ss.aes_iv;
+
     state_->app_state->running_sessions->update(
         [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
     state_->app_state->event_bus->fire_event(immer::box<events::StreamSession>(*new_session));

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -2,6 +2,7 @@
 #include <control/input_handler.hpp>
 #include <state/config.hpp>
 #include <state/sessions.hpp>
+#include <rtp/udp-ping.hpp>
 
 namespace wolf::api {
 
@@ -141,6 +142,25 @@ void UnixSocketServer::endpoint_StreamSessions(const HTTPRequest &req, std::shar
   send_http(socket, 200, rfl::json::write(res));
 }
 
+void start_rtp_ping(const wolf::core::events::StreamSession &session) {
+
+  // Video RTP Ping
+  rtp::wait_for_ping(session.video_stream_port,
+                     [ev_bus = session.event_bus](unsigned short client_port, const std::string &client_ip) {
+                       logs::log(logs::trace, "[PING] video from {}:{}", client_ip, client_port);
+                       auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = client_ip, .client_port = client_port};
+                       ev_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
+                     });
+
+  // Audio RTP Ping
+  rtp::wait_for_ping(session.audio_stream_port,
+                     [ev_bus = session.event_bus](unsigned short client_port, const std::string &client_ip) {
+                       logs::log(logs::trace, "[PING] audio from {}:{}", client_ip, client_port);
+                       auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = client_ip, .client_port = client_port};
+                       ev_bus->fire_event(immer::box<wolf::core::events::RTPAudioPingEvent>(ev));
+                     });
+}
+
 void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
   auto session = rfl::json::read<rfl::Reflector<wolf::core::events::StreamSession>::ReflType>(req.body);
   if (session) {
@@ -176,6 +196,8 @@ void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::sh
     state_->app_state->running_sessions->update(
         [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
     state_->app_state->event_bus->fire_event(immer::box<events::StreamSession>(*new_session));
+
+    start_rtp_ping(*new_session);
 
     auto res = StreamSessionCreated{.success = true, .session_id = std::to_string(new_session->session_id)};
     send_http(socket, 200, rfl::json::write(res));

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -181,8 +181,6 @@ void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::sh
         [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
     state_->app_state->event_bus->fire_event(immer::box<events::StreamSession>(*new_session));
 
-    rtp::start_rtp_ping(new_session->video_stream_port, new_session->audio_stream_port, new_session->event_bus);
-
     auto res = StreamSessionCreated{.success = true, .session_id = std::to_string(new_session->session_id)};
     send_http(socket, 200, rfl::json::write(res));
   } else {

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -171,11 +171,11 @@ void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::sh
                                .refreshRate = ss.video_refresh_rate,
                                .hevc_supported = state_->app_state->config->support_hevc,
                                .av1_supported = state_->app_state->config->support_av1},
-        ss.audio_channel_count);
-    new_session->ip = ss.client_ip; // Needed in order to match `/serverinfo`
-
-    new_session->aes_key = ss.aes_key;
-    new_session->aes_iv = ss.aes_iv;
+        ss.audio_channel_count,
+        ss.aes_key,
+        ss.aes_iv);
+    new_session->ip = ss.client_ip;
+    new_session->rtsp_fake_ip = ss.rtsp_fake_ip;
 
     state_->app_state->running_sessions->update(
         [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });

--- a/src/moonlight-server/control/control.cpp
+++ b/src/moonlight-server/control/control.cpp
@@ -153,7 +153,7 @@ void run_control(int port,
             return;
           }
         }
-        logs::log(logs::warning, "Client not found for session: {}", ev->session_id);
+        logs::log(logs::debug, "[ENET] Client not found for session: {}", ev->session_id);
       });
 
   while (true) {

--- a/src/moonlight-server/control/control.cpp
+++ b/src/moonlight-server/control/control.cpp
@@ -97,6 +97,16 @@ bool encrypt_and_send(std::string_view payload,
   }
 }
 
+std::optional<StreamSession>
+get_current_session(const state::SessionsAtoms &running_sessions, std::string_view client_ip, uint32_t connect_data) {
+  for (const StreamSession &session : *running_sessions->load()) {
+    if (session.enet_secret_payload == connect_data || session.ip == client_ip) {
+      return session;
+    }
+  }
+  return {};
+}
+
 void run_control(int port,
                  const state::SessionsAtoms &running_sessions,
                  const std::shared_ptr<events::EventBusType> &event_bus,
@@ -124,7 +134,7 @@ void run_control(int port,
   while (true) {
     if (enet_host_service(host.get(), &event, timeout.count()) > 0) {
       auto [client_ip, client_port] = get_ip((sockaddr *)&event.peer->address.address);
-      auto client_session = state::get_session_by_ip(running_sessions->load(), client_ip);
+      auto client_session = get_current_session(running_sessions, client_ip, event.data);
       if (client_session) {
         switch (event.type) {
         case ENET_EVENT_TYPE_NONE:

--- a/src/moonlight-server/control/control.cpp
+++ b/src/moonlight-server/control/control.cpp
@@ -84,27 +84,48 @@ bool send_packet(std::string_view payload, ENetPeer *peer) {
 
 bool encrypt_and_send(std::string_view payload,
                       std::string_view aes_key,
-                      const immer::atom<enet_clients_map> &connected_clients,
-                      std::size_t session_id) {
-  auto clients = connected_clients.load();
-  auto enet_peer = clients->find(session_id);
-  if (!enet_peer) {
-    logs::log(logs::debug, "[ENET] Unable to send encrypted packed {}", session_id);
-    return false;
-  } else {
+                      immer::box<std::shared_ptr<ENetPeer>> connected_client) {
+  if (auto enet_client = connected_client->get()) {
     auto encrypted = control::encrypt_packet(aes_key, 0, payload); // TODO: seq?
-    return send_packet({(char *)encrypted.get(), encrypted->full_size()}, enet_peer->get().get());
+    return send_packet({(char *)encrypted.get(), encrypted->full_size()}, enet_client);
+  } else {
+    logs::log(logs::warning, "[ENET] Failed to send packet, client is not connected");
+    return false;
   }
 }
 
-std::optional<StreamSession>
-get_current_session(const state::SessionsAtoms &running_sessions, std::string_view client_ip, uint32_t connect_data) {
-  for (const StreamSession &session : *running_sessions->load()) {
-    if (session.enet_secret_payload == connect_data || session.ip == client_ip) {
-      return session;
+std::optional<events::StreamSession> get_current_session(const enet_clients_map &connected_clients,
+                                                         const state::SessionsAtoms &running_sessions,
+                                                         std::string_view client_ip,
+                                                         const ENetEvent &enet_event) {
+  if (enet_event.type == ENET_EVENT_TYPE_CONNECT) {
+    // A new connection, we should check if there's a session that matches the current client
+    for (const StreamSession &session : *running_sessions->load()) {
+      if (session.enet_secret_payload == enet_event.data) {
+        return session;
+      }
+    }
+    logs::log(logs::warning,
+              "[ENET] Unable to find a session that matches the client secret {}, matching by IP",
+              enet_event.data);
+    for (const StreamSession &session : *running_sessions->load()) {
+      if (session.ip == client_ip) {
+        return session;
+      }
+    }
+  } else {
+    // The connection has already been established, we'll check for a match in our connected client map
+    if (auto client = connected_clients.find(enet_event.peer)) {
+      return client->get();
     }
   }
-  return {};
+  return std::nullopt;
+}
+
+std::shared_ptr<ENetPeer> to_shared_ptr(ENetPeer *peer) {
+  return std::shared_ptr<ENetPeer>(peer, [](auto _peer) {
+    // DO NOTHING, we don't want to free peer, the lifecycle is dictated by enet
+  });
 }
 
 void run_control(int port,
@@ -122,37 +143,38 @@ void run_control(int port,
   immer::atom<enet_clients_map> connected_clients;
 
   auto stop_ev = event_bus->register_handler<immer::box<StopStreamEvent>>(
-      [&connected_clients, &running_sessions](const immer::box<StopStreamEvent> &ev) {
-        auto client_session = state::get_session_by_id(running_sessions->load(), ev->session_id);
-        if (client_session) {
-          auto terminate_pkt = ControlTerminatePacket{};
-          std::string plaintext = {(char *)&terminate_pkt, sizeof(terminate_pkt)};
-          encrypt_and_send(plaintext, client_session->aes_key, connected_clients, ev->session_id);
+      [&connected_clients](const immer::box<StopStreamEvent> &ev) {
+        auto terminate_pkt = ControlTerminatePacket{};
+        std::string plaintext = {(char *)&terminate_pkt, sizeof(terminate_pkt)};
+        for (auto &[peer, session] : *connected_clients.load()) {
+          if (session->session_id == ev->session_id) {
+            immer::box<std::shared_ptr<ENetPeer>> enet_client = {to_shared_ptr(peer)};
+            encrypt_and_send(plaintext, session->aes_key, enet_client);
+            return;
+          }
         }
+        logs::log(logs::warning, "Client not found for session: {}", ev->session_id);
       });
 
   while (true) {
     if (enet_host_service(host.get(), &event, timeout.count()) > 0) {
       auto [client_ip, client_port] = get_ip((sockaddr *)&event.peer->address.address);
-      auto client_session = get_current_session(running_sessions, client_ip, event.data);
+      auto client_session = get_current_session(connected_clients, running_sessions, client_ip, event);
       if (client_session) {
         switch (event.type) {
         case ENET_EVENT_TYPE_NONE:
           break;
         case ENET_EVENT_TYPE_CONNECT:
           logs::log(logs::debug, "[ENET] connected client: {}:{}", client_ip, client_port);
-          connected_clients.update([&event, sess_id = client_session->session_id](const enet_clients_map &m) {
-            return m.set(sess_id, std::shared_ptr<ENetPeer>(event.peer, [](auto peer) {
-                           // DO NOTHING, we don't want to free peer, the lifecycle is dictated by enet
-                         }));
+          connected_clients.update([peer = event.peer, client_session](const enet_clients_map &m) {
+            return m.set(peer, client_session.value());
           });
           event_bus->fire_event(
               immer::box<ResumeStreamEvent>(ResumeStreamEvent{.session_id = client_session->session_id}));
           break;
         case ENET_EVENT_TYPE_DISCONNECT:
           logs::log(logs::debug, "[ENET] disconnected client: {}:{}", client_ip, client_port);
-          connected_clients.update(
-              [sess_id = client_session->session_id](const enet_clients_map &m) { return m.erase(sess_id); });
+          connected_clients.update([peer = event.peer](const enet_clients_map &m) { return m.erase(peer); });
           event_bus->fire_event(
               immer::box<PauseStreamEvent>(PauseStreamEvent{.session_id = client_session->session_id}));
           break;
@@ -184,7 +206,8 @@ void run_control(int port,
                 event_bus->fire_event(
                     immer::box<PauseStreamEvent>(PauseStreamEvent{.session_id = client_session->session_id}));
               } else if (sub_type == INPUT_DATA) {
-                handle_input(client_session.value(), connected_clients, (INPUT_PKT *)decrypted.data());
+                immer::box<std::shared_ptr<ENetPeer>> enet_client = {to_shared_ptr(event.peer)};
+                handle_input(client_session.value(), enet_client, (INPUT_PKT *)decrypted.data());
               } else if (sub_type == IDR_FRAME) {
                 auto ev = IDRRequestEvent{.session_id = client_session->session_id};
                 event_bus->fire_event(immer::box<IDRRequestEvent>{ev});

--- a/src/moonlight-server/control/control.hpp
+++ b/src/moonlight-server/control/control.hpp
@@ -21,12 +21,13 @@ void run_control(int port,
                  std::chrono::milliseconds timeout = 1000ms,
                  const std::string &host_ip = "0.0.0.0");
 
-using enet_clients_map = immer::map<std::size_t, immer::box<std::shared_ptr<ENetPeer>>>;
+using enet_clients_map = immer::map<ENetPeer *, immer::box<events::StreamSession>>;
+
+std::shared_ptr<ENetPeer> to_shared_ptr(ENetPeer *peer);
 
 bool encrypt_and_send(std::string_view payload,
                       std::string_view aes_key,
-                      const immer::atom<enet_clients_map> &connected_clients,
-                      std::size_t session_id);
+                      immer::box<std::shared_ptr<ENetPeer>> connected_client);
 
 bool init();
 

--- a/src/moonlight-server/control/input_handler.cpp
+++ b/src/moonlight-server/control/input_handler.cpp
@@ -16,28 +16,22 @@ using namespace std::string_literals;
 using namespace moonlight::control;
 
 std::shared_ptr<events::JoypadTypes> create_new_joypad(const events::StreamSession &session,
-                                                       const immer::atom<enet_clients_map> &connected_clients,
+                                                       immer::box<std::shared_ptr<ENetPeer>> connected_client,
                                                        int controller_number,
                                                        CONTROLLER_TYPE requested_type,
                                                        uint8_t capabilities) {
 
-  auto on_rumble_fn = ([clients = &connected_clients,
-                        controller_number,
-                        session_id = session.session_id,
-                        aes_key = session.aes_key](int low_freq, int high_freq) {
+  auto on_rumble_fn = ([connected_client, controller_number, aes_key = session.aes_key](int low_freq, int high_freq) {
     auto rumble_pkt = ControlRumblePacket{
         .header = {.type = RUMBLE_DATA, .length = sizeof(ControlRumblePacket) - sizeof(ControlPacket)},
         .controller_number = boost::endian::native_to_little((uint16_t)controller_number),
         .low_freq = boost::endian::native_to_little((uint16_t)low_freq),
         .high_freq = boost::endian::native_to_little((uint16_t)high_freq)};
     std::string plaintext = {(char *)&rumble_pkt, sizeof(rumble_pkt)};
-    encrypt_and_send(plaintext, aes_key, *clients, session_id);
+    encrypt_and_send(plaintext, aes_key, connected_client);
   });
 
-  auto on_led_fn = ([clients = &connected_clients,
-                     controller_number,
-                     session_id = session.session_id,
-                     aes_key = session.aes_key](int r, int g, int b) {
+  auto on_led_fn = ([connected_client, controller_number, aes_key = session.aes_key](int r, int g, int b) {
     auto led_pkt = ControlRGBLedPacket{
         .header{.type = RGB_LED_EVENT, .length = sizeof(ControlRGBLedPacket) - sizeof(ControlPacket)},
         .controller_number = boost::endian::native_to_little((uint16_t)controller_number),
@@ -45,19 +39,17 @@ std::shared_ptr<events::JoypadTypes> create_new_joypad(const events::StreamSessi
         .g = static_cast<uint8_t>(g),
         .b = static_cast<uint8_t>(b)};
     std::string plaintext = {(char *)&led_pkt, sizeof(led_pkt)};
-    encrypt_and_send(plaintext, aes_key, *clients, session_id);
+    encrypt_and_send(plaintext, aes_key, connected_client);
   });
 
-  auto on_adaptive_trigger_fn = ([clients = &connected_clients,
-                                  controller_number,
-                                  session_id = session.session_id,
-                                  aes_key = session.aes_key](const inputtino::PS5Joypad::TriggerEffect &effect) {
+  auto on_adaptive_trigger_fn = ([connected_client, controller_number, aes_key = session.aes_key](
+                                     const inputtino::PS5Joypad::TriggerEffect &effect) {
     auto rumble_pkt = ControlAdaptiveTriggerPacket{
         .header{.type = ADAPTIVE_TRIGGER_EVENT, .length = sizeof(ControlAdaptiveTriggerPacket) - sizeof(ControlPacket)},
         .controller_number = boost::endian::native_to_little((uint16_t)controller_number),
         .effect = effect};
     std::string plaintext = {(char *)&rumble_pkt, sizeof(rumble_pkt)};
-    encrypt_and_send(plaintext, aes_key, *clients, session_id);
+    encrypt_and_send(plaintext, aes_key, connected_client);
   });
 
   std::shared_ptr<events::JoypadTypes> new_pad;
@@ -155,7 +147,7 @@ std::shared_ptr<events::JoypadTypes> create_new_joypad(const events::StreamSessi
         .reportrate = 100,
         .type = ACCELERATION};
     std::string plaintext = {(char *)&accelerometer_pkt, sizeof(accelerometer_pkt)};
-    encrypt_and_send(plaintext, session.aes_key, connected_clients, session.session_id);
+    encrypt_and_send(plaintext, session.aes_key, connected_client);
   }
 
   if (capabilities & GYRO && final_type == wolf::config::ControllerType::PS) {
@@ -167,7 +159,7 @@ std::shared_ptr<events::JoypadTypes> create_new_joypad(const events::StreamSessi
         .reportrate = 100,
         .type = GYROSCOPE};
     std::string plaintext = {(char *)&gyro_pkt, sizeof(gyro_pkt)};
-    encrypt_and_send(plaintext, session.aes_key, connected_clients, session.session_id);
+    encrypt_and_send(plaintext, session.aes_key, connected_client);
   }
 
   session.joypads->update([&](events::JoypadList joypads) {
@@ -510,7 +502,7 @@ void pen(const PEN_PACKET &pkt, events::StreamSession &session) {
 
 void controller_arrival(const CONTROLLER_ARRIVAL_PACKET &pkt,
                         events::StreamSession &session,
-                        const immer::atom<enet_clients_map> &connected_clients) {
+                        immer::box<std::shared_ptr<ENetPeer>> connected_client) {
   auto joypads = session.joypads->load();
   if (joypads->find(pkt.controller_number)) {
     // TODO: should we replace it instead?
@@ -519,7 +511,7 @@ void controller_arrival(const CONTROLLER_ARRIVAL_PACKET &pkt,
               pkt.controller_number);
   } else {
     create_new_joypad(session,
-                      connected_clients,
+                      connected_client,
                       pkt.controller_number,
                       (CONTROLLER_TYPE)pkt.controller_type,
                       pkt.capabilities);
@@ -528,7 +520,7 @@ void controller_arrival(const CONTROLLER_ARRIVAL_PACKET &pkt,
 
 void controller_multi(const CONTROLLER_MULTI_PACKET &pkt,
                       events::StreamSession &session,
-                      const immer::atom<enet_clients_map> &connected_clients) {
+                      immer::box<std::shared_ptr<ENetPeer>> connected_client) {
   auto joypads = session.joypads->load();
   std::shared_ptr<events::JoypadTypes> selected_pad;
   if (auto joypad = joypads->find(pkt.controller_number)) {
@@ -552,7 +544,7 @@ void controller_multi(const CONTROLLER_MULTI_PACKET &pkt,
     }
   } else {
     // Old Moonlight doesn't support CONTROLLER_ARRIVAL, we create a default pad when it's first mentioned
-    selected_pad = create_new_joypad(session, connected_clients, pkt.controller_number, XBOX, ANALOG_TRIGGERS | RUMBLE);
+    selected_pad = create_new_joypad(session, connected_client, pkt.controller_number, XBOX, ANALOG_TRIGGERS | RUMBLE);
   }
   std::visit(
       [pkt](inputtino::Joypad &pad) {
@@ -656,7 +648,7 @@ void controller_battery(const CONTROLLER_BATTERY_PACKET &pkt, events::StreamSess
 }
 
 void handle_input(events::StreamSession &session,
-                  const immer::atom<enet_clients_map> &connected_clients,
+                  immer::box<std::shared_ptr<ENetPeer>> connected_client,
                   INPUT_PKT *pkt) {
   switch (pkt->type) {
   case MOUSE_MOVE_REL: {
@@ -718,13 +710,13 @@ void handle_input(events::StreamSession &session,
   case CONTROLLER_ARRIVAL: {
     logs::log(logs::trace, "[INPUT] Received input of type: CONTROLLER_ARRIVAL");
     auto new_controller = static_cast<CONTROLLER_ARRIVAL_PACKET *>(pkt);
-    controller_arrival(*new_controller, session, connected_clients);
+    controller_arrival(*new_controller, session, connected_client);
     break;
   }
   case CONTROLLER_MULTI: {
     logs::log(logs::trace, "[INPUT] Received input of type: CONTROLLER_MULTI");
     auto controller_pkt = static_cast<CONTROLLER_MULTI_PACKET *>(pkt);
-    controller_multi(*controller_pkt, session, connected_clients);
+    controller_multi(*controller_pkt, session, connected_client);
     break;
   }
   case CONTROLLER_TOUCH: {

--- a/src/moonlight-server/control/input_handler.hpp
+++ b/src/moonlight-server/control/input_handler.hpp
@@ -13,7 +13,7 @@ using namespace wolf::core;
  * Side effect: session devices might be updated when hotplugging
  */
 void handle_input(events::StreamSession &session,
-                  const immer::atom<enet_clients_map> &connected_clients,
+                  immer::box<std::shared_ptr<ENetPeer>> connected_client,
                   INPUT_PKT *pkt);
 
 void mouse_move_rel(const MOUSE_MOVE_REL_PACKET &pkt, events::StreamSession &session);
@@ -36,11 +36,11 @@ void pen(const PEN_PACKET &pkt, events::StreamSession &session);
 
 void controller_arrival(const CONTROLLER_ARRIVAL_PACKET &pkt,
                         events::StreamSession &session,
-                        const immer::atom<enet_clients_map> &connected_clients);
+                        immer::box<std::shared_ptr<ENetPeer>> connected_client);
 
 void controller_multi(const CONTROLLER_MULTI_PACKET &pkt,
                       events::StreamSession &session,
-                      const immer::atom<enet_clients_map> &connected_clients);
+                      immer::box<std::shared_ptr<ENetPeer>> connected_client);
 
 void controller_touch(const CONTROLLER_TOUCH_PACKET &pkt, events::StreamSession &session);
 

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -114,7 +114,7 @@ struct VideoSession {
   ColorSpace color_space;
 
   std::string client_ip;
-  std::array<uint8_t, 16> rtp_secret_payload;
+  std::array<char, 16> rtp_secret_payload;
 };
 
 struct AudioSession {
@@ -130,7 +130,7 @@ struct AudioSession {
   std::uint16_t port;
   bool wait_for_ping = true;
   std::string client_ip;
-  std::array<uint8_t, 16> rtp_secret_payload;
+  std::array<char, 16> rtp_secret_payload;
 
   int packet_duration;
   wolf::core::audio::AudioMode audio_mode;
@@ -156,13 +156,13 @@ struct StopStreamEvent {
 struct RTPVideoPingEvent {
   std::string client_ip;
   unsigned short client_port;
-  std::optional<std::array<uint8_t, 16>> payload;
+  std::optional<std::array<char, 16>> payload;
 };
 
 struct RTPAudioPingEvent {
   std::string client_ip;
   unsigned short client_port;
-  std::optional<std::array<uint8_t, 16>> payload;
+  std::optional<std::array<char, 16>> payload;
 };
 
 struct StreamSession;
@@ -233,7 +233,7 @@ struct StreamSession {
   std::string aes_iv;
 
   // Moonlight protocol extension to support IP-less connections
-  std::array<uint8_t, 16> rtp_secret_payload;
+  std::array<char, 16> rtp_secret_payload;
   uint32_t enet_secret_payload;
   /**
    * A dirty hack in order to support RTSP without IP.

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -114,6 +114,7 @@ struct VideoSession {
   ColorSpace color_space;
 
   std::string client_ip;
+  std::array<char, 16> rtp_secret_payload;
 };
 
 struct AudioSession {
@@ -129,6 +130,7 @@ struct AudioSession {
   std::uint16_t port;
   bool wait_for_ping = true;
   std::string client_ip;
+  std::array<char, 16> rtp_secret_payload;
 
   int packet_duration;
   wolf::core::audio::AudioMode audio_mode;
@@ -154,11 +156,13 @@ struct StopStreamEvent {
 struct RTPVideoPingEvent {
   std::string client_ip;
   unsigned short client_port;
+  std::optional<std::array<char, 16>> payload;
 };
 
 struct RTPAudioPingEvent {
   std::string client_ip;
   unsigned short client_port;
+  std::optional<std::array<char, 16>> payload;
 };
 
 struct StreamSession;
@@ -227,6 +231,10 @@ struct StreamSession {
   // gcm encryption keys
   std::string aes_key;
   std::string aes_iv;
+
+  // Moonlight protocol extension to support IP-less connections
+  std::array<char, 16> rtp_secret_payload;
+  uint32_t enet_secret_payload;
 
   // client info
   std::size_t session_id;

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -117,6 +117,8 @@ struct VideoSession {
   std::array<char, 16> rtp_secret_payload;
 };
 
+using video_session_list = immer::vector<immer::box<VideoSession>>;
+
 struct AudioSession {
   std::string gst_pipeline;
 
@@ -135,6 +137,8 @@ struct AudioSession {
   int packet_duration;
   wolf::core::audio::AudioMode audio_mode;
 };
+
+using audio_session_list = immer::vector<immer::box<AudioSession>>;
 
 struct IDRRequestEvent {
   // A unique ID that identifies this session

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -114,7 +114,7 @@ struct VideoSession {
   ColorSpace color_space;
 
   std::string client_ip;
-  std::array<char, 16> rtp_secret_payload;
+  std::array<uint8_t, 16> rtp_secret_payload;
 };
 
 struct AudioSession {
@@ -130,7 +130,7 @@ struct AudioSession {
   std::uint16_t port;
   bool wait_for_ping = true;
   std::string client_ip;
-  std::array<char, 16> rtp_secret_payload;
+  std::array<uint8_t, 16> rtp_secret_payload;
 
   int packet_duration;
   wolf::core::audio::AudioMode audio_mode;
@@ -156,13 +156,13 @@ struct StopStreamEvent {
 struct RTPVideoPingEvent {
   std::string client_ip;
   unsigned short client_port;
-  std::optional<std::array<char, 16>> payload;
+  std::optional<std::array<uint8_t, 16>> payload;
 };
 
 struct RTPAudioPingEvent {
   std::string client_ip;
   unsigned short client_port;
-  std::optional<std::array<char, 16>> payload;
+  std::optional<std::array<uint8_t, 16>> payload;
 };
 
 struct StreamSession;
@@ -233,8 +233,15 @@ struct StreamSession {
   std::string aes_iv;
 
   // Moonlight protocol extension to support IP-less connections
-  std::array<char, 16> rtp_secret_payload;
+  std::array<uint8_t, 16> rtp_secret_payload;
   uint32_t enet_secret_payload;
+  /**
+   * A dirty hack in order to support RTSP without IP.
+   *
+   * Moonlight will parrot back the IP that we send out in the launch or resume HTTPs requests.
+   * So we send out a fake unique IP for each session in order to identify the session back in the RTSP thread.
+   */
+  std::string rtsp_fake_ip;
 
   // client info
   std::size_t session_id;

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -160,12 +160,14 @@ struct StopStreamEvent {
 struct RTPVideoPingEvent {
   std::string client_ip;
   unsigned short client_port;
+  rfl::Skip<std::shared_ptr<boost::asio::ip::udp::socket>> video_socket;
   std::optional<std::array<char, 16>> payload;
 };
 
 struct RTPAudioPingEvent {
   std::string client_ip;
   unsigned short client_port;
+  rfl::Skip<std::shared_ptr<boost::asio::ip::udp::socket>> audio_socket;
   std::optional<std::array<char, 16>> payload;
 };
 
@@ -253,6 +255,7 @@ struct StreamSession {
 
   unsigned short video_stream_port;
   unsigned short audio_stream_port;
+  unsigned short control_stream_port;
 
   /**
    * Optional: the wayland display for the current session.

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -117,8 +117,6 @@ struct VideoSession {
   std::array<char, 16> rtp_secret_payload;
 };
 
-using video_session_list = immer::vector<immer::box<VideoSession>>;
-
 struct AudioSession {
   std::string gst_pipeline;
 
@@ -137,8 +135,6 @@ struct AudioSession {
   int packet_duration;
   wolf::core::audio::AudioMode audio_mode;
 };
-
-using audio_session_list = immer::vector<immer::box<AudioSession>>;
 
 struct IDRRequestEvent {
   // A unique ID that identifies this session

--- a/src/moonlight-server/events/reflectors.hpp
+++ b/src/moonlight-server/events/reflectors.hpp
@@ -81,6 +81,10 @@ template <> struct Reflector<events::StreamSession> {
     std::string client_id;
     std::string client_ip;
 
+    // gcm encryption keys
+    std::string aes_key;
+    std::string aes_iv;
+
     int video_width;
     int video_height;
     int video_refresh_rate;
@@ -94,11 +98,14 @@ template <> struct Reflector<events::StreamSession> {
     return {.app_id = v.app->base.id,
             .client_id = std::to_string(v.session_id),
             .client_ip = v.ip,
+            .aes_key = v.aes_key,
+            .aes_iv = v.aes_iv,
             .video_width = v.display_mode.width,
             .video_height = v.display_mode.height,
             .video_refresh_rate = v.display_mode.refreshRate,
             .audio_channel_count = v.audio_channel_count,
-            .client_settings = v.client_settings};
+            .client_settings = v.client_settings
+          };
   }
 };
 

--- a/src/moonlight-server/events/reflectors.hpp
+++ b/src/moonlight-server/events/reflectors.hpp
@@ -84,6 +84,7 @@ template <> struct Reflector<events::StreamSession> {
     // gcm encryption keys
     std::string aes_key;
     std::string aes_iv;
+    std::string rtsp_fake_ip;
 
     int video_width;
     int video_height;
@@ -100,12 +101,12 @@ template <> struct Reflector<events::StreamSession> {
             .client_ip = v.ip,
             .aes_key = v.aes_key,
             .aes_iv = v.aes_iv,
+            .rtsp_fake_ip = v.rtsp_fake_ip,
             .video_width = v.display_mode.width,
             .video_height = v.display_mode.height,
             .video_refresh_rate = v.display_mode.refreshRate,
             .audio_channel_count = v.audio_channel_count,
-            .client_settings = v.client_settings
-          };
+            .client_settings = v.client_settings};
   }
 };
 

--- a/src/moonlight-server/rest/custom-https.cpp
+++ b/src/moonlight-server/rest/custom-https.cpp
@@ -17,7 +17,7 @@ Server<HTTPS>::Server(const std::string &certification_file, const std::string &
 
   this->on_error = [](std::shared_ptr<typename ServerBase<HTTPS>::Request> request, const error_code &ec) -> void {
     // TODO: why is stream truncated happening so frequently?
-    logs::log(ec.value() == 1 ? logs::trace : logs::warning,
+    logs::log(ec.value() == 1 || ec.value() == 167773206 ? logs::trace : logs::warning,
               "HTTPS error during request at {} error code: {} - {}",
               request->path,
               ec.value(),

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -346,7 +346,7 @@ void appasset(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>
   }
   auto app = state::get_app_by_id(state->config, app_id.value());
   if (!app || !app.value()->base.icon_png_path) {
-    logs::log(logs::warning, "[HTTP] Can't find icon_png_path for app with id: {}", app_id.value());
+    logs::log(logs::trace, "[HTTP] Can't find icon_png_path for app with id: {}", app_id.value());
     server_error<SimpleWeb::HTTPS>(response);
     return;
   }
@@ -421,7 +421,7 @@ void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
   state->running_sessions->update(
       [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
 
-  rtp::start_rtp_ping(*new_session);
+  rtp::start_rtp_ping(new_session->video_stream_port, new_session->audio_stream_port, new_session->event_bus);
 
   auto rtsp_ip = get_rtsp_ip_string(get_host_ip<SimpleWeb::HTTPS>(request, state), *new_session);
   auto xml = moonlight::launch_success(rtsp_ip, std::to_string(state::RTSP_SETUP_PORT));
@@ -448,7 +448,7 @@ void resume(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
     new_session->pen_tablet = std::move(old_session->pen_tablet);
     new_session->touch_screen = std::move(old_session->touch_screen);
 
-    rtp::start_rtp_ping(*new_session);
+    rtp::start_rtp_ping(new_session->video_stream_port, new_session->audio_stream_port, new_session->event_bus);
 
     state->running_sessions->update([&old_session, new_session](const immer::vector<events::StreamSession> ses_v) {
       return state::remove_session(ses_v, old_session.value()).push_back(*new_session);

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -48,6 +48,7 @@ std::string get_host_ip(const std::shared_ptr<typename SimpleWeb::Server<T>::Req
 template <class T>
 void serverinfo(const std::shared_ptr<typename SimpleWeb::Server<T>::Response> &response,
                 const std::shared_ptr<typename SimpleWeb::Server<T>::Request> &request,
+                std::optional<events::StreamSession> stream_session,
                 const immer::box<state::AppState> &state) {
   log_req<T>(request);
 
@@ -57,9 +58,8 @@ void serverinfo(const std::shared_ptr<typename SimpleWeb::Server<T>::Response> &
   auto host = state->host;
   bool is_https = std::is_same_v<SimpleWeb::HTTPS, T>;
 
-  auto session = state::get_session_by_ip(state->running_sessions->load(), get_client_ip<T>(request));
-  bool is_busy = session.has_value();
-  int app_id = session.has_value() ? std::stoi(session->app->base.id) : 0;
+  bool is_busy = stream_session.has_value();
+  int app_id = stream_session.has_value() ? std::stoi(stream_session->app->base.id) : 0;
 
   auto local_ip = get_host_ip<T>(request, state);
 
@@ -393,25 +393,6 @@ auto create_run_session(const SimpleWeb::CaseInsensitiveMultimap &headers,
   return std::move(base_session);
 }
 
-void start_rtp_ping(const events::StreamSession &session) {
-
-  // Video RTP Ping
-  rtp::wait_for_ping(session.video_stream_port,
-                     [ev_bus = session.event_bus](unsigned short client_port, const std::string &client_ip) {
-                       logs::log(logs::trace, "[PING] video from {}:{}", client_ip, client_port);
-                       auto ev = events::RTPVideoPingEvent{.client_ip = client_ip, .client_port = client_port};
-                       ev_bus->fire_event(immer::box<events::RTPVideoPingEvent>(ev));
-                     });
-
-  // Audio RTP Ping
-  rtp::wait_for_ping(session.audio_stream_port,
-                     [ev_bus = session.event_bus](unsigned short client_port, const std::string &client_ip) {
-                       logs::log(logs::trace, "[PING] audio from {}:{}", client_ip, client_port);
-                       auto ev = events::RTPAudioPingEvent{.client_ip = client_ip, .client_port = client_port};
-                       ev_bus->fire_event(immer::box<events::RTPAudioPingEvent>(ev));
-                     });
-}
-
 void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::Response> &response,
             const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::Request> &request,
             const state::PairedClient &current_client,
@@ -431,7 +412,7 @@ void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
   state->running_sessions->update(
       [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
 
-  start_rtp_ping(*new_session);
+  rtp::start_rtp_ping(*new_session);
 
   auto xml =
       moonlight::launch_success(get_host_ip<SimpleWeb::HTTPS>(request, state), std::to_string(state::RTSP_SETUP_PORT));
@@ -458,7 +439,7 @@ void resume(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
     new_session->pen_tablet = std::move(old_session->pen_tablet);
     new_session->touch_screen = std::move(old_session->touch_screen);
 
-    start_rtp_ping(*new_session);
+    rtp::start_rtp_ping(*new_session);
 
     state->running_sessions->update([&old_session, new_session](const immer::vector<events::StreamSession> ses_v) {
       return state::remove_session(ses_v, old_session.value()).push_back(*new_session);

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -422,7 +422,7 @@ void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
       [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
 
   auto rtsp_ip = get_rtsp_ip_string(get_host_ip<SimpleWeb::HTTPS>(request, state), *new_session);
-  auto xml = moonlight::launch_success(rtsp_ip, std::to_string(state::RTSP_SETUP_PORT));
+  auto xml = moonlight::launch_success(rtsp_ip, std::to_string(get_port(state::RTSP_SETUP_PORT)));
   send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::success_ok, xml);
 }
 
@@ -451,7 +451,7 @@ void resume(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
     });
 
     auto rtsp_ip = get_rtsp_ip_string(get_host_ip<SimpleWeb::HTTPS>(request, state), *new_session);
-    auto xml = moonlight::launch_resume(rtsp_ip, std::to_string(state::RTSP_SETUP_PORT));
+    auto xml = moonlight::launch_resume(rtsp_ip, std::to_string(get_port(state::RTSP_SETUP_PORT)));
     send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::success_ok, xml);
   } else {
     logs::log(logs::warning, "[HTTPS] Received resume event from an unregistered session, ip: {}", client_ip);

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -385,12 +385,21 @@ auto create_run_session(const SimpleWeb::CaseInsensitiveMultimap &headers,
   auto surround_info = std::stoi(get_header(headers, "surroundAudioInfo").value_or("196610"));
   int channelCount = surround_info & (0xffff /* last 16 bits */);
 
-  auto base_session = create_stream_session(state, run_app, current_client, display_mode, channelCount);
+  auto base_session = create_stream_session(state,
+                                            run_app,
+                                            current_client,
+                                            display_mode,
+                                            channelCount,
+                                            get_header(headers, "rikey").value(),
+                                            get_header(headers, "rikeyid").value());
 
   base_session->ip = client_ip;
-  base_session->aes_key = get_header(headers, "rikey").value();
-  base_session->aes_iv = get_header(headers, "rikeyid").value();
   return std::move(base_session);
+}
+
+std::string get_rtsp_ip_string(const std::string &local_ip, const events::StreamSession &session) {
+  auto use_fake_ip = utils::get_env("WOLF_USE_RTSP_FAKE_IP", "TRUE") == "TRUE"s;
+  return use_fake_ip ? session.rtsp_fake_ip : local_ip;
 }
 
 void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::Response> &response,
@@ -414,8 +423,8 @@ void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
 
   rtp::start_rtp_ping(*new_session);
 
-  auto xml =
-      moonlight::launch_success(get_host_ip<SimpleWeb::HTTPS>(request, state), std::to_string(state::RTSP_SETUP_PORT));
+  auto rtsp_ip = get_rtsp_ip_string(get_host_ip<SimpleWeb::HTTPS>(request, state), *new_session);
+  auto xml = moonlight::launch_success(rtsp_ip, std::to_string(state::RTSP_SETUP_PORT));
   send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::success_ok, xml);
 }
 
@@ -444,16 +453,15 @@ void resume(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
     state->running_sessions->update([&old_session, new_session](const immer::vector<events::StreamSession> ses_v) {
       return state::remove_session(ses_v, old_session.value()).push_back(*new_session);
     });
+
+    auto rtsp_ip = get_rtsp_ip_string(get_host_ip<SimpleWeb::HTTPS>(request, state), *new_session);
+    auto xml = moonlight::launch_resume(rtsp_ip, std::to_string(state::RTSP_SETUP_PORT));
+    send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::success_ok, xml);
   } else {
     logs::log(logs::warning, "[HTTPS] Received resume event from an unregistered session, ip: {}", client_ip);
   }
 
-  XML xml;
-  xml.put("root.<xmlattr>.status_code", 200);
-  xml.put("root.sessionUrl0",
-          "rtsp://"s + get_host_ip<SimpleWeb::HTTPS>(request, state) + ':' + std::to_string(state::RTSP_SETUP_PORT));
-  xml.put("root.resume", 1);
-  send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::success_ok, xml);
+  server_error<SimpleWeb::HTTPS>(response);
 }
 
 void cancel(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::Response> &response,

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -65,8 +65,8 @@ void serverinfo(const std::shared_ptr<typename SimpleWeb::Server<T>::Response> &
 
   auto xml = moonlight::serverinfo(is_busy,
                                    app_id,
-                                   state::HTTPS_PORT,
-                                   state::HTTP_PORT,
+                                   get_port(state::HTTPS_PORT),
+                                   get_port(state::HTTP_PORT),
                                    cfg->uuid,
                                    cfg->hostname,
                                    utils::lazy_value_or(host->mac_address, [&]() { return get_mac_address(local_ip); }),
@@ -421,8 +421,6 @@ void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
   state->running_sessions->update(
       [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
 
-  rtp::start_rtp_ping(new_session->video_stream_port, new_session->audio_stream_port, new_session->event_bus);
-
   auto rtsp_ip = get_rtsp_ip_string(get_host_ip<SimpleWeb::HTTPS>(request, state), *new_session);
   auto xml = moonlight::launch_success(rtsp_ip, std::to_string(state::RTSP_SETUP_PORT));
   send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::success_ok, xml);
@@ -447,8 +445,6 @@ void resume(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
     new_session->joypads = std::move(old_session->joypads);
     new_session->pen_tablet = std::move(old_session->pen_tablet);
     new_session->touch_screen = std::move(old_session->touch_screen);
-
-    rtp::start_rtp_ping(new_session->video_stream_port, new_session->audio_stream_port, new_session->event_bus);
 
     state->running_sessions->update([&old_session, new_session](const immer::vector<events::StreamSession> ses_v) {
       return state::remove_session(ses_v, old_session.value()).push_back(*new_session);

--- a/src/moonlight-server/rest/servers.cpp
+++ b/src/moonlight-server/rest/servers.cpp
@@ -28,7 +28,7 @@ void startServer(HttpServer *server, const immer::box<state::AppState> state, in
   server->default_resource["POST"] = endpoints::not_found<SimpleWeb::HTTP>;
 
   server->resource["^/serverinfo$"]["GET"] = [&state](auto resp, auto req) {
-    endpoints::serverinfo<SimpleWeb::HTTP>(resp, req, state);
+    endpoints::serverinfo<SimpleWeb::HTTP>(resp, req, {}, state);
   };
 
   server->resource["^/pair$"]["GET"] = [&state](auto resp, auto req) { endpoints::pair(resp, req, state); };
@@ -121,8 +121,9 @@ void startServer(HttpsServer *server, const immer::box<state::AppState> state, i
   server->default_resource["POST"] = endpoints::not_found<SimpleWeb::HTTPS>;
 
   server->resource["^/serverinfo$"]["GET"] = [&state](auto resp, auto req) {
-    if (get_client_if_paired(state, req)) {
-      endpoints::serverinfo<SimpleWeb::HTTPS>(resp, req, state);
+    if (auto client = get_client_if_paired(state, req)) {
+      auto client_session = state::get_session_by_client(state->running_sessions->load(), client.value());
+      endpoints::serverinfo<SimpleWeb::HTTPS>(resp, req, client_session, state);
     } else {
       reply_unauthorized(req, resp);
     }

--- a/src/moonlight-server/rtp/udp-ping.cpp
+++ b/src/moonlight-server/rtp/udp-ping.cpp
@@ -5,9 +5,7 @@
 
 namespace rtp {
 
-UDP_Server::UDP_Server(
-    unsigned short port,
-    const std::function<void(unsigned short /* client_port */, const std::string & /* client_ip */)> &callback)
+UDP_Server::UDP_Server(unsigned short port, const on_rtp_ping_fn &callback)
     : io_context(), socket_(io_context, udp::endpoint(udp::v4(), port)), callback(callback) {
   // We have to enable this because we'll bind additional sockets as udpsink in the audio/video pipelines
   socket_.set_option(udp::socket::reuse_address(true));
@@ -26,33 +24,41 @@ void UDP_Server::run(std::chrono::milliseconds timeout) {
 void UDP_Server::start_receive() {
   socket_.async_receive_from(boost::asio::buffer(recv_buffer_),
                              remote_endpoint_,
+                             0,
                              boost::bind(&UDP_Server::handle_receive,
                                          this,
                                          boost::asio::placeholders::error,
                                          boost::asio::placeholders::bytes_transferred));
 }
 
-void UDP_Server::handle_receive(const boost::system::error_code &error, std::size_t /*bytes_transferred*/) {
+void UDP_Server::handle_receive(const boost::system::error_code &error, std::size_t bytes_transferred) {
   if (!error) {
     auto client_ip = remote_endpoint_.address().to_string();
     auto client_port = remote_endpoint_.port();
 
-    logs::log(logs::trace, "[RTP] Received ping from {}:{}", client_ip, client_port);
-    callback(client_port, client_ip);
+    if (bytes_transferred == 4) {
+      logs::log(logs::trace, "[RTP] Received ping from {}:{}", client_ip, client_port);
+      callback({.client_ip = client_ip, .client_port = client_port, .payload = {}});
+    } else if (bytes_transferred >= sizeof(moonlight::SS_PING)) {
+      logs::log(logs::trace, "[RTP] Received ping from {}:{} with payload", client_ip, client_port);
+
+      auto ping = (moonlight::SS_PING *)recv_buffer_.data();
+      callback({.client_ip = client_ip, .client_port = client_port, .payload = ping->payload});
+    }
+
     // We'll keep receiving pings and sending callback events until the timeout elapsed.
     // This is because we don't know if downstream they are ready to start the session.
     // Downstream will make sure to only send one ping per session
-    std::this_thread::sleep_for(std::chrono::milliseconds(500)); // let's avoid spamming though
+    std::this_thread::sleep_for(std::chrono::milliseconds(250)); // let's avoid spamming though
     start_receive();
+  } else {
+    logs::log(logs::debug, "[RTP] Error receiving ping: {}", error.message());
   }
 }
 
-void wait_for_ping(
-    unsigned short port,
-    const std::function<void(unsigned short /* client_port */, const std::string & /* client_ip */)> &callback) {
+void wait_for_ping(unsigned short port, const on_rtp_ping_fn &callback) {
   auto thread = std::thread(
-      [port](
-          const std::function<void(unsigned short /* client_port */, const std::string & /* client_ip */)> &callback) {
+      [port](const on_rtp_ping_fn &callback) {
         try {
           auto server = UDP_Server(port, callback);
 
@@ -66,6 +72,26 @@ void wait_for_ping(
       },
       callback);
   thread.detach();
+}
+
+void start_rtp_ping(const wolf::core::events::StreamSession &session) {
+  // Video RTP Ping
+  wait_for_ping(session.video_stream_port, [ev_bus = session.event_bus](const RTPPingEvent &ping) {
+    logs::log(logs::trace, "[PING] video from {}:{}", ping.client_ip, ping.client_port);
+    auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = ping.client_ip,
+                                                    .client_port = ping.client_port,
+                                                    .payload = ping.payload};
+    ev_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
+  });
+
+  // Audio RTP Ping
+  wait_for_ping(session.audio_stream_port, [ev_bus = session.event_bus](const RTPPingEvent &ping) {
+    logs::log(logs::trace, "[PING] audio from {}:{}", ping.client_ip, ping.client_port);
+    auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = ping.client_ip,
+                                                    .client_port = ping.client_port,
+                                                    .payload = ping.payload};
+    ev_bus->fire_event(immer::box<wolf::core::events::RTPAudioPingEvent>(ev));
+  });
 }
 
 } // namespace rtp

--- a/src/moonlight-server/rtp/udp-ping.cpp
+++ b/src/moonlight-server/rtp/udp-ping.cpp
@@ -22,7 +22,6 @@ void UDP_Server::run(std::chrono::milliseconds timeout) {
 }
 
 void UDP_Server::start_receive() {
-  remote_endpoint_ = udp::endpoint();
   socket_.async_receive_from(boost::asio::buffer(recv_buffer_),
                              remote_endpoint_,
                              0,
@@ -37,6 +36,8 @@ void UDP_Server::handle_receive(const boost::system::error_code &error, std::siz
     auto client_ip = remote_endpoint_.address().to_string();
     auto client_port = remote_endpoint_.port();
 
+    logs::log(logs::trace, "[RTP] Received ping from {}:{} ({} bytes)", client_ip, client_port, bytes_transferred);
+
     if (bytes_transferred == 4) {
       callback({.client_ip = client_ip, .client_port = client_port, .payload = {}});
     } else if (bytes_transferred >= sizeof(moonlight::SS_PING)) {
@@ -46,7 +47,7 @@ void UDP_Server::handle_receive(const boost::system::error_code &error, std::siz
     // Continue to receive more data
     start_receive();
   } else {
-    logs::log(logs::debug, "[RTP] Error receiving ping: {}", error.message());
+    logs::log(logs::warning, "[RTP] Error receiving ping: {}", error.message());
   }
 }
 
@@ -72,8 +73,8 @@ void start_rtp_ping(unsigned short video_port,
                     unsigned short audio_port,
                     std::shared_ptr<wolf::core::events::EventBusType> event_bus) {
   // Video RTP Ping
-  wait_for_ping(video_port, [event_bus](const RTPPingEvent &ping) {
-    logs::log(logs::trace, "[PING] video from {}:{}", ping.client_ip, ping.client_port);
+  wait_for_ping(video_port, [=](const RTPPingEvent &ping) {
+    logs::log(logs::trace, "[RTP] video {} from {}:{}", video_port, ping.client_ip, ping.client_port);
     auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = ping.client_ip,
                                                     .client_port = ping.client_port,
                                                     .payload = ping.payload};
@@ -81,8 +82,8 @@ void start_rtp_ping(unsigned short video_port,
   });
 
   // Audio RTP Ping
-  wait_for_ping(audio_port, [event_bus](const RTPPingEvent &ping) {
-    logs::log(logs::trace, "[PING] audio from {}:{}", ping.client_ip, ping.client_port);
+  wait_for_ping(audio_port, [=](const RTPPingEvent &ping) {
+    logs::log(logs::trace, "[RTP] audio {} from {}:{}", audio_port, ping.client_ip, ping.client_port);
     auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = ping.client_ip,
                                                     .client_port = ping.client_port,
                                                     .payload = ping.payload};

--- a/src/moonlight-server/rtp/udp-ping.cpp
+++ b/src/moonlight-server/rtp/udp-ping.cpp
@@ -22,6 +22,7 @@ void UDP_Server::run(std::chrono::milliseconds timeout) {
 }
 
 void UDP_Server::start_receive() {
+  remote_endpoint_ = udp::endpoint();
   socket_.async_receive_from(boost::asio::buffer(recv_buffer_),
                              remote_endpoint_,
                              0,
@@ -37,19 +38,12 @@ void UDP_Server::handle_receive(const boost::system::error_code &error, std::siz
     auto client_port = remote_endpoint_.port();
 
     if (bytes_transferred == 4) {
-      logs::log(logs::trace, "[RTP] Received ping from {}:{}", client_ip, client_port);
       callback({.client_ip = client_ip, .client_port = client_port, .payload = {}});
     } else if (bytes_transferred >= sizeof(moonlight::SS_PING)) {
-      logs::log(logs::trace, "[RTP] Received ping from {}:{} with payload", client_ip, client_port);
-
       auto ping = (moonlight::SS_PING *)recv_buffer_.data();
       callback({.client_ip = client_ip, .client_port = client_port, .payload = ping->payload});
     }
-
-    // We'll keep receiving pings and sending callback events until the timeout elapsed.
-    // This is because we don't know if downstream they are ready to start the session.
-    // Downstream will make sure to only send one ping per session
-    std::this_thread::sleep_for(std::chrono::milliseconds(250)); // let's avoid spamming though
+    // Continue to receive more data
     start_receive();
   } else {
     logs::log(logs::debug, "[RTP] Error receiving ping: {}", error.message());
@@ -74,23 +68,25 @@ void wait_for_ping(unsigned short port, const on_rtp_ping_fn &callback) {
   thread.detach();
 }
 
-void start_rtp_ping(const wolf::core::events::StreamSession &session) {
+void start_rtp_ping(unsigned short video_port,
+                    unsigned short audio_port,
+                    std::shared_ptr<wolf::core::events::EventBusType> event_bus) {
   // Video RTP Ping
-  wait_for_ping(session.video_stream_port, [ev_bus = session.event_bus](const RTPPingEvent &ping) {
+  wait_for_ping(video_port, [event_bus](const RTPPingEvent &ping) {
     logs::log(logs::trace, "[PING] video from {}:{}", ping.client_ip, ping.client_port);
     auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = ping.client_ip,
                                                     .client_port = ping.client_port,
                                                     .payload = ping.payload};
-    ev_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
+    event_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
   });
 
   // Audio RTP Ping
-  wait_for_ping(session.audio_stream_port, [ev_bus = session.event_bus](const RTPPingEvent &ping) {
+  wait_for_ping(audio_port, [event_bus](const RTPPingEvent &ping) {
     logs::log(logs::trace, "[PING] audio from {}:{}", ping.client_ip, ping.client_port);
     auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = ping.client_ip,
                                                     .client_port = ping.client_port,
                                                     .payload = ping.payload};
-    ev_bus->fire_event(immer::box<wolf::core::events::RTPAudioPingEvent>(ev));
+    event_bus->fire_event(immer::box<wolf::core::events::RTPAudioPingEvent>(ev));
   });
 }
 

--- a/src/moonlight-server/rtp/udp-ping.cpp
+++ b/src/moonlight-server/rtp/udp-ping.cpp
@@ -57,7 +57,7 @@ void wait_for_ping(
           auto server = UDP_Server(port, callback);
 
           logs::log(logs::info, "RTP server started on port: {}", port);
-          server.run(std::chrono::seconds(4));
+          server.run(std::chrono::seconds(30));
           logs::log(logs::debug, "RTP server on port: {} stopped", port);
 
         } catch (std::exception &e) {

--- a/src/moonlight-server/rtp/udp-ping.cpp
+++ b/src/moonlight-server/rtp/udp-ping.cpp
@@ -29,46 +29,47 @@ void UDP_Server::handle_receive(const boost::system::error_code &error, std::siz
       auto ping = (moonlight::SS_PING *)recv_buffer_.data();
       callback({.client_ip = client_ip, .client_port = client_port, .payload = ping->payload});
     }
-    // Continue to receive more data
-    start_receive();
   } else {
     logs::log(logs::warning, "[RTP] Error receiving ping: {}", error.message());
   }
+
+  // Continue to receive more data
+  start_receive();
 }
 
 void start_rtp_ping(unsigned short video_port,
                     unsigned short audio_port,
                     std::shared_ptr<wolf::core::events::EventBusType> event_bus) {
-  try {
-    std::shared_ptr<boost::asio::io_context> io_context = std::make_shared<boost::asio::io_context>();
-    std::shared_ptr<udp::socket> video_socket =
-        std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), video_port));
-    video_socket->set_option(udp::socket::reuse_address(true));
+  auto io_context = std::make_shared<boost::asio::io_context>();
 
-    std::shared_ptr<udp::socket> audio_socket =
-        std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), audio_port));
-    audio_socket->set_option(udp::socket::reuse_address(true));
+  try {
+    logs::log(logs::info, "[RTP] Starting RTP ping server on ports {} and {}", video_port, audio_port);
+    auto video_socket = std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), video_port));
+    auto audio_socket = std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), audio_port));
 
     std::thread([io_context, video_socket, audio_socket, event_bus]() {
-      UDP_Server video_server(*video_socket, [event_bus](const RTPPingEvent &ping) {
+      UDP_Server video_server(*video_socket, [event_bus, video_socket](const RTPPingEvent &ping) {
         logs::log(logs::trace, "[RTP] video from {}:{}", ping.client_ip, ping.client_port);
         auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = ping.client_ip,
                                                         .client_port = ping.client_port,
+                                                        .video_socket = video_socket,
                                                         .payload = ping.payload};
         event_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
       });
 
-      UDP_Server audio_server(*audio_socket, [event_bus](const RTPPingEvent &ping) {
-        logs::log(logs::trace, "[RTP] audio  from {}:{}", ping.client_ip, ping.client_port);
+      UDP_Server audio_server(*audio_socket, [event_bus, audio_socket](const RTPPingEvent &ping) {
+        logs::log(logs::trace, "[RTP] audio from {}:{}", ping.client_ip, ping.client_port);
         auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = ping.client_ip,
                                                         .client_port = ping.client_port,
+                                                        .audio_socket = audio_socket,
                                                         .payload = ping.payload};
         event_bus->fire_event(immer::box<wolf::core::events::RTPAudioPingEvent>(ev));
       });
 
       io_context->run();
-      logs::log(logs::info, "[RTP] io_context stopped");
+      logs::log(logs::info, "[RTP] server stopped");
     }).detach();
+
   } catch (std::exception &e) {
     logs::log(logs::warning, "[RTP] Unable to start RTP server: {}", e.what());
   }

--- a/src/moonlight-server/rtp/udp-ping.cpp
+++ b/src/moonlight-server/rtp/udp-ping.cpp
@@ -7,13 +7,13 @@
 namespace rtp {
 
 void UDP_Server::start_receive() {
-  socket_.async_receive_from(boost::asio::buffer(recv_buffer_),
-                             remote_endpoint_,
-                             0,
-                             boost::bind(&UDP_Server::handle_receive,
-                                         this,
-                                         boost::asio::placeholders::error,
-                                         boost::asio::placeholders::bytes_transferred));
+  socket_->async_receive_from(boost::asio::buffer(recv_buffer_),
+                              remote_endpoint_,
+                              0,
+                              boost::bind(&UDP_Server::handle_receive,
+                                          this,
+                                          boost::asio::placeholders::error,
+                                          boost::asio::placeholders::bytes_transferred));
 }
 
 void UDP_Server::handle_receive(const boost::system::error_code &error, std::size_t bytes_transferred) {
@@ -48,7 +48,7 @@ void start_rtp_ping(unsigned short video_port,
     auto audio_socket = std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), audio_port));
 
     std::thread([io_context, video_socket, audio_socket, event_bus]() {
-      UDP_Server video_server(*video_socket, [event_bus, video_socket](const RTPPingEvent &ping) {
+      UDP_Server video_server(video_socket, [event_bus, video_socket](const RTPPingEvent &ping) {
         logs::log(logs::trace, "[RTP] video from {}:{}", ping.client_ip, ping.client_port);
         auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = ping.client_ip,
                                                         .client_port = ping.client_port,
@@ -57,7 +57,7 @@ void start_rtp_ping(unsigned short video_port,
         event_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
       });
 
-      UDP_Server audio_server(*audio_socket, [event_bus, audio_socket](const RTPPingEvent &ping) {
+      UDP_Server audio_server(audio_socket, [event_bus, audio_socket](const RTPPingEvent &ping) {
         logs::log(logs::trace, "[RTP] audio from {}:{}", ping.client_ip, ping.client_port);
         auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = ping.client_ip,
                                                         .client_port = ping.client_port,

--- a/src/moonlight-server/rtp/udp-ping.cpp
+++ b/src/moonlight-server/rtp/udp-ping.cpp
@@ -1,25 +1,10 @@
 #include <boost/bind/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <helpers/logger.hpp>
 #include <rtp/udp-ping.hpp>
 #include <thread>
 
 namespace rtp {
-
-UDP_Server::UDP_Server(unsigned short port, const on_rtp_ping_fn &callback)
-    : io_context(), socket_(io_context, udp::endpoint(udp::v4(), port)), callback(callback) {
-  // We have to enable this because we'll bind additional sockets as udpsink in the audio/video pipelines
-  socket_.set_option(udp::socket::reuse_address(true));
-  start_receive();
-}
-
-UDP_Server::~UDP_Server() {
-  socket_.close();
-  io_context.stop();
-}
-
-void UDP_Server::run(std::chrono::milliseconds timeout) {
-  io_context.run_for(timeout);
-}
 
 void UDP_Server::start_receive() {
   socket_.async_receive_from(boost::asio::buffer(recv_buffer_),
@@ -51,44 +36,42 @@ void UDP_Server::handle_receive(const boost::system::error_code &error, std::siz
   }
 }
 
-void wait_for_ping(unsigned short port, const on_rtp_ping_fn &callback) {
-  auto thread = std::thread(
-      [port](const on_rtp_ping_fn &callback) {
-        try {
-          auto server = UDP_Server(port, callback);
-
-          logs::log(logs::info, "RTP server started on port: {}", port);
-          server.run(std::chrono::seconds(30));
-          logs::log(logs::debug, "RTP server on port: {} stopped", port);
-
-        } catch (std::exception &e) {
-          logs::log(logs::warning, "[RTP] Unable to start RTP server on {}: {}", port, e.what());
-        }
-      },
-      callback);
-  thread.detach();
-}
-
 void start_rtp_ping(unsigned short video_port,
                     unsigned short audio_port,
                     std::shared_ptr<wolf::core::events::EventBusType> event_bus) {
-  // Video RTP Ping
-  wait_for_ping(video_port, [=](const RTPPingEvent &ping) {
-    logs::log(logs::trace, "[RTP] video {} from {}:{}", video_port, ping.client_ip, ping.client_port);
-    auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = ping.client_ip,
-                                                    .client_port = ping.client_port,
-                                                    .payload = ping.payload};
-    event_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
-  });
+  try {
+    std::shared_ptr<boost::asio::io_context> io_context = std::make_shared<boost::asio::io_context>();
+    std::shared_ptr<udp::socket> video_socket =
+        std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), video_port));
+    video_socket->set_option(udp::socket::reuse_address(true));
 
-  // Audio RTP Ping
-  wait_for_ping(audio_port, [=](const RTPPingEvent &ping) {
-    logs::log(logs::trace, "[RTP] audio {} from {}:{}", audio_port, ping.client_ip, ping.client_port);
-    auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = ping.client_ip,
-                                                    .client_port = ping.client_port,
-                                                    .payload = ping.payload};
-    event_bus->fire_event(immer::box<wolf::core::events::RTPAudioPingEvent>(ev));
-  });
+    std::shared_ptr<udp::socket> audio_socket =
+        std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), audio_port));
+    audio_socket->set_option(udp::socket::reuse_address(true));
+
+    std::thread([io_context, video_socket, audio_socket, event_bus]() {
+      UDP_Server video_server(*video_socket, [event_bus](const RTPPingEvent &ping) {
+        logs::log(logs::trace, "[RTP] video from {}:{}", ping.client_ip, ping.client_port);
+        auto ev = wolf::core::events::RTPVideoPingEvent{.client_ip = ping.client_ip,
+                                                        .client_port = ping.client_port,
+                                                        .payload = ping.payload};
+        event_bus->fire_event(immer::box<wolf::core::events::RTPVideoPingEvent>(ev));
+      });
+
+      UDP_Server audio_server(*audio_socket, [event_bus](const RTPPingEvent &ping) {
+        logs::log(logs::trace, "[RTP] audio  from {}:{}", ping.client_ip, ping.client_port);
+        auto ev = wolf::core::events::RTPAudioPingEvent{.client_ip = ping.client_ip,
+                                                        .client_port = ping.client_port,
+                                                        .payload = ping.payload};
+        event_bus->fire_event(immer::box<wolf::core::events::RTPAudioPingEvent>(ev));
+      });
+
+      io_context->run();
+      logs::log(logs::info, "[RTP] io_context stopped");
+    }).detach();
+  } catch (std::exception &e) {
+    logs::log(logs::warning, "[RTP] Unable to start RTP server: {}", e.what());
+  }
 }
 
 } // namespace rtp

--- a/src/moonlight-server/rtp/udp-ping.hpp
+++ b/src/moonlight-server/rtp/udp-ping.hpp
@@ -48,6 +48,8 @@ private:
 
 void wait_for_ping(unsigned short port, const on_rtp_ping_fn &callback);
 
-void start_rtp_ping(unsigned short video_port, unsigned short audio_port, std::shared_ptr<wolf::core::events::EventBusType> event_bus);
+void start_rtp_ping(unsigned short video_port,
+                    unsigned short audio_port,
+                    std::shared_ptr<wolf::core::events::EventBusType> event_bus);
 
 } // namespace rtp

--- a/src/moonlight-server/rtp/udp-ping.hpp
+++ b/src/moonlight-server/rtp/udp-ping.hpp
@@ -27,7 +27,8 @@ using on_rtp_ping_fn = std::function<void(const RTPPingEvent &)>;
  */
 class UDP_Server : public boost::enable_shared_from_this<UDP_Server> {
 public:
-  UDP_Server(std::shared_ptr<udp::socket> socket, const on_rtp_ping_fn &callback) : socket_(std::move(socket)), callback(callback) {
+  UDP_Server(std::shared_ptr<udp::socket> socket, const on_rtp_ping_fn &callback)
+      : socket_(std::move(socket)), callback(callback) {
     start_receive();
   };
 

--- a/src/moonlight-server/rtp/udp-ping.hpp
+++ b/src/moonlight-server/rtp/udp-ping.hpp
@@ -18,7 +18,7 @@ struct RTPPingEvent {
    * will send back what was originally exchanged over RTSP
    * (see: X-SS-Ping-Payload and X-SS-Connect-Data)
    */
-  std::optional<std::array<uint8_t, 16>> payload;
+  std::optional<std::array<char, 16>> payload;
 };
 
 using on_rtp_ping_fn = std::function<void(const RTPPingEvent &)>;
@@ -48,6 +48,6 @@ private:
 
 void wait_for_ping(unsigned short port, const on_rtp_ping_fn &callback);
 
-void start_rtp_ping(const wolf::core::events::StreamSession &session);
+void start_rtp_ping(unsigned short video_port, unsigned short audio_port, std::shared_ptr<wolf::core::events::EventBusType> event_bus);
 
 } // namespace rtp

--- a/src/moonlight-server/rtp/udp-ping.hpp
+++ b/src/moonlight-server/rtp/udp-ping.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <events/events.hpp>
+
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
 #include <helpers/logger.hpp>
@@ -8,15 +10,26 @@ namespace rtp {
 
 using boost::asio::ip::udp;
 
+struct RTPPingEvent {
+  std::string client_ip;
+  unsigned short client_port;
+  /**
+   * Moonlight protocol extension to support IP-less clients
+   * will send back what was originally exchanged over RTSP
+   * (see: X-SS-Ping-Payload and X-SS-Connect-Data)
+   */
+  std::optional<std::array<char, 16>> payload;
+};
+
+using on_rtp_ping_fn = std::function<void(const RTPPingEvent &)>;
+
 /**
  * Generic UDP server, adapted from:
  * https://www.boost.org/doc/libs/1_81_0/doc/html/boost_asio/tutorial/tutdaytime6/src.html
  */
 class UDP_Server : public boost::enable_shared_from_this<UDP_Server> {
 public:
-  UDP_Server(
-      unsigned short port,
-      const std::function<void(unsigned short /* client_port */, const std::string & /* client_ip */)> &callback);
+  UDP_Server(unsigned short port, const on_rtp_ping_fn &callback);
 
   ~UDP_Server();
 
@@ -29,12 +42,12 @@ private:
   boost::asio::io_context io_context;
   udp::socket socket_;
   udp::endpoint remote_endpoint_;
-  boost::array<char, 1> recv_buffer_{};
-  std::function<void(unsigned short /* client_port */, const std::string & /* client_ip */)> callback;
+  boost::array<char, 2048> recv_buffer_{};
+  on_rtp_ping_fn callback;
 };
 
-void wait_for_ping(
-    unsigned short port,
-    const std::function<void(unsigned short /* client_port */, const std::string & /* client_ip */)> &callback);
+void wait_for_ping(unsigned short port, const on_rtp_ping_fn &callback);
+
+void start_rtp_ping(const wolf::core::events::StreamSession &session);
 
 } // namespace rtp

--- a/src/moonlight-server/rtp/udp-ping.hpp
+++ b/src/moonlight-server/rtp/udp-ping.hpp
@@ -27,7 +27,7 @@ using on_rtp_ping_fn = std::function<void(const RTPPingEvent &)>;
  */
 class UDP_Server : public boost::enable_shared_from_this<UDP_Server> {
 public:
-  UDP_Server(udp::socket &socket, const on_rtp_ping_fn &callback) : socket_(std::move(socket)), callback(callback) {
+  UDP_Server(std::shared_ptr<udp::socket> socket, const on_rtp_ping_fn &callback) : socket_(std::move(socket)), callback(callback) {
     start_receive();
   };
 
@@ -35,7 +35,7 @@ private:
   void start_receive();
   void handle_receive(const boost::system::error_code &error, std::size_t /*bytes_transferred*/);
 
-  udp::socket socket_;
+  std::shared_ptr<udp::socket> socket_;
   udp::endpoint remote_endpoint_;
   boost::array<char, 2048> recv_buffer_{};
   on_rtp_ping_fn callback;

--- a/src/moonlight-server/rtp/udp-ping.hpp
+++ b/src/moonlight-server/rtp/udp-ping.hpp
@@ -18,7 +18,7 @@ struct RTPPingEvent {
    * will send back what was originally exchanged over RTSP
    * (see: X-SS-Ping-Payload and X-SS-Connect-Data)
    */
-  std::optional<std::array<char, 16>> payload;
+  std::optional<std::array<uint8_t, 16>> payload;
 };
 
 using on_rtp_ping_fn = std::function<void(const RTPPingEvent &)>;

--- a/src/moonlight-server/rtp/udp-ping.hpp
+++ b/src/moonlight-server/rtp/udp-ping.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
-#include <events/events.hpp>
-
 #include <boost/array.hpp>
 #include <boost/asio.hpp>
-#include <helpers/logger.hpp>
+#include <events/events.hpp>
 
 namespace rtp {
 
@@ -29,24 +27,19 @@ using on_rtp_ping_fn = std::function<void(const RTPPingEvent &)>;
  */
 class UDP_Server : public boost::enable_shared_from_this<UDP_Server> {
 public:
-  UDP_Server(unsigned short port, const on_rtp_ping_fn &callback);
-
-  ~UDP_Server();
-
-  void run(std::chrono::milliseconds timeout);
+  UDP_Server(udp::socket &socket, const on_rtp_ping_fn &callback) : socket_(std::move(socket)), callback(callback) {
+    start_receive();
+  };
 
 private:
   void start_receive();
   void handle_receive(const boost::system::error_code &error, std::size_t /*bytes_transferred*/);
 
-  boost::asio::io_context io_context;
   udp::socket socket_;
   udp::endpoint remote_endpoint_;
   boost::array<char, 2048> recv_buffer_{};
   on_rtp_ping_fn callback;
 };
-
-void wait_for_ping(unsigned short port, const on_rtp_ping_fn &callback);
 
 void start_rtp_ping(unsigned short video_port,
                     unsigned short audio_port,

--- a/src/moonlight-server/rtsp/commands.hpp
+++ b/src/moonlight-server/rtsp/commands.hpp
@@ -109,27 +109,32 @@ describe(const RTSP_PACKET &req, const events::StreamSession &session) {
 
 RTSP_PACKET setup(const RTSP_PACKET &req, const events::StreamSession &session) {
 
-  int service_port;
   auto type = req.request.stream.type;
   logs::log(logs::trace, "[RTSP] setup type: {}", type);
 
+  std::map<std::string, std::string> options = {{"Session", "DEADBEEFCAFE;timeout = 90"}};
+
   switch (utils::hash(type)) {
-  case utils::hash("audio"):
-    service_port = session.audio_stream_port;
+  case utils::hash("audio"): {
+    options["Transport"] = "server_port=" + std::to_string(session.audio_stream_port);
+    options["X-SS-Ping-Payload"] = {session.rtp_secret_payload.begin(), session.rtp_secret_payload.end()};
     break;
-  case utils::hash("video"):
-    service_port = session.video_stream_port;
+  }
+  case utils::hash("video"): {
+    options["Transport"] = "server_port=" + std::to_string(session.video_stream_port);
+    options["X-SS-Ping-Payload"] = {session.rtp_secret_payload.begin(), session.rtp_secret_payload.end()};
     break;
-  case utils::hash("control"):
-    service_port = state::CONTROL_PORT;
+  }
+  case utils::hash("control"): {
+    options["Transport"] = "server_port=" + std::to_string(state::CONTROL_PORT);
+    options["X-SS-Connect-Data"] = std::to_string(session.enet_secret_payload);
     break;
+  }
   default:
     return error_msg(404, "NOT FOUND", req.seq_number);
   }
 
-  auto session_opt = "DEADBEEFCAFE;timeout = 90"s;
-  return ok_msg(req.seq_number,
-                {{"Session", session_opt}, {"Transport", "server_port=" + std::to_string(service_port)}});
+  return ok_msg(req.seq_number, options);
 }
 
 /**
@@ -229,7 +234,9 @@ announce(const RTSP_PACKET &req, const events::StreamSession &session) {
       .color_range = (csc & 0x1) ? events::ColorRange::JPEG : events::ColorRange::MPEG,
       .color_space = events::ColorSpace(csc >> 1),
 
-      .client_ip = session.ip};
+      .client_ip = session.ip,
+      .rtp_secret_payload = session.rtp_secret_payload,
+  };
   session.event_bus->fire_event(immer::box<events::VideoSession>(video));
 
   // Audio session
@@ -246,6 +253,7 @@ announce(const RTSP_PACKET &req, const events::StreamSession &session) {
 
       .port = session.audio_stream_port,
       .client_ip = session.ip,
+      .rtp_secret_payload = session.rtp_secret_payload,
 
       .packet_duration = args["x-nv-aqos.packetDuration"].value_or(5),
       .audio_mode = audio_mode};

--- a/src/moonlight-server/rtsp/commands.hpp
+++ b/src/moonlight-server/rtsp/commands.hpp
@@ -126,7 +126,7 @@ RTSP_PACKET setup(const RTSP_PACKET &req, const events::StreamSession &session) 
     break;
   }
   case utils::hash("control"): {
-    options["Transport"] = "server_port=" + std::to_string(state::CONTROL_PORT);
+    options["Transport"] = "server_port=" + std::to_string(session.control_stream_port);
     options["X-SS-Connect-Data"] = std::to_string(session.enet_secret_payload);
     break;
   }

--- a/src/moonlight-server/rtsp/net.hpp
+++ b/src/moonlight-server/rtsp/net.hpp
@@ -63,10 +63,10 @@ public:
     }
     for (const events::StreamSession &session : sessions) {
       if (session.rtsp_fake_ip == packet.request.uri.ip || host_option == session.rtsp_fake_ip) {
-        logs::log(logs::trace, "[RTSP] found session by matching payload: {}", session.rtsp_fake_ip);
+        logs::log(logs::debug, "[RTSP] found session by matching payload: {}", session.rtsp_fake_ip);
         return session;
       } else if ((host_option == "0.0.0.0" || host_option.empty()) && session.ip == user_ip) {
-        logs::log(logs::trace, "[RTSP] found session by matching IP: {}", session.ip);
+        logs::log(logs::debug, "[RTSP] found session by matching IP: {}", session.ip);
         return session;
       }
     }

--- a/src/moonlight-server/rtsp/net.hpp
+++ b/src/moonlight-server/rtsp/net.hpp
@@ -54,6 +54,25 @@ public:
     socket_.close();
   }
 
+  static std::optional<events::StreamSession> get_session(const immer::vector<events::StreamSession> &sessions,
+                                                          const RTSP_PACKET &packet,
+                                                          std::string_view user_ip) {
+    std::string host_option = "";
+    if (auto host = packet.options.find("Host"); host != packet.options.end()) {
+      host_option = host->second;
+    }
+    for (const events::StreamSession &session : sessions) {
+      if (session.rtsp_fake_ip == packet.request.uri.ip || host_option == session.rtsp_fake_ip) {
+        logs::log(logs::trace, "[RTSP] found session by matching payload: {}", session.rtsp_fake_ip);
+        return session;
+      } else if ((host_option == "0.0.0.0" || host_option.empty()) && session.ip == user_ip) {
+        logs::log(logs::trace, "[RTSP] found session by matching IP: {}", session.ip);
+        return session;
+      }
+    }
+    return std::nullopt;
+  }
+
   /**
    * Will start the following (async) chain:
    *  1- wait for a message
@@ -66,7 +85,7 @@ public:
     receive_message([self = shared_from_this()](auto parsed_msg) {
       if (parsed_msg) {
         auto user_ip = self->socket().remote_endpoint().address().to_string();
-        auto session = state::get_session_by_ip(self->stream_sessions->load(), user_ip);
+        auto session = get_session(self->stream_sessions->load(), parsed_msg.value(), user_ip);
         if (session) {
           auto response = commands::message_handler(parsed_msg.value(), session.value());
           self->send_message(response, [self](auto bytes) { self->close(); });

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -24,9 +24,7 @@ static std::optional<std::string> get_device_major(std::string_view type) {
     if (line.find(type) != std::string::npos) {
       // Example line: "244 hidraw" or " 13 input" (note the leading space)
       line.erase(line.begin(),
-                 std::find_if(line.begin(), line.end(), [](unsigned char ch) {
-                   return ch >= '0' && ch <= '9';
- }));
+                 std::find_if(line.begin(), line.end(), [](unsigned char ch) { return ch >= '0' && ch <= '9'; }));
       return line.substr(0, line.find(' '));
     }
   }

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -139,7 +139,7 @@ Config load_or_default(const std::string &source,
     default_gst_video_settings.default_sink = "rtpmoonlightpay_video name=moonlight_pay "
                                               "payload_size={payload_size} fec_percentage={fec_percentage} "
                                               "min_required_fec_packets={min_required_fec_packets} ! "
-                                              "appsink name=wolf_udp_sink";
+                                              "appsink sync=false name=wolf_udp_sink";
   }
 
   auto default_gst_audio_settings = cfg.gstreamer.audio;
@@ -153,7 +153,7 @@ Config load_or_default(const std::string &source,
     default_gst_audio_settings.default_sink =
         "rtpmoonlightpay_audio name=moonlight_pay packet_duration={packet_duration} encrypt={encrypt}"
         "aes_key=\"{aes_key}\" aes_iv=\"{aes_iv}\" ! "
-        "appsink name=wolf_udp_sink";
+        "appsink sync=false name=wolf_udp_sink";
   }
 
   auto default_gst_encoder_settings = default_gst_video_settings.defaults;

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -134,12 +134,26 @@ Config load_or_default(const std::string &source,
     default_gst_video_settings.default_source = "interpipesrc listen-to={session_id}_video is-live=true "
                                                 "stream-sync=restart-ts max-buffers=1 block=false";
   }
+  if (default_gst_video_settings.default_sink.find("udpsink") != std::string::npos) {
+    logs::log(logs::debug, "Found udpsink in default_sink, migrating to appsink");
+    default_gst_video_settings.default_sink = "rtpmoonlightpay_video name=moonlight_pay "
+                                              "payload_size={payload_size} fec_percentage={fec_percentage} "
+                                              "min_required_fec_packets={min_required_fec_packets} ! "
+                                              "appsink name=wolf_udp_sink";
+  }
 
   auto default_gst_audio_settings = cfg.gstreamer.audio;
   if (default_gst_audio_settings.default_source.find("appsrc") != std::string::npos) {
     logs::log(logs::debug, "Found pulsesrc in default_source, migrating to interpipesrc");
     default_gst_audio_settings.default_source = "interpipesrc listen-to={session_id}_audio is-live=true "
                                                 "stream-sync=restart-ts max-bytes=0 max-buffers=3 block=false";
+  }
+  if (default_gst_audio_settings.default_sink.find("udpsink") != std::string::npos) {
+    logs::log(logs::debug, "Found udpsink in default_sink, migrating to appsink");
+    default_gst_audio_settings.default_sink =
+        "rtpmoonlightpay_audio name=moonlight_pay packet_duration={packet_duration} encrypt={encrypt}"
+        "aes_key=\"{aes_key}\" aes_iv=\"{aes_iv}\" ! "
+        "appsink name=wolf_udp_sink";
   }
 
   auto default_gst_encoder_settings = default_gst_video_settings.defaults;

--- a/src/moonlight-server/state/data-structures.hpp
+++ b/src/moonlight-server/state/data-structures.hpp
@@ -41,7 +41,7 @@ enum STANDARD_PORTS_MAPPING {
 inline int get_port(STANDARD_PORTS_MAPPING port) {
   switch (port) {
   case HTTPS_PORT:
-    return utils::get_env("WOLF_HTTP_PORT") ? std::stoi(utils::get_env("WOLF_HTTP_PORT")) : HTTPS_PORT;
+    return utils::get_env("WOLF_HTTPS_PORT") ? std::stoi(utils::get_env("WOLF_HTTPS_PORT")) : HTTPS_PORT;
   case HTTP_PORT:
     return utils::get_env("WOLF_HTTP_PORT") ? std::stoi(utils::get_env("WOLF_HTTP_PORT")) : HTTP_PORT;
   case CONTROL_PORT:

--- a/src/moonlight-server/state/data-structures.hpp
+++ b/src/moonlight-server/state/data-structures.hpp
@@ -38,6 +38,23 @@ enum STANDARD_PORTS_MAPPING {
   RTSP_SETUP_PORT = 48010
 };
 
+inline int get_port(STANDARD_PORTS_MAPPING port) {
+  switch (port) {
+  case HTTPS_PORT:
+    return utils::get_env("WOLF_HTTP_PORT") ? std::stoi(utils::get_env("WOLF_HTTP_PORT")) : HTTPS_PORT;
+  case HTTP_PORT:
+    return utils::get_env("WOLF_HTTP_PORT") ? std::stoi(utils::get_env("WOLF_HTTP_PORT")) : HTTP_PORT;
+  case CONTROL_PORT:
+    return utils::get_env("WOLF_CONTROL_PORT") ? std::stoi(utils::get_env("WOLF_CONTROL_PORT")) : CONTROL_PORT;
+  case VIDEO_PING_PORT:
+    return utils::get_env("WOLF_VIDEO_PING_PORT") ? std::stoi(utils::get_env("WOLF_VIDEO_PING_PORT")) : VIDEO_PING_PORT;
+  case AUDIO_PING_PORT:
+    return utils::get_env("WOLF_AUDIO_PING_PORT") ? std::stoi(utils::get_env("WOLF_AUDIO_PING_PORT")) : AUDIO_PING_PORT;
+  case RTSP_SETUP_PORT:
+    return utils::get_env("WOLF_RTSP_SETUP_PORT") ? std::stoi(utils::get_env("WOLF_RTSP_SETUP_PORT")) : RTSP_SETUP_PORT;
+  }
+}
+
 using PairedClientList = immer::vector<immer::box<wolf::config::PairedClient>>;
 
 enum Encoder {

--- a/src/moonlight-server/state/default/config.include.toml
+++ b/src/moonlight-server/state/default/config.include.toml
@@ -203,7 +203,7 @@ default_source = 'interpipesrc listen-to={session_id}_video is-live=true stream-
 default_sink = """
 rtpmoonlightpay_video name=moonlight_pay \
 payload_size={payload_size} fec_percentage={fec_percentage} min_required_fec_packets={min_required_fec_packets} !
-appsink name=wolf_udp_sink\
+appsink sync=false name=wolf_udp_sink
 """
 
 ######################
@@ -416,6 +416,7 @@ audio-type=restricted-lowdelay max-payload-size=1400\
 default_sink = """
 rtpmoonlightpay_audio name=moonlight_pay packet_duration={packet_duration} encrypt={encrypt} \
 aes_key="{aes_key}" aes_iv="{aes_iv}" !
+queue !
 appsink name=wolf_udp_sink\
 """
 

--- a/src/moonlight-server/state/default/config.include.toml
+++ b/src/moonlight-server/state/default/config.include.toml
@@ -203,7 +203,7 @@ default_source = 'interpipesrc listen-to={session_id}_video is-live=true stream-
 default_sink = """
 rtpmoonlightpay_video name=moonlight_pay \
 payload_size={payload_size} fec_percentage={fec_percentage} min_required_fec_packets={min_required_fec_packets} !
-udpsink bind-port={host_port} host={client_ip} port={client_port} sync=true\
+appsink name=wolf_udp_sink\
 """
 
 ######################
@@ -416,7 +416,7 @@ audio-type=restricted-lowdelay max-payload-size=1400\
 default_sink = """
 rtpmoonlightpay_audio name=moonlight_pay packet_duration={packet_duration} encrypt={encrypt} \
 aes_key="{aes_key}" aes_iv="{aes_iv}" !
-udpsink bind-port={host_port} host={client_ip} port={client_port} sync=true\
+appsink name=wolf_udp_sink\
 """
 
 )for_c++_include"

--- a/src/moonlight-server/state/default/config.v4.toml
+++ b/src/moonlight-server/state/default/config.v4.toml
@@ -202,7 +202,7 @@ default_source = 'interpipesrc listen-to={session_id}_video is-live=true stream-
 default_sink = """
 rtpmoonlightpay_video name=moonlight_pay \
 payload_size={payload_size} fec_percentage={fec_percentage} min_required_fec_packets={min_required_fec_packets} !
-appsink name=wolf_udp_sink\
+appsink sync=false name=wolf_udp_sink
 """
 
 ######################
@@ -415,6 +415,7 @@ audio-type=restricted-lowdelay max-payload-size=1400\
 default_sink = """
 rtpmoonlightpay_audio name=moonlight_pay packet_duration={packet_duration} encrypt={encrypt} \
 aes_key="{aes_key}" aes_iv="{aes_iv}" !
+queue !
 appsink name=wolf_udp_sink\
 """
 

--- a/src/moonlight-server/state/default/config.v4.toml
+++ b/src/moonlight-server/state/default/config.v4.toml
@@ -202,7 +202,7 @@ default_source = 'interpipesrc listen-to={session_id}_video is-live=true stream-
 default_sink = """
 rtpmoonlightpay_video name=moonlight_pay \
 payload_size={payload_size} fec_percentage={fec_percentage} min_required_fec_packets={min_required_fec_packets} !
-udpsink bind-port={host_port} host={client_ip} port={client_port} sync=true\
+appsink name=wolf_udp_sink\
 """
 
 ######################
@@ -415,6 +415,6 @@ audio-type=restricted-lowdelay max-payload-size=1400\
 default_sink = """
 rtpmoonlightpay_audio name=moonlight_pay packet_duration={packet_duration} encrypt={encrypt} \
 aes_key="{aes_key}" aes_iv="{aes_iv}" !
-udpsink bind-port={host_port} host={client_ip} port={client_port} sync=true\
+appsink name=wolf_udp_sink\
 """
 

--- a/src/moonlight-server/state/sessions.hpp
+++ b/src/moonlight-server/state/sessions.hpp
@@ -64,13 +64,20 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
   auto video_stream_port = get_next_available_port(state->running_sessions->load(), true);
   auto audio_stream_port = get_next_available_port(state->running_sessions->load(), false);
 
-  auto rtp_secret = crypto::random(16);
-  std::array<uint8_t, 16> rtp_secret_payload;
-  std::copy(rtp_secret.begin(), rtp_secret.end(), rtp_secret_payload.begin());
+  std::random_device rd;
+  std::mt19937 generator(rd());
 
-  auto enet_secret = crypto::random(4);
-  uint32_t enet_secret_payload;
-  std::memcpy(&enet_secret_payload, enet_secret.data(), 4);
+  std::uniform_int_distribution<> chars(33, 126); // ASCII values for printable character
+  std::array<char, 16> rtp_secret_payload;
+  for (auto &c : rtp_secret_payload) {
+    c = static_cast<char>(chars(generator));
+  }
+
+  std::uniform_int_distribution<u_int32_t> uints(0, UINT32_MAX);
+
+  std::uniform_int_distribution<> ints(0, 255);
+  auto rtsp_fake_ip = fmt::format("{}.{}.{}.{}", ints(generator), ints(generator), ints(generator), ints(generator));
+
   auto session = events::StreamSession{.display_mode = display_mode,
                                        .audio_channel_count = audio_channel_count,
                                        .event_bus = state->event_bus,
@@ -83,12 +90,8 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
 
                                        // Moonlight protocol extension to support IP-less connections
                                        .rtp_secret_payload = rtp_secret_payload,
-                                       .enet_secret_payload = enet_secret_payload,
-                                       .rtsp_fake_ip = fmt::format("{}.{}.{}.{}",
-                                                                   rtp_secret_payload[0],
-                                                                   rtp_secret_payload[1],
-                                                                   rtp_secret_payload[2],
-                                                                   rtp_secret_payload[3]),
+                                       .enet_secret_payload = uints(generator),
+                                       .rtsp_fake_ip = rtsp_fake_ip,
 
                                        // client info
                                        .session_id = state::get_client_id(current_client),

--- a/src/moonlight-server/state/sessions.hpp
+++ b/src/moonlight-server/state/sessions.hpp
@@ -90,12 +90,23 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
   auto video_stream_port = get_next_available_port(state->running_sessions->load(), true);
   auto audio_stream_port = get_next_available_port(state->running_sessions->load(), false);
 
+  auto rtp_secret = crypto::random(16);
+  std::array<char, 16> rtp_secret_payload;
+  std::copy(rtp_secret.begin(), rtp_secret.end(), rtp_secret_payload.begin());
+
+  auto enet_secret = crypto::random(4);
+  uint32_t enet_secret_payload;
+  std::memcpy(&enet_secret_payload, enet_secret.data(), 4);
   auto session = events::StreamSession{.display_mode = display_mode,
                                        .audio_channel_count = audio_channel_count,
                                        .event_bus = state->event_bus,
                                        .client_settings = current_client.settings,
                                        .app = std::make_shared<events::App>(run_app),
                                        .app_state_folder = full_path.string(),
+
+                                       // Moonlight protocol extension to support IP-less connections
+                                       .rtp_secret_payload = rtp_secret_payload,
+                                       .enet_secret_payload = enet_secret_payload,
 
                                        // client info
                                        .session_id = state::get_client_id(current_client),

--- a/src/moonlight-server/state/sessions.hpp
+++ b/src/moonlight-server/state/sessions.hpp
@@ -36,19 +36,6 @@ inline std::optional<events::StreamSession> get_session_by_client(const immer::v
   return get_session_by_id(sessions, client_id);
 }
 
-inline unsigned short get_next_available_port(const immer::vector<events::StreamSession> &sessions, bool video) {
-  auto ports = sessions |                                                               //
-               ranges::views::transform([video](const events::StreamSession &session) { //
-                 return video ? session.video_stream_port : session.audio_stream_port;  //
-               })                                                                       //
-               | ranges::to_vector;
-  unsigned short port = video ? state::VIDEO_PING_PORT : state::AUDIO_PING_PORT;
-  while (std::find(ports.begin(), ports.end(), port) != ports.end()) {
-    port++;
-  }
-  return port;
-}
-
 inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<state::AppState> state,
                                                                     const events::App &run_app,
                                                                     const wolf::config::PairedClient &current_client,
@@ -60,9 +47,6 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
   auto full_path = std::filesystem::path(host_state_folder) / current_client.app_state_folder / run_app.base.title;
   logs::log(logs::debug, "Host app state folder: {}, creating paths", full_path.string());
   std::filesystem::create_directories(full_path);
-
-  auto video_stream_port = get_next_available_port(state->running_sessions->load(), true);
-  auto audio_stream_port = get_next_available_port(state->running_sessions->load(), false);
 
   std::random_device rd;
   std::mt19937 generator(rd());
@@ -94,9 +78,10 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
                                        .rtsp_fake_ip = rtsp_fake_ip,
 
                                        // client info
-                                       .session_id = state::get_client_id(current_client),
-                                       .video_stream_port = video_stream_port,
-                                       .audio_stream_port = audio_stream_port};
+                                       .session_id = get_client_id(current_client),
+                                       .video_stream_port = static_cast<unsigned short>(get_port(VIDEO_PING_PORT)),
+                                       .audio_stream_port = static_cast<unsigned short>(get_port(AUDIO_PING_PORT)),
+                                       .control_stream_port = static_cast<unsigned short>(get_port(CONTROL_PORT))};
 
   return std::make_shared<events::StreamSession>(session);
 }

--- a/src/moonlight-server/state/sessions.hpp
+++ b/src/moonlight-server/state/sessions.hpp
@@ -2,6 +2,7 @@
 
 #include <events/events.hpp>
 #include <helpers/logger.hpp>
+#include <helpers/utils.hpp>
 #include <immer/vector.hpp>
 #include <optional>
 #include <range/v3/view.hpp>
@@ -21,6 +22,18 @@ inline std::optional<events::StreamSession> get_session_by_ip(const immer::vecto
   if (results.size() == 1) {
     return results[0];
   } else if (results.empty()) {
+    // If no sessions for specific IP, try to find wildcard
+    if (auto wildcardIP = utils::get_env("WOLF_STREAM_CLIENT_IP")) {
+      std::string ipString = wildcardIP;
+      auto newResults = sessions |                                                                                      //
+                 ranges::views::filter([&ip,&ipString](const events::StreamSession &session) { return session.ip == ipString; }) //
+                 | ranges::views::take(1)                                                                        //
+                 | ranges::to_vector;
+      if (newResults.size() == 1) {
+        return newResults[0];
+      }
+    }
+
     return {};
   } else {
     logs::log(logs::warning, "Found multiple sessions for a given IP: {}", ip);

--- a/src/moonlight-server/state/sessions.hpp
+++ b/src/moonlight-server/state/sessions.hpp
@@ -13,34 +13,6 @@ namespace state {
 
 using namespace wolf::core;
 
-inline std::optional<events::StreamSession> get_session_by_ip(const immer::vector<events::StreamSession> &sessions,
-                                                              const std::string &ip) {
-  auto results = sessions |                                                                                      //
-                 ranges::views::filter([&ip](const events::StreamSession &session) { return session.ip == ip; }) //
-                 | ranges::views::take(1)                                                                        //
-                 | ranges::to_vector;                                                                            //
-  if (results.size() == 1) {
-    return results[0];
-  } else if (results.empty()) {
-    // If no sessions for specific IP, try to find wildcard
-    if (auto wildcardIP = utils::get_env("WOLF_STREAM_CLIENT_IP")) {
-      std::string ipString = wildcardIP;
-      auto newResults = sessions |                                                                                      //
-                 ranges::views::filter([&ip,&ipString](const events::StreamSession &session) { return session.ip == ipString; }) //
-                 | ranges::views::take(1)                                                                        //
-                 | ranges::to_vector;
-      if (newResults.size() == 1) {
-        return newResults[0];
-      }
-    }
-
-    return {};
-  } else {
-    logs::log(logs::warning, "Found multiple sessions for a given IP: {}", ip);
-    return {};
-  }
-}
-
 inline std::optional<events::StreamSession> get_session_by_id(const immer::vector<events::StreamSession> &sessions,
                                                               const std::size_t id) {
   auto results =
@@ -81,7 +53,9 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
                                                                     const events::App &run_app,
                                                                     const wolf::config::PairedClient &current_client,
                                                                     const moonlight::DisplayMode &display_mode,
-                                                                    int audio_channel_count) {
+                                                                    int audio_channel_count,
+                                                                    const std::string &aes_key,
+                                                                    const std::string &aes_iv) {
   std::string host_state_folder = utils::get_env("HOST_APPS_STATE_FOLDER", "/etc/wolf");
   auto full_path = std::filesystem::path(host_state_folder) / current_client.app_state_folder / run_app.base.title;
   logs::log(logs::debug, "Host app state folder: {}, creating paths", full_path.string());
@@ -91,7 +65,7 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
   auto audio_stream_port = get_next_available_port(state->running_sessions->load(), false);
 
   auto rtp_secret = crypto::random(16);
-  std::array<char, 16> rtp_secret_payload;
+  std::array<uint8_t, 16> rtp_secret_payload;
   std::copy(rtp_secret.begin(), rtp_secret.end(), rtp_secret_payload.begin());
 
   auto enet_secret = crypto::random(4);
@@ -104,9 +78,17 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
                                        .app = std::make_shared<events::App>(run_app),
                                        .app_state_folder = full_path.string(),
 
+                                       .aes_key = aes_key,
+                                       .aes_iv = aes_iv,
+
                                        // Moonlight protocol extension to support IP-less connections
                                        .rtp_secret_payload = rtp_secret_payload,
                                        .enet_secret_payload = enet_secret_payload,
+                                       .rtsp_fake_ip = fmt::format("{}.{}.{}.{}",
+                                                                   rtp_secret_payload[0],
+                                                                   rtp_secret_payload[1],
+                                                                   rtp_secret_payload[2],
+                                                                   rtp_secret_payload[3]),
 
                                        // client info
                                        .session_id = state::get_client_id(current_client),

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -188,36 +188,35 @@ send_buffer(std::shared_ptr<GstBuffer> buffer, std::shared_ptr<GstSample> sample
 static GstFlowReturn on_new_sample(GstAppSink *appsink, gpointer user_data) {
   std::shared_ptr<GstSample> sample(gst_app_sink_pull_sample(appsink), gst_sample_unref);
   if (!sample) {
+    logs::log(logs::warning, "Custom sink: failed to create sample");
     return GST_FLOW_ERROR;
   }
 
   UDPSink *udp_sink = static_cast<UDPSink *>(user_data);
 
-  GstBufferList *buffer_list = gst_sample_get_buffer_list(sample.get());
-  if (buffer_list) {
-    // TODO: use boost to properly send multiple buffers in one go
+  if (GstBufferList *buffer_list = gst_sample_get_buffer_list(sample.get())) {
+    // TODO: use boost to properly send multiple buffers in one go (scatter-gather I/O)
     for (guint i = 0; i < gst_buffer_list_length(buffer_list); ++i) {
       GstBuffer *buffer = gst_buffer_list_get(buffer_list, i);
       std::shared_ptr<GstBuffer> buffer_ptr(gst_buffer_ref(buffer), gst_buffer_unref);
-      return send_buffer(buffer_ptr, sample, udp_sink);
+      if (auto result = send_buffer(buffer_ptr, sample, udp_sink); result != GST_FLOW_OK) {
+        return result;
+      }
     }
+    return GST_FLOW_OK;
+  } else if (GstBuffer *buffer = gst_sample_get_buffer(sample.get())) {
+    std::shared_ptr<GstBuffer> buffer_ptr(gst_buffer_ref(buffer), gst_buffer_unref);
+    return send_buffer(buffer_ptr, sample, udp_sink);
   } else {
-    GstBuffer *buffer = gst_sample_get_buffer(sample.get());
-    if (buffer) {
-      std::shared_ptr<GstBuffer> buffer_ptr(gst_buffer_ref(buffer), gst_buffer_unref);
-      return send_buffer(buffer_ptr, sample, udp_sink);
-    }
+    logs::log(logs::warning, "Custom sink: failed to get buffer");
+    return GST_FLOW_ERROR;
   }
-  return GST_FLOW_ERROR;
 }
 
-// Configure the appsink element
 static void configure_appsink(GstElement *appsink, UDPSink *udp_sink) {
-  // Set to emit signals
-  g_object_set(appsink, "emit-signals", TRUE, NULL);
-  g_object_set(appsink, "buffer-list", FALSE, NULL); // TODO: implement this
+  g_object_set(appsink, "emit-signals", FALSE, NULL);
+  g_object_set(appsink, "buffer-list", TRUE, NULL);
 
-  // Connect the new-sample signal
   GstAppSinkCallbacks callbacks = {nullptr};
   callbacks.new_sample = on_new_sample;
   gst_app_sink_set_callbacks(GST_APP_SINK(appsink), &callbacks, udp_sink, nullptr);

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -1,5 +1,6 @@
 #include <control/control.hpp>
-#include <functional>
+#include <gstreamer-1.0/gst/app/gstappsink.h>
+#include <gstreamer-1.0/gst/app/gstappsrc.h>
 #include <immer/array.hpp>
 #include <immer/array_transient.hpp>
 #include <immer/box.hpp>
@@ -152,13 +153,85 @@ void start_audio_producer(std::size_t session_id,
   });
 }
 
+namespace custom_sink {
+
+struct UDPSink {
+  std::shared_ptr<udp::socket> socket;
+  std::shared_ptr<udp::endpoint> client_endpoint;
+};
+
+static GstFlowReturn
+send_buffer(std::shared_ptr<GstBuffer> buffer, std::shared_ptr<GstSample> sample, UDPSink *udp_sink) {
+  GstMapInfo map;
+  if (gst_buffer_map(buffer.get(), &map, GST_MAP_READ)) {
+    std::shared_ptr<GstMapInfo> map_ptr = std::make_shared<GstMapInfo>(map);
+    if (!udp_sink->socket->is_open()) {
+      logs::log(logs::debug, "UDP Socket is not open");
+      udp_sink->socket->open(udp::v4());
+    }
+    udp_sink->socket->async_send_to(
+        boost::asio::buffer(map.data, map.size),
+        *udp_sink->client_endpoint,
+        [buffer, sample, map_ptr](const boost::system::error_code &error, std::size_t bytes_sent) {
+          if (error) {
+            logs::log(logs::error, "Error sending UDP packet: {}", error.message());
+          }
+          gst_buffer_unmap(buffer.get(), map_ptr.get());
+        });
+    return GST_FLOW_OK;
+  } else {
+    logs::log(logs::error, "Failed to map buffer");
+    return GST_FLOW_ERROR;
+  }
+}
+
+static GstFlowReturn on_new_sample(GstAppSink *appsink, gpointer user_data) {
+  std::shared_ptr<GstSample> sample(gst_app_sink_pull_sample(appsink), gst_sample_unref);
+  if (!sample) {
+    return GST_FLOW_ERROR;
+  }
+
+  UDPSink *udp_sink = static_cast<UDPSink *>(user_data);
+
+  GstBufferList *buffer_list = gst_sample_get_buffer_list(sample.get());
+  if (buffer_list) {
+    // TODO: use boost to properly send multiple buffers in one go
+    for (guint i = 0; i < gst_buffer_list_length(buffer_list); ++i) {
+      GstBuffer *buffer = gst_buffer_list_get(buffer_list, i);
+      std::shared_ptr<GstBuffer> buffer_ptr(gst_buffer_ref(buffer), gst_buffer_unref);
+      return send_buffer(buffer_ptr, sample, udp_sink);
+    }
+  } else {
+    GstBuffer *buffer = gst_sample_get_buffer(sample.get());
+    if (buffer) {
+      std::shared_ptr<GstBuffer> buffer_ptr(gst_buffer_ref(buffer), gst_buffer_unref);
+      return send_buffer(buffer_ptr, sample, udp_sink);
+    }
+  }
+  return GST_FLOW_ERROR;
+}
+
+// Configure the appsink element
+static void configure_appsink(GstElement *appsink, UDPSink *udp_sink) {
+  // Set to emit signals
+  g_object_set(appsink, "emit-signals", TRUE, NULL);
+  g_object_set(appsink, "buffer-list", FALSE, NULL); // TODO: implement this
+
+  // Connect the new-sample signal
+  GstAppSinkCallbacks callbacks = {nullptr};
+  callbacks.new_sample = on_new_sample;
+  gst_app_sink_set_callbacks(GST_APP_SINK(appsink), &callbacks, udp_sink, nullptr);
+}
+} // namespace custom_sink
+
 /**
  * Start VIDEO pipeline
  */
-void start_streaming_video(const immer::box<events::VideoSession> &video_session,
+void start_streaming_video(immer::box<events::VideoSession> video_session,
                            const std::shared_ptr<events::EventBusType> &event_bus,
                            std::string client_ip,
-                           unsigned short client_port) {
+                           unsigned short client_port,
+                           std::shared_ptr<udp::socket> video_socket) {
   std::string color_range = (video_session->color_range == events::ColorRange::JPEG) ? "jpeg" : "mpeg2";
   std::string color_space;
   switch (video_session->color_space) {
@@ -190,7 +263,18 @@ void start_streaming_video(const immer::box<events::VideoSession> &video_session
                               fmt::arg("host_port", video_session->port));
   logs::log(logs::debug, "Starting video pipeline: \n{}", pipeline);
 
-  run_pipeline(pipeline, [video_session, event_bus](auto pipeline, auto loop) {
+  std::shared_ptr<custom_sink::UDPSink> udp_sink = std::make_shared<custom_sink::UDPSink>(custom_sink::UDPSink{
+      .socket = video_socket,
+      .client_endpoint = std::make_shared<udp::endpoint>(boost::asio::ip::make_address(client_ip), client_port)});
+
+  run_pipeline(pipeline, [video_session, event_bus, udp_sink](auto pipeline, auto loop) {
+    if (auto app_sink_el = gst_bin_get_by_name(GST_BIN(pipeline.get()), "wolf_udp_sink")) {
+      logs::log(logs::debug, "Setting up wolf_udp_sink");
+      g_assert(GST_IS_APP_SINK(app_sink_el));
+      configure_appsink(app_sink_el, udp_sink.get());
+      gst_object_unref(app_sink_el);
+    }
+
     /*
      * The force IDR event will be triggered by the control stream.
      * We have to pass this back into the gstreamer pipeline
@@ -246,10 +330,11 @@ void start_streaming_video(const immer::box<events::VideoSession> &video_session
 /**
  * Start AUDIO pipeline
  */
-void start_streaming_audio(const immer::box<events::AudioSession> &audio_session,
+void start_streaming_audio(immer::box<events::AudioSession> audio_session,
                            const std::shared_ptr<events::EventBusType> &event_bus,
                            std::string client_ip,
                            unsigned short client_port,
+                           std::shared_ptr<udp::socket> audio_socket,
                            const std::string &sink_name,
                            const std::string &server_name) {
   auto pipeline = fmt::format(
@@ -272,7 +357,18 @@ void start_streaming_audio(const immer::box<events::AudioSession> &audio_session
       fmt::arg("host_port", audio_session->port));
   logs::log(logs::debug, "Starting audio pipeline: \n{}", pipeline);
 
-  run_pipeline(pipeline, [session_id = audio_session->session_id, event_bus](auto pipeline, auto loop) {
+  std::shared_ptr<custom_sink::UDPSink> udp_sink = std::make_shared<custom_sink::UDPSink>(custom_sink::UDPSink{
+      .socket = audio_socket,
+      .client_endpoint = std::make_shared<udp::endpoint>(boost::asio::ip::make_address(client_ip), client_port)});
+
+  run_pipeline(pipeline, [session_id = audio_session->session_id, udp_sink, event_bus](auto pipeline, auto loop) {
+    if (auto app_sink_el = gst_bin_get_by_name(GST_BIN(pipeline.get()), "wolf_udp_sink")) {
+      logs::log(logs::debug, "Setting up wolf_udp_sink");
+      g_assert(GST_IS_APP_SINK(app_sink_el));
+      custom_sink::configure_appsink(app_sink_el, udp_sink.get());
+      gst_object_unref(app_sink_el);
+    }
+
     auto pause_handler = event_bus->register_handler<immer::box<events::PauseStreamEvent>>(
         [session_id, loop](const immer::box<events::PauseStreamEvent> &ev) {
           if (ev->session_id == session_id) {

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -157,6 +157,7 @@ void start_audio_producer(std::size_t session_id,
  */
 void start_streaming_video(const immer::box<events::VideoSession> &video_session,
                            const std::shared_ptr<events::EventBusType> &event_bus,
+                           std::string client_ip,
                            unsigned short client_port) {
   std::string color_range = (video_session->color_range == events::ColorRange::JPEG) ? "jpeg" : "mpeg2";
   std::string color_space;
@@ -179,7 +180,7 @@ void start_streaming_video(const immer::box<events::VideoSession> &video_session
                               fmt::arg("fps", video_session->display_mode.refreshRate),
                               fmt::arg("bitrate", video_session->bitrate_kbps),
                               fmt::arg("client_port", client_port),
-                              fmt::arg("client_ip", video_session->client_ip),
+                              fmt::arg("client_ip", client_ip),
                               fmt::arg("payload_size", video_session->packet_size),
                               fmt::arg("fec_percentage", video_session->fec_percentage),
                               fmt::arg("min_required_fec_packets", video_session->min_required_fec_packets),
@@ -247,6 +248,7 @@ void start_streaming_video(const immer::box<events::VideoSession> &video_session
  */
 void start_streaming_audio(const immer::box<events::AudioSession> &audio_session,
                            const std::shared_ptr<events::EventBusType> &event_bus,
+                           std::string client_ip,
                            unsigned short client_port,
                            const std::string &sink_name,
                            const std::string &server_name) {
@@ -266,7 +268,7 @@ void start_streaming_audio(const immer::box<events::AudioSession> &audio_session
       fmt::arg("aes_iv", audio_session->aes_iv),
       fmt::arg("encrypt", audio_session->encrypt_audio),
       fmt::arg("client_port", client_port),
-      fmt::arg("client_ip", audio_session->client_ip),
+      fmt::arg("client_ip", client_ip),
       fmt::arg("host_port", audio_session->port));
   logs::log(logs::debug, "Starting audio pipeline: \n{}", pipeline);
 

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -166,7 +166,7 @@ send_buffer(std::shared_ptr<GstBuffer> buffer, std::shared_ptr<GstSample> sample
   if (gst_buffer_map(buffer.get(), &map, GST_MAP_READ)) {
     std::shared_ptr<GstMapInfo> map_ptr = std::make_shared<GstMapInfo>(map);
     if (!udp_sink->socket->is_open()) {
-      logs::log(logs::debug, "UDP Socket is not open");
+      logs::log(logs::warning, "UDP Socket is not open");
       udp_sink->socket->open(udp::v4());
     }
     udp_sink->socket->async_send_to(

--- a/src/moonlight-server/streaming/streaming.hpp
+++ b/src/moonlight-server/streaming/streaming.hpp
@@ -81,11 +81,8 @@ inline void init() {
   gst_init(nullptr, nullptr);
   logs::log(logs::info, "Gstreamer version: {}", get_gst_version());
 
-  GstPlugin *video_plugin = gst_plugin_load_by_name("rtpmoonlightpay_video");
-  gst_element_register(video_plugin, "rtpmoonlightpay_video", GST_RANK_PRIMARY, gst_TYPE_rtp_moonlight_pay_video);
-
-  GstPlugin *audio_plugin = gst_plugin_load_by_name("rtpmoonlightpay_audio");
-  gst_element_register(audio_plugin, "rtpmoonlightpay_audio", GST_RANK_PRIMARY, gst_TYPE_rtp_moonlight_pay_audio);
+  gst_element_register(nullptr, "rtpmoonlightpay_video", GST_RANK_PRIMARY, gst_TYPE_rtp_moonlight_pay_video);
+  gst_element_register(nullptr, "rtpmoonlightpay_audio", GST_RANK_PRIMARY, gst_TYPE_rtp_moonlight_pay_audio);
 
   moonlight::fec::init();
 }

--- a/src/moonlight-server/streaming/streaming.hpp
+++ b/src/moonlight-server/streaming/streaming.hpp
@@ -1,23 +1,21 @@
 #pragma once
-#include "moonlight/fec.hpp"
 #include <boost/asio.hpp>
 #include <core/gstreamer.hpp>
 #include <core/virtual-display.hpp>
 #include <events/events.hpp>
-#include <fmt/core.h>
 #include <fmt/format.h>
 #include <gst-plugin/gstrtpmoonlightpay_audio.hpp>
 #include <gst-plugin/gstrtpmoonlightpay_video.hpp>
 #include <gst-plugin/video.hpp>
 #include <gst/gst.h>
-#include <gstreamer-1.0/gst/app/gstappsink.h>
-#include <gstreamer-1.0/gst/app/gstappsrc.h>
 #include <immer/box.hpp>
 #include <memory>
+#include <moonlight/fec.hpp>
 
 namespace streaming {
 
 using namespace wolf::core;
+using boost::asio::ip::udp;
 
 void start_video_producer(std::size_t session_id,
                           wolf::core::virtual_display::wl_state_ptr wl_state,
@@ -30,15 +28,17 @@ void start_audio_producer(std::size_t session_id,
                           const std::string &sink_name,
                           const std::string &server_name);
 
-void start_streaming_video(const immer::box<events::VideoSession> &video_session,
-                           const std::shared_ptr<events::EventBusType> &event_bus,
-                           std::string client_ip,
-                           unsigned short client_port);
-
-void start_streaming_audio(const immer::box<events::AudioSession> &audio_session,
+void start_streaming_video(immer::box<events::VideoSession> video_session,
                            const std::shared_ptr<events::EventBusType> &event_bus,
                            std::string client_ip,
                            unsigned short client_port,
+                           std::shared_ptr<udp::socket> video_socket);
+
+void start_streaming_audio(immer::box<events::AudioSession> audio_session,
+                           const std::shared_ptr<events::EventBusType> &event_bus,
+                           std::string client_ip,
+                           unsigned short client_port,
+                           std::shared_ptr<udp::socket> audio_socket,
                            const std::string &sink_name,
                            const std::string &server_name);
 

--- a/src/moonlight-server/streaming/streaming.hpp
+++ b/src/moonlight-server/streaming/streaming.hpp
@@ -32,10 +32,12 @@ void start_audio_producer(std::size_t session_id,
 
 void start_streaming_video(const immer::box<events::VideoSession> &video_session,
                            const std::shared_ptr<events::EventBusType> &event_bus,
+                           std::string client_ip,
                            unsigned short client_port);
 
 void start_streaming_audio(const immer::box<events::AudioSession> &audio_session,
                            const std::shared_ptr<events::EventBusType> &event_bus,
+                           std::string client_ip,
                            unsigned short client_port,
                            const std::string &sink_name,
                            const std::string &server_name);

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -362,9 +362,10 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
       }));
 
   struct PingInfo {
-    unsigned short port;
     std::string ip;
+    unsigned short port;
   };
+
   // Video streaming pipeline
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::VideoSession>>(
       [=](const immer::box<events::VideoSession> &sess) {
@@ -375,19 +376,15 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
           auto ev_handler = app_state->event_bus->register_handler<immer::box<events::RTPVideoPingEvent>>(
               [pp = std::ref(ping_promise), &called, sess](const immer::box<events::RTPVideoPingEvent> &ping_ev) {
                 std::call_once(called, [=]() { // We'll keep receiving PING requests, but we only want the first one
-                  auto ip = sess->client_ip;
-                  bool matches = ping_ev->client_ip == ip;
-
-                  if (auto client_ip = utils::get_env("WOLF_STREAM_CLIENT_IP")) {
-                    logs::log(logs::debug, "Client IP override: {}", client_ip);
-                    matches |= ip == std::string(client_ip);
-                  }
-
-                  if (matches) {
-                    pp.get().set_value({
-                      .ip = ping_ev->client_ip,
-                      .port = ping_ev->client_port
-                    }); // This throws when set multiple times
+                  if (ping_ev->payload) {
+                    if (ping_ev->payload.value() == sess->rtp_secret_payload) {
+                      logs::log(logs::debug, "Matched RTP secret payload for video session {}", sess->session_id);
+                      pp.get().set_value({.ip = ping_ev->client_ip, .port = ping_ev->client_port});
+                    }
+                  } else if (ping_ev->client_ip == sess->client_ip) {
+                    logs::log(logs::debug, "Matched client IP for video session {}", sess->session_id);
+                    pp.get().set_value({.ip = ping_ev->client_ip,
+                                        .port = ping_ev->client_port}); // This throws when set multiple times
                   }
                 });
               });
@@ -437,20 +434,15 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
           auto ev_handler = app_state->event_bus->register_handler<immer::box<events::RTPAudioPingEvent>>(
               [pp = std::ref(ping_promise), &called, sess](const immer::box<events::RTPAudioPingEvent> &ping_ev) {
                 std::call_once(called, [=]() { // We'll keep receiving PING requests, but we only want the first one
-                  auto ip = sess->client_ip;
-                  bool matches = ping_ev->client_ip == ip;
-
-                  if (auto client_ip = utils::get_env("WOLF_STREAM_CLIENT_IP")) {
-                    logs::log(logs::debug, "Client IP override: {}", client_ip);
-                    matches |= ip == std::string(client_ip);
-                  }
-
-
-                  if (matches) {
-                    pp.get().set_value({
-                      .ip = ping_ev->client_ip,
-                      .port = ping_ev->client_port
-                    }); // This throws when set multiple times
+                  if (ping_ev->payload) {
+                    if (ping_ev->payload.value() == sess->rtp_secret_payload) {
+                      logs::log(logs::debug, "Matched RTP secret payload for audio session {}", sess->session_id);
+                      pp.get().set_value({.ip = ping_ev->client_ip, .port = ping_ev->client_port});
+                    }
+                  } else if (ping_ev->client_ip == sess->client_ip) {
+                    logs::log(logs::debug, "Matched client IP for audio session {}", sess->session_id);
+                    pp.get().set_value({.ip = ping_ev->client_ip,
+                                        .port = ping_ev->client_port}); // This throws when set multiple times
                   }
                 });
               });

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -27,8 +27,6 @@ using namespace std::string_literals;
 using namespace std::chrono_literals;
 using namespace wolf::core;
 
-static constexpr int DEFAULT_SESSION_TIMEOUT_MILLIS = 10000;
-
 /**
  * @brief Will try to load the config file and fallback to defaults
  */
@@ -141,6 +139,14 @@ std::optional<AudioServer> setup_audio_server(const std::string &runtime_dir) {
 }
 
 using session_devices = immer::map<std::size_t /* session_id */, std::shared_ptr<events::devices_atom_queue>>;
+
+template <typename SessionType>
+immer::vector<immer::box<SessionType>> remove_session(const immer::vector<immer::box<SessionType>> &sessions,
+                                                      const std::size_t session_id) {
+  return sessions                                                                                               //
+         | ranges::views::filter([=](const immer::box<SessionType> &s) { return s->session_id != session_id; }) //
+         | ranges::to<immer::vector<immer::box<SessionType>>>();
+}
 
 auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
                              const std::string &runtime_dir,
@@ -361,62 +367,58 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
         }).detach();
       }));
 
+  /**
+   * A list of video sessions created during RTSP and waiting for a RTP ping
+   */
   std::shared_ptr<immer::atom<events::video_session_list>> video_waiting_list =
       std::make_shared<immer::atom<events::video_session_list>>(events::video_session_list{});
 
-  // Video streaming pipeline
+  // When a VideoSession is created, add it to the waiting list
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::VideoSession>>(
       [video_waiting_list](const immer::box<events::VideoSession> &sess) {
-        video_waiting_list->update(
-            [=](const events::video_session_list &sessions) { return sessions.push_back(sess.get()); });
+        video_waiting_list->update([=](auto &sessions) { return sessions.push_back(sess.get()); });
       }));
 
+  // When we receive a RTP ping, look for the matching session and fire the streaming pipeline
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::RTPVideoPingEvent>>(
       [ev_bus = app_state->event_bus, video_waiting_list](const immer::box<events::RTPVideoPingEvent> &ping_ev) {
         for (immer::box<events::VideoSession> sess : video_waiting_list->load().get()) {
-          // TODO: no payload? Legacy IP matching?
-          if (sess->rtp_secret_payload == ping_ev->payload) {
+          if (sess->rtp_secret_payload == ping_ev->payload || // Secret payload matching
+              (!ping_ev->payload.has_value() && ping_ev->client_ip == sess->client_ip &&
+               ping_ev->client_port == sess->port)) { // Legacy IP+port matching when no payload has been passed
             // Found a session waiting for a ping, remove it from the list (we want to call this once)
-            video_waiting_list->update([=](const events::video_session_list &sessions) {
-              return sessions //
-                     | ranges::views::filter([=](const immer::box<events::VideoSession> &s) {
-                         return s->session_id != sess->session_id;
-                       }) //
-                     | ranges::to<events::video_session_list>();
-            });
+            video_waiting_list->update([id = sess->session_id](auto &s) { return remove_session(s, id); });
             // Start streaming
-            std::thread([=]() {
+            std::thread([sess, ev_bus, ping_ev]() {
               streaming::start_streaming_video(sess, ev_bus, ping_ev->client_ip, ping_ev->client_port);
             }).detach();
           }
         }
       }));
 
+  /**
+   * A list of audio sessions created during RTSP and waiting for a RTP ping
+   */
   std::shared_ptr<immer::atom<events::audio_session_list>> audio_waiting_list =
       std::make_shared<immer::atom<events::audio_session_list>>(events::audio_session_list{});
 
-  // Audio streaming pipeline
+  // When an Audio session is created, add it to the waiting list
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::AudioSession>>(
       [audio_waiting_list](const immer::box<events::AudioSession> &sess) {
-        audio_waiting_list->update(
-            [=](const events::audio_session_list &sessions) { return sessions.push_back(sess.get()); });
+        audio_waiting_list->update([=](auto &sessions) { return sessions.push_back(sess.get()); });
       }));
 
+  // When we receive a RTP ping, look for the matching session and fire the streaming pipeline
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::RTPAudioPingEvent>>(
       [audio_waiting_list, audio_server, ev_bus = app_state->event_bus](
           const immer::box<events::RTPAudioPingEvent> &ping_ev) {
         for (immer::box<events::AudioSession> sess : audio_waiting_list->load().get()) {
-          // TODO: no payload? Legacy IP matching?
-          if (sess->rtp_secret_payload == ping_ev->payload) {
+          if (sess->rtp_secret_payload == ping_ev->payload || // Secret payload matching
+              (!ping_ev->payload.has_value() && ping_ev->client_ip == sess->client_ip &&
+               ping_ev->client_port == sess->port)) { // Legacy IP+port matching when no payload has been passed
             // Found a session waiting for a ping, remove it from the list (we want to call this once)
-            audio_waiting_list->update([=](const events::audio_session_list &sessions) {
-              return sessions //
-                     | ranges::views::filter([=](const immer::box<events::AudioSession> &s) {
-                         return s->session_id != sess->session_id;
-                       }) //
-                     | ranges::to<events::audio_session_list>();
-            });
-            std::thread([=]() {
+            audio_waiting_list->update([id = sess->session_id](auto &s) { return remove_session(s, id); });
+            std::thread([audio_server, sess, ev_bus, ping_ev]() {
               // Start streaming
               auto audio_server_name = audio_server ? audio::get_server_name(audio_server->server)
                                                     : std::optional<std::string>();

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -27,7 +27,7 @@ using namespace std::string_literals;
 using namespace std::chrono_literals;
 using namespace wolf::core;
 
-static constexpr int DEFAULT_SESSION_TIMEOUT_MILLIS = 4000;
+static constexpr int DEFAULT_SESSION_TIMEOUT_MILLIS = 10000;
 
 /**
  * @brief Will try to load the config file and fallback to defaults
@@ -361,130 +361,77 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
         }).detach();
       }));
 
-  struct PingInfo {
-    std::string ip;
-    unsigned short port;
-  };
+  std::shared_ptr<immer::atom<events::video_session_list>> video_waiting_list =
+      std::make_shared<immer::atom<events::video_session_list>>(events::video_session_list{});
 
   // Video streaming pipeline
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::VideoSession>>(
-      [=](const immer::box<events::VideoSession> &sess) {
-        std::thread([=]() {
-          boost::promise<PingInfo> ping_promise;
-          auto ping_fut = ping_promise.get_future();
-          std::once_flag called;
-          auto ev_handler = app_state->event_bus->register_handler<immer::box<events::RTPVideoPingEvent>>(
-              [pp = std::ref(ping_promise), &called, sess](const immer::box<events::RTPVideoPingEvent> &ping_ev) {
-                std::call_once(called, [=]() { // We'll keep receiving PING requests, but we only want the first one
-                  if (ping_ev->payload) {
-                    if (ping_ev->payload.value() == sess->rtp_secret_payload) {
-                      logs::log(logs::debug, "Matched RTP secret payload for video session {}", sess->session_id);
-                      pp.get().set_value({.ip = ping_ev->client_ip, .port = ping_ev->client_port});
-                    }
-                  } else if (ping_ev->client_ip == sess->client_ip) {
-                    logs::log(logs::debug, "Matched client IP for video session {}", sess->session_id);
-                    pp.get().set_value({.ip = ping_ev->client_ip,
-                                        .port = ping_ev->client_port}); // This throws when set multiple times
-                  }
-                });
-              });
-
-          std::shared_ptr<std::atomic_bool> cancel_job = std::make_shared<std::atomic<bool>>(false);
-          auto cancel_event = app_state->event_bus->register_handler<immer::box<events::VideoSession>>(
-              [=](const immer::box<events::VideoSession> &new_sess) {
-                if (new_sess->session_id == sess->session_id) {
-                  // A new VideoSession has been queued whilst we still haven't received a PING
-                  *cancel_job = true;
-                }
-              });
-
-          logs::log(logs::debug, "Video session {}, waiting for PING...", sess->session_id);
-
-          // Stop here until we get a PING
-          std::string client_ip = "";
-          unsigned short client_port = 0;
-          if (sess->wait_for_ping) {
-            auto status = ping_fut.wait_for(boost::chrono::milliseconds(DEFAULT_SESSION_TIMEOUT_MILLIS));
-            if (status != boost::future_status::ready) {
-              logs::log(logs::warning, "Video session {} timed out waiting for PING", sess->session_id);
-              return;
-            }
-            auto ping_info = ping_fut.get();
-            client_port = ping_info.port;
-            client_ip = ping_info.ip;
-            cancel_event.unregister();
-            ev_handler.unregister();
-
-            if (*cancel_job) {
-              return;
-            }
-          }
-
-          streaming::start_streaming_video(sess, app_state->event_bus, client_ip, client_port);
-        }).detach();
+      [video_waiting_list](const immer::box<events::VideoSession> &sess) {
+        video_waiting_list->update(
+            [=](const events::video_session_list &sessions) { return sessions.push_back(sess.get()); });
       }));
+
+  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::RTPVideoPingEvent>>(
+      [ev_bus = app_state->event_bus, video_waiting_list](const immer::box<events::RTPVideoPingEvent> &ping_ev) {
+        for (immer::box<events::VideoSession> sess : video_waiting_list->load().get()) {
+          // TODO: no payload? Legacy IP matching?
+          if (sess->rtp_secret_payload == ping_ev->payload) {
+            // Found a session waiting for a ping, remove it from the list (we want to call this once)
+            video_waiting_list->update([=](const events::video_session_list &sessions) {
+              return sessions //
+                     | ranges::views::filter([=](const immer::box<events::VideoSession> &s) {
+                         return s->session_id != sess->session_id;
+                       }) //
+                     | ranges::to<events::video_session_list>();
+            });
+            // Start streaming
+            std::thread([=]() {
+              streaming::start_streaming_video(sess, ev_bus, ping_ev->client_ip, ping_ev->client_port);
+            }).detach();
+          }
+        }
+      }));
+
+  std::shared_ptr<immer::atom<events::audio_session_list>> audio_waiting_list =
+      std::make_shared<immer::atom<events::audio_session_list>>(events::audio_session_list{});
 
   // Audio streaming pipeline
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::AudioSession>>(
-      [=](const immer::box<events::AudioSession> &sess) {
-        std::thread([=]() {
-          boost::promise<PingInfo> ping_promise;
-          auto ping_fut = ping_promise.get_future();
-          std::once_flag called;
-          auto ev_handler = app_state->event_bus->register_handler<immer::box<events::RTPAudioPingEvent>>(
-              [pp = std::ref(ping_promise), &called, sess](const immer::box<events::RTPAudioPingEvent> &ping_ev) {
-                std::call_once(called, [=]() { // We'll keep receiving PING requests, but we only want the first one
-                  if (ping_ev->payload) {
-                    if (ping_ev->payload.value() == sess->rtp_secret_payload) {
-                      logs::log(logs::debug, "Matched RTP secret payload for audio session {}", sess->session_id);
-                      pp.get().set_value({.ip = ping_ev->client_ip, .port = ping_ev->client_port});
-                    }
-                  } else if (ping_ev->client_ip == sess->client_ip) {
-                    logs::log(logs::debug, "Matched client IP for audio session {}", sess->session_id);
-                    pp.get().set_value({.ip = ping_ev->client_ip,
-                                        .port = ping_ev->client_port}); // This throws when set multiple times
-                  }
-                });
-              });
+      [audio_waiting_list](const immer::box<events::AudioSession> &sess) {
+        audio_waiting_list->update(
+            [=](const events::audio_session_list &sessions) { return sessions.push_back(sess.get()); });
+      }));
 
-          std::shared_ptr<std::atomic_bool> cancel_job = std::make_shared<std::atomic<bool>>(false);
-          auto cancel_event = app_state->event_bus->register_handler<immer::box<events::AudioSession>>(
-              [=](const immer::box<events::AudioSession> &new_sess) {
-                if (new_sess->session_id == sess->session_id) {
-                  // A new AudioSession has been queued whilst we still haven't received a PING
-                  *cancel_job = true;
-                }
-              });
+  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::RTPAudioPingEvent>>(
+      [audio_waiting_list, audio_server, ev_bus = app_state->event_bus](
+          const immer::box<events::RTPAudioPingEvent> &ping_ev) {
+        for (immer::box<events::AudioSession> sess : audio_waiting_list->load().get()) {
+          // TODO: no payload? Legacy IP matching?
+          if (sess->rtp_secret_payload == ping_ev->payload) {
+            // Found a session waiting for a ping, remove it from the list (we want to call this once)
+            audio_waiting_list->update([=](const events::audio_session_list &sessions) {
+              return sessions //
+                     | ranges::views::filter([=](const immer::box<events::AudioSession> &s) {
+                         return s->session_id != sess->session_id;
+                       }) //
+                     | ranges::to<events::audio_session_list>();
+            });
+            std::thread([=]() {
+              // Start streaming
+              auto audio_server_name = audio_server ? audio::get_server_name(audio_server->server)
+                                                    : std::optional<std::string>();
+              auto sink_name = fmt::format("virtual_sink_{}.monitor", sess->session_id);
+              auto server_name = audio_server_name ? audio_server_name.value() : "";
 
-          logs::log(logs::debug, "Audio session {}, waiting for PING...", sess->session_id);
-
-          // Stop here until we get a PING
-          std::string client_ip = "";
-          unsigned short client_port = 0;
-          if (sess->wait_for_ping) {
-            auto status = ping_fut.wait_for(boost::chrono::milliseconds(DEFAULT_SESSION_TIMEOUT_MILLIS));
-            if (status != boost::future_status::ready) {
-              logs::log(logs::warning, "Audio session {} timed out waiting for PING", sess->session_id);
-              return;
-            }
-            auto ping_info = ping_fut.get();
-            client_port = ping_info.port;
-            client_ip = ping_info.ip;
-            cancel_event.unregister();
-            ev_handler.unregister();
-
-            if (*cancel_job) {
-              return;
-            }
+              streaming::start_streaming_audio(sess,
+                                               ev_bus,
+                                               ping_ev->client_ip,
+                                               ping_ev->client_port,
+                                               sink_name,
+                                               server_name);
+            }).detach();
           }
-
-          auto audio_server_name = audio_server ? audio::get_server_name(audio_server->server)
-                                                : std::optional<std::string>();
-          auto sink_name = fmt::format("virtual_sink_{}.monitor", sess->session_id);
-          auto server_name = audio_server_name ? audio_server_name.value() : "";
-
-          streaming::start_streaming_audio(sess, app_state->event_bus, client_ip, client_port, sink_name, server_name);
-        }).detach();
+        }
       }));
 
   return handlers.persistent();

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -140,7 +140,6 @@ std::optional<AudioServer> setup_audio_server(const std::string &runtime_dir) {
 
 using session_devices = immer::map<std::size_t /* session_id */, std::shared_ptr<events::devices_atom_queue>>;
 
-
 /**
  * Will stop the execution until an event of type RTPPingType is triggered
  * and the signature is matching the input `sess`.

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -387,10 +387,14 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
               (!ping_ev->payload.has_value() && ping_ev->client_ip == sess->client_ip &&
                ping_ev->client_port == sess->port)) { // Legacy IP+port matching when no payload has been passed
             // Found a session waiting for a ping, remove it from the list (we want to call this once)
-            video_waiting_list->update([id = sess->session_id](auto &s) { return remove_session(s, id); });
+            video_waiting_list->update([id = sess->session_id](auto s) { return remove_session(s, id); });
             // Start streaming
-            std::thread([sess, ev_bus, ping_ev]() {
-              streaming::start_streaming_video(sess, ev_bus, ping_ev->client_ip, ping_ev->client_port);
+            std::thread([sess,
+                         ev_bus,
+                         ip = ping_ev->client_ip,
+                         port = ping_ev->client_port,
+                         socket = ping_ev->video_socket.get()]() {
+              streaming::start_streaming_video(sess, ev_bus, ip, port, socket);
             }).detach();
           }
         }
@@ -417,20 +421,20 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
               (!ping_ev->payload.has_value() && ping_ev->client_ip == sess->client_ip &&
                ping_ev->client_port == sess->port)) { // Legacy IP+port matching when no payload has been passed
             // Found a session waiting for a ping, remove it from the list (we want to call this once)
-            audio_waiting_list->update([id = sess->session_id](auto &s) { return remove_session(s, id); });
-            std::thread([audio_server, sess, ev_bus, ping_ev]() {
+            audio_waiting_list->update([id = sess->session_id](auto s) { return remove_session(s, id); });
+            std::thread([audio_server,
+                         sess,
+                         ev_bus,
+                         ip = ping_ev->client_ip,
+                         port = ping_ev->client_port,
+                         socket = ping_ev->audio_socket.get()]() {
               // Start streaming
               auto audio_server_name = audio_server ? audio::get_server_name(audio_server->server)
                                                     : std::optional<std::string>();
               auto sink_name = fmt::format("virtual_sink_{}.monitor", sess->session_id);
               auto server_name = audio_server_name ? audio_server_name.value() : "";
 
-              streaming::start_streaming_audio(sess,
-                                               ev_bus,
-                                               ping_ev->client_ip,
-                                               ping_ev->client_port,
-                                               sink_name,
-                                               server_name);
+              streaming::start_streaming_audio(sess, ev_bus, ip, port, socket, sink_name, server_name);
             }).detach();
           }
         }
@@ -458,24 +462,29 @@ void run() {
   // HTTP APIs
   auto http_thread = std::thread([local_state]() {
     HttpServer server = HttpServer();
-    HTTPServers::startServer(&server, local_state, state::HTTP_PORT);
+    HTTPServers::startServer(&server, local_state, state::get_port(state::HTTP_PORT));
   });
 
   // HTTPS APIs
   std::thread([local_state, p_key_file, p_cert_file]() {
     HttpsServer server = HttpsServer(p_cert_file, p_key_file);
-    HTTPServers::startServer(&server, local_state, state::HTTPS_PORT);
+    HTTPServers::startServer(&server, local_state, state::get_port(state::HTTPS_PORT));
   }).detach();
 
   // RTSP
   std::thread([sessions = local_state->running_sessions]() {
-    rtsp::run_server(state::RTSP_SETUP_PORT, sessions);
+    rtsp::run_server(state::get_port(state::RTSP_SETUP_PORT), sessions);
   }).detach();
 
   // Control
   std::thread([sessions = local_state->running_sessions, ev_bus = local_state->event_bus]() {
-    control::run_control(state::CONTROL_PORT, sessions, ev_bus);
+    control::run_control(state::get_port(state::CONTROL_PORT), sessions, ev_bus);
   }).detach();
+
+  // RTP
+  rtp::start_rtp_ping(state::get_port(state::VIDEO_PING_PORT),
+                      state::get_port(state::AUDIO_PING_PORT),
+                      local_state->event_bus);
 
   // Wolf API server
   std::thread([local_state]() { wolf::api::start_server(local_state); }).detach();

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -140,12 +140,35 @@ std::optional<AudioServer> setup_audio_server(const std::string &runtime_dir) {
 
 using session_devices = immer::map<std::size_t /* session_id */, std::shared_ptr<events::devices_atom_queue>>;
 
-template <typename SessionType>
-immer::vector<immer::box<SessionType>> remove_session(const immer::vector<immer::box<SessionType>> &sessions,
-                                                      const std::size_t session_id) {
-  return sessions                                                                                               //
-         | ranges::views::filter([=](const immer::box<SessionType> &s) { return s->session_id != session_id; }) //
-         | ranges::to<immer::vector<immer::box<SessionType>>>();
+
+/**
+ * Will stop the execution until an event of type RTPPingType is triggered
+ * and the signature is matching the input `sess`.
+ * Returns the RTPPingType event
+ */
+template <typename RTPPingType>
+immer::box<RTPPingType> wait_for_ping(std::shared_ptr<events::EventBusType> ev_bus, const auto &sess) {
+  auto ping_promise = std::make_shared<std::promise<RTPPingType>>();
+  auto ping_future = ping_promise->get_future();
+
+  auto handler =
+      ev_bus->register_handler<immer::box<RTPPingType>>([sess, ping_promise](const immer::box<RTPPingType> &ping_ev) {
+        // Check if this ping is for our session
+        if (sess->rtp_secret_payload == ping_ev->payload || // Secret payload matching
+            (!ping_ev->payload.has_value() && ping_ev->client_ip == sess->client_ip &&
+             ping_ev->client_port == sess->port)) { // Legacy IP+port matching when no payload has been passed
+          // Resolve the promise with the ping event data
+          ping_promise->set_value(*ping_ev);
+        }
+      });
+
+  // Wait for the promise to be fulfilled
+  auto ping_ev = ping_future.get();
+
+  // Unregister the handler since we only need it once
+  handler.unregister();
+
+  return ping_ev;
 }
 
 auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
@@ -367,77 +390,41 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
         }).detach();
       }));
 
-  /**
-   * A list of video sessions created during RTSP and waiting for a RTP ping
-   */
-  std::shared_ptr<immer::atom<events::video_session_list>> video_waiting_list =
-      std::make_shared<immer::atom<events::video_session_list>>(events::video_session_list{});
-
-  // When a VideoSession is created, add it to the waiting list
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::VideoSession>>(
-      [video_waiting_list](const immer::box<events::VideoSession> &sess) {
-        video_waiting_list->update([=](auto &sessions) { return sessions.push_back(sess.get()); });
+      [ev_bus = app_state->event_bus](const immer::box<events::VideoSession> &sess) {
+        // Start a thread that will wait for the RTP ping event
+        std::thread([sess, ev_bus]() {
+          auto ping_ev = wait_for_ping<events::RTPVideoPingEvent>(ev_bus, sess);
+
+          // Start streaming
+          streaming::start_streaming_video(sess,
+                                           ev_bus,
+                                           ping_ev->client_ip,
+                                           ping_ev->client_port,
+                                           ping_ev->video_socket.get());
+        }).detach();
       }));
 
-  // When we receive a RTP ping, look for the matching session and fire the streaming pipeline
-  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::RTPVideoPingEvent>>(
-      [ev_bus = app_state->event_bus, video_waiting_list](const immer::box<events::RTPVideoPingEvent> &ping_ev) {
-        for (immer::box<events::VideoSession> sess : video_waiting_list->load().get()) {
-          if (sess->rtp_secret_payload == ping_ev->payload || // Secret payload matching
-              (!ping_ev->payload.has_value() && ping_ev->client_ip == sess->client_ip &&
-               ping_ev->client_port == sess->port)) { // Legacy IP+port matching when no payload has been passed
-            // Found a session waiting for a ping, remove it from the list (we want to call this once)
-            video_waiting_list->update([id = sess->session_id](auto s) { return remove_session(s, id); });
-            // Start streaming
-            std::thread([sess,
-                         ev_bus,
-                         ip = ping_ev->client_ip,
-                         port = ping_ev->client_port,
-                         socket = ping_ev->video_socket.get()]() {
-              streaming::start_streaming_video(sess, ev_bus, ip, port, socket);
-            }).detach();
-          }
-        }
-      }));
-
-  /**
-   * A list of audio sessions created during RTSP and waiting for a RTP ping
-   */
-  std::shared_ptr<immer::atom<events::audio_session_list>> audio_waiting_list =
-      std::make_shared<immer::atom<events::audio_session_list>>(events::audio_session_list{});
-
-  // When an Audio session is created, add it to the waiting list
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::AudioSession>>(
-      [audio_waiting_list](const immer::box<events::AudioSession> &sess) {
-        audio_waiting_list->update([=](auto &sessions) { return sessions.push_back(sess.get()); });
-      }));
+      [ev_bus = app_state->event_bus, audio_server](const immer::box<events::AudioSession> &sess) {
+        // Start a thread that will wait for the RTP ping event
+        std::thread([sess, ev_bus, audio_server]() {
+          auto ping_ev = wait_for_ping<events::RTPAudioPingEvent>(ev_bus, sess);
 
-  // When we receive a RTP ping, look for the matching session and fire the streaming pipeline
-  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::RTPAudioPingEvent>>(
-      [audio_waiting_list, audio_server, ev_bus = app_state->event_bus](
-          const immer::box<events::RTPAudioPingEvent> &ping_ev) {
-        for (immer::box<events::AudioSession> sess : audio_waiting_list->load().get()) {
-          if (sess->rtp_secret_payload == ping_ev->payload || // Secret payload matching
-              (!ping_ev->payload.has_value() && ping_ev->client_ip == sess->client_ip &&
-               ping_ev->client_port == sess->port)) { // Legacy IP+port matching when no payload has been passed
-            // Found a session waiting for a ping, remove it from the list (we want to call this once)
-            audio_waiting_list->update([id = sess->session_id](auto s) { return remove_session(s, id); });
-            std::thread([audio_server,
-                         sess,
-                         ev_bus,
-                         ip = ping_ev->client_ip,
-                         port = ping_ev->client_port,
-                         socket = ping_ev->audio_socket.get()]() {
-              // Start streaming
-              auto audio_server_name = audio_server ? audio::get_server_name(audio_server->server)
-                                                    : std::optional<std::string>();
-              auto sink_name = fmt::format("virtual_sink_{}.monitor", sess->session_id);
-              auto server_name = audio_server_name ? audio_server_name.value() : "";
+          // Start streaming
+          auto audio_server_name = audio_server ? audio::get_server_name(audio_server->server)
+                                                : std::optional<std::string>();
+          auto sink_name = fmt::format("virtual_sink_{}.monitor", sess->session_id);
+          auto server_name = audio_server_name ? audio_server_name.value() : "";
 
-              streaming::start_streaming_audio(sess, ev_bus, ip, port, socket, sink_name, server_name);
-            }).detach();
-          }
-        }
+          streaming::start_streaming_audio(sess,
+                                           ev_bus,
+                                           ping_ev->client_ip,
+                                           ping_ev->client_port,
+                                           ping_ev->audio_socket.get(),
+                                           sink_name,
+                                           server_name);
+        }).detach();
       }));
 
   return handlers.persistent();

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -361,18 +361,28 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
         }).detach();
       }));
 
+  struct PingInfo {
+    unsigned short port;
+    std::string ip;
+  };
   // Video streaming pipeline
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::VideoSession>>(
       [=](const immer::box<events::VideoSession> &sess) {
         std::thread([=]() {
-          boost::promise<unsigned short> port_promise;
-          auto port_fut = port_promise.get_future();
+          boost::promise<PingInfo> ping_promise;
+          auto ping_fut = ping_promise.get_future();
           std::once_flag called;
           auto ev_handler = app_state->event_bus->register_handler<immer::box<events::RTPVideoPingEvent>>(
-              [pp = std::ref(port_promise), &called, sess](const immer::box<events::RTPVideoPingEvent> &ping_ev) {
+              [pp = std::ref(ping_promise), &called, sess](const immer::box<events::RTPVideoPingEvent> &ping_ev) {
                 std::call_once(called, [=]() { // We'll keep receiving PING requests, but we only want the first one
-                  if (ping_ev->client_ip == sess->client_ip) {
-                    pp.get().set_value(ping_ev->client_port); // This throws when set multiple times
+                  auto ip = sess->client_ip;
+                  bool matches = ping_ev->client_ip == ip;
+
+                  if (matches) {
+                    pp.get().set_value({
+                      .ip = ping_ev->client_ip,
+                      .port = ping_ev->client_port
+                    }); // This throws when set multiple times
                   }
                 });
               });
@@ -389,14 +399,17 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
           logs::log(logs::debug, "Video session {}, waiting for PING...", sess->session_id);
 
           // Stop here until we get a PING
+          std::string client_ip = "";
           unsigned short client_port = 0;
           if (sess->wait_for_ping) {
-            auto status = port_fut.wait_for(boost::chrono::milliseconds(DEFAULT_SESSION_TIMEOUT_MILLIS));
+            auto status = ping_fut.wait_for(boost::chrono::milliseconds(DEFAULT_SESSION_TIMEOUT_MILLIS));
             if (status != boost::future_status::ready) {
               logs::log(logs::warning, "Video session {} timed out waiting for PING", sess->session_id);
               return;
             }
-            client_port = port_fut.get();
+            auto ping_info = ping_fut.get();
+            client_port = ping_info.port;
+            client_ip = ping_info.ip;
             cancel_event.unregister();
             ev_handler.unregister();
 
@@ -405,7 +418,7 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
             }
           }
 
-          streaming::start_streaming_video(sess, app_state->event_bus, client_port);
+          streaming::start_streaming_video(sess, app_state->event_bus, client_ip, client_port);
         }).detach();
       }));
 
@@ -413,14 +426,26 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::AudioSession>>(
       [=](const immer::box<events::AudioSession> &sess) {
         std::thread([=]() {
-          boost::promise<unsigned short> port_promise;
-          auto port_fut = port_promise.get_future();
+          boost::promise<PingInfo> ping_promise;
+          auto ping_fut = ping_promise.get_future();
           std::once_flag called;
           auto ev_handler = app_state->event_bus->register_handler<immer::box<events::RTPAudioPingEvent>>(
-              [pp = std::ref(port_promise), &called, sess](const immer::box<events::RTPAudioPingEvent> &ping_ev) {
+              [pp = std::ref(ping_promise), &called, sess](const immer::box<events::RTPAudioPingEvent> &ping_ev) {
                 std::call_once(called, [=]() { // We'll keep receiving PING requests, but we only want the first one
-                  if (ping_ev->client_ip == sess->client_ip) {
-                    pp.get().set_value(ping_ev->client_port); // This throws when set multiple times
+                  auto ip = sess->client_ip;
+                  bool matches = ping_ev->client_ip == ip;
+
+                  if (auto client_ip = utils::get_env("WOLF_STREAM_CLIENT_IP")) {
+                    logs::log(logs::debug, "Client IP override: {}", client_ip);
+                    matches |= ip == std::string(client_ip);
+                  }
+
+
+                  if (matches) {
+                    pp.get().set_value({
+                      .ip = ping_ev->client_ip,
+                      .port = ping_ev->client_port
+                    }); // This throws when set multiple times
                   }
                 });
               });
@@ -437,14 +462,17 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
           logs::log(logs::debug, "Audio session {}, waiting for PING...", sess->session_id);
 
           // Stop here until we get a PING
+          std::string client_ip = "";
           unsigned short client_port = 0;
           if (sess->wait_for_ping) {
-            auto status = port_fut.wait_for(boost::chrono::milliseconds(DEFAULT_SESSION_TIMEOUT_MILLIS));
+            auto status = ping_fut.wait_for(boost::chrono::milliseconds(DEFAULT_SESSION_TIMEOUT_MILLIS));
             if (status != boost::future_status::ready) {
               logs::log(logs::warning, "Audio session {} timed out waiting for PING", sess->session_id);
               return;
             }
-            client_port = port_fut.get();
+            auto ping_info = ping_fut.get();
+            client_port = ping_info.port;
+            client_ip = ping_info.ip;
             cancel_event.unregister();
             ev_handler.unregister();
 
@@ -458,7 +486,7 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
           auto sink_name = fmt::format("virtual_sink_{}.monitor", sess->session_id);
           auto server_name = audio_server_name ? audio_server_name.value() : "";
 
-          streaming::start_streaming_audio(sess, app_state->event_bus, client_port, sink_name, server_name);
+          streaming::start_streaming_audio(sess, app_state->event_bus, client_ip, client_port, sink_name, server_name);
         }).detach();
       }));
 

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -378,6 +378,11 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
                   auto ip = sess->client_ip;
                   bool matches = ping_ev->client_ip == ip;
 
+                  if (auto client_ip = utils::get_env("WOLF_STREAM_CLIENT_IP")) {
+                    logs::log(logs::debug, "Client IP override: {}", client_ip);
+                    matches |= ip == std::string(client_ip);
+                  }
+
                   if (matches) {
                     pp.get().set_value({
                       .ip = ping_ev->client_ip,

--- a/tests/testMoonlight.cpp
+++ b/tests/testMoonlight.cpp
@@ -527,8 +527,8 @@ TEST_CASE("Multiple users", "[HTTP]") {
   app_state.running_sessions->update([session1](auto &sessions) { return sessions.push_back(*session1); });
   auto session2 = endpoints::https::create_run_session(client1_headers, client1_ip, client1, app_state, app1);
 
-  REQUIRE(session2->video_stream_port == 48101);
-  REQUIRE(session2->audio_stream_port == 48201);
+  REQUIRE(session2->video_stream_port == 48100);
+  REQUIRE(session2->audio_stream_port == 48200);
 
   // Saving only the second session
   app_state.running_sessions->update(
@@ -546,6 +546,6 @@ TEST_CASE("Multiple users", "[HTTP]") {
   // We should now assign the 2nd port (even if we have 3 sessions) because of port clash
   auto session4 = endpoints::https::create_run_session(client1_headers, client1_ip, client1, app_state, app1);
 
-  REQUIRE(session4->video_stream_port == 48102);
-  REQUIRE(session4->audio_stream_port == 48202);
+  REQUIRE(session4->video_stream_port == 48100);
+  REQUIRE(session4->audio_stream_port == 48200);
 }

--- a/tests/testRTSP.cpp
+++ b/tests/testRTSP.cpp
@@ -247,23 +247,22 @@ TEST_CASE("Custom Parser", "[RTSP]") {
 }
 
 state::SessionsAtoms test_init_state() {
-  events::StreamSession session = {
-      .display_mode = {1920, 1080, 60},
-      .audio_channel_count = 2,
-      .event_bus = std::make_shared<events::EventBusType>(),
-      .app = std::make_shared<events::App>(events::App{.base = {},
-                                                       .h264_gst_pipeline = "",
-                                                       .hevc_gst_pipeline = "",
-                                                       .opus_gst_pipeline = "",
-                                                       .runner = nullptr}),
-      .aes_key = crypto::hex_to_str("9d804e47a6aa6624b7d4b502b32cc522", true),
-      .aes_iv = crypto::hex_to_str("01234567890", true),
-      .rtsp_fake_ip = "00.11.22.33.44",
-      .session_id = 1234,
-      .ip = "127.0.0.1",
-      .video_stream_port = 1234,
-      .audio_stream_port = 1235,
-  };
+  events::StreamSession session = {.display_mode = {1920, 1080, 60},
+                                   .audio_channel_count = 2,
+                                   .event_bus = std::make_shared<events::EventBusType>(),
+                                   .app = std::make_shared<events::App>(events::App{.base = {},
+                                                                                    .h264_gst_pipeline = "",
+                                                                                    .hevc_gst_pipeline = "",
+                                                                                    .opus_gst_pipeline = "",
+                                                                                    .runner = nullptr}),
+                                   .aes_key = crypto::hex_to_str("9d804e47a6aa6624b7d4b502b32cc522", true),
+                                   .aes_iv = crypto::hex_to_str("01234567890", true),
+                                   .rtsp_fake_ip = "00.11.22.33.44",
+                                   .session_id = 1234,
+                                   .ip = "127.0.0.1",
+                                   .video_stream_port = 1234,
+                                   .audio_stream_port = 1235,
+                                   .control_stream_port = 1236};
   return std::make_shared<immer::atom<immer::vector<events::StreamSession>>>(
       immer::vector<events::StreamSession>{session});
 }
@@ -371,8 +370,7 @@ TEST_CASE("Commands (Payload matching)", "[RTSP]") {
                        REQUIRE(response.value().seq_number == 5);
 
                        REQUIRE_THAT(response.value().options["Session"], Equals("DEADBEEFCAFE;timeout = 90"));
-                       REQUIRE_THAT(response.value().options["Transport"],
-                                    Equals(fmt::format("server_port={}", (int)state::CONTROL_PORT)));
+                       REQUIRE_THAT(response.value().options["Transport"], Equals(fmt::format("server_port={}", 1236)));
                      });
   }
 
@@ -558,8 +556,7 @@ TEST_CASE("Commands (IP Matching)", "[RTSP]") {
                        REQUIRE(response.value().seq_number == 5);
 
                        REQUIRE_THAT(response.value().options["Session"], Equals("DEADBEEFCAFE;timeout = 90"));
-                       REQUIRE_THAT(response.value().options["Transport"],
-                                    Equals(fmt::format("server_port={}", (int)state::CONTROL_PORT)));
+                       REQUIRE_THAT(response.value().options["Transport"], Equals(fmt::format("server_port={}", 1236)));
                      });
   }
 

--- a/tests/testRTSP.cpp
+++ b/tests/testRTSP.cpp
@@ -258,6 +258,7 @@ state::SessionsAtoms test_init_state() {
                                                        .runner = nullptr}),
       .aes_key = crypto::hex_to_str("9d804e47a6aa6624b7d4b502b32cc522", true),
       .aes_iv = crypto::hex_to_str("01234567890", true),
+      .rtsp_fake_ip = "00.11.22.33.44",
       .session_id = 1234,
       .ip = "127.0.0.1",
       .video_stream_port = 1234,
@@ -267,7 +268,7 @@ state::SessionsAtoms test_init_state() {
       immer::vector<events::StreamSession>{session});
 }
 
-TEST_CASE("Commands", "[RTSP]") {
+TEST_CASE("Commands (Payload matching)", "[RTSP]") {
   constexpr int port = 8080;
   boost::asio::io_context ioc;
   auto state = test_init_state();
@@ -275,7 +276,7 @@ TEST_CASE("Commands", "[RTSP]") {
   auto wolf_client = tcp_tester::create_client(ioc, port, state);
 
   SECTION("MissingNo") {
-    wolf_client->run("MissingNo rtsp://10.1.2.49:48010 RTSP/1.0\r\n"
+    wolf_client->run("MissingNo rtsp://00.11.22.33.44:48010 RTSP/1.0\r\n"
                      "CSeq: 1\r\n\r\n"sv,
                      [](std::optional<RTSP_PACKET> response) {
                        REQUIRE(response.has_value());
@@ -285,10 +286,10 @@ TEST_CASE("Commands", "[RTSP]") {
   }
 
   SECTION("OPTION") {
-    wolf_client->run("OPTIONS rtsp://10.1.2.49:48010 RTSP/1.0\r\n"
+    wolf_client->run("OPTIONS rtsp://00.11.22.33.44:48010 RTSP/1.0\r\n"
                      "CSeq: 1\r\n"
                      "X-GS-ClientVersion: 14\r\n"
-                     "Host: 10.1.2.49"
+                     "Host: 0.0.0.0"
                      "\r\n\r\n"sv,
                      [](std::optional<RTSP_PACKET> response) {
                        REQUIRE(response.has_value());
@@ -298,10 +299,10 @@ TEST_CASE("Commands", "[RTSP]") {
   }
 
   SECTION("DESCRIBE") {
-    wolf_client->run("DESCRIBE rtsp://10.1.2.49:48010 RTSP/1.0\n"
+    wolf_client->run("DESCRIBE rtsp://00.11.22.33.44:48010 RTSP/1.0\n"
                      "CSeq: 2\n"
                      "X-GS-ClientVersion: 14\n"
-                     "Host: 10.1.2.49\n"
+                     "Host: 00.11.22.33.44\n"
                      "Accept: application/sdp"
                      "\r\n\r\n"sv,
                      [](std::optional<RTSP_PACKET> response) {
@@ -322,7 +323,7 @@ TEST_CASE("Commands", "[RTSP]") {
     wolf_client->run("SETUP streamid=audio/0/0 RTSP/1.0\n"
                      "CSeq: 3\n"
                      "X-GS-ClientVersion: 14\n"
-                     "Host: 10.1.2.49\n"
+                     "Host: 00.11.22.33.44\n"
                      "Transport: unicast;X-GS-ClientPort=50000-50001\n"
                      "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 GMT"
                      "\r\n\r\n"sv,
@@ -340,7 +341,7 @@ TEST_CASE("Commands", "[RTSP]") {
     wolf_client->run("SETUP streamid=video/0/0 RTSP/1.0\n"
                      "CSeq: 4\n"
                      "X-GS-ClientVersion: 14\n"
-                     "Host: 10.1.2.49\n"
+                     "Host: 00.11.22.33.44\n"
                      "Session:  DEADBEEFCAFE\n"
                      "Transport: unicast;X-GS-ClientPort=50000-50001\n"
                      "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 GMT"
@@ -359,7 +360,194 @@ TEST_CASE("Commands", "[RTSP]") {
     wolf_client->run("SETUP streamid=control/0/0 RTSP/1.0\n"
                      "CSeq: 5\n"
                      "X-GS-ClientVersion: 14\n"
-                     "Host: 10.1.2.49\n"
+                     "Host: 00.11.22.33.44\n"
+                     "Session:  DEADBEEFCAFE\n"
+                     "Transport: unicast;X-GS-ClientPort=50000-50001\n"
+                     "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 GMT"
+                     "\r\n\r\n"sv,
+                     [](std::optional<RTSP_PACKET> response) {
+                       REQUIRE(response.has_value());
+                       REQUIRE(response.value().response.status_code == 200);
+                       REQUIRE(response.value().seq_number == 5);
+
+                       REQUIRE_THAT(response.value().options["Session"], Equals("DEADBEEFCAFE;timeout = 90"));
+                       REQUIRE_THAT(response.value().options["Transport"],
+                                    Equals(fmt::format("server_port={}", (int)state::CONTROL_PORT)));
+                     });
+  }
+
+  SECTION("ANNOUNCE control") {
+    // This is a very long message, it'll kick the recursion in receive_message()
+    wolf_client->run("ANNOUNCE streamid=control/13/0 RTSP/1.0\n"
+                     "CSeq: 6\n"
+                     "X-GS-ClientVersion: 14\n"
+                     "Host: 00.11.22.33.44\n"
+                     "Session:  DEADBEEFCAFE\n"
+                     "Content-type: application/sdp\n"
+                     "Content-length: 1308"
+                     "\r\n\r\n" // start of payload
+                     "v=0\n"
+                     "o=android 0 14 IN IPv4 0.0.0.0\n"
+                     "s=NVIDIA Streaming Client\n"
+                     "a=x-nv-video[0].clientViewportWd:1920 \n"
+                     "a=x-nv-video[0].clientViewportHt:1080 \n"
+                     "a=x-nv-video[0].maxFPS:60 \n"
+                     "a=x-nv-video[0].packetSize:1024 \n"
+                     "a=x-nv-video[0].rateControlMode:4 \n"
+                     "a=x-nv-video[0].timeoutLengthMs:7000 \n"
+                     "a=x-nv-video[0].framesWithInvalidRefThreshold:0 \n"
+                     "a=x-nv-video[0].initialBitrateKbps:15500 \n"
+                     "a=x-nv-video[0].initialPeakBitrateKbps:15500 \n"
+                     "a=x-nv-vqos[0].bw.minimumBitrateKbps:15500 \n"
+                     "a=x-nv-vqos[0].bw.maximumBitrateKbps:15500 \n"
+                     "a=x-nv-vqos[0].fec.enable:1 \n"
+                     "a=x-nv-vqos[0].videoQualityScoreUpdateTime:5000 \n"
+                     "a=x-nv-vqos[0].qosTrafficType:0 \n"
+                     "a=x-nv-aqos.qosTrafficType:0 \n"
+                     "a=x-nv-general.featureFlags:167 \n"
+                     "a=x-nv-general.useReliableUdp:13 \n"
+                     "a=x-nv-vqos[0].fec.minRequiredFecPackets:2 \n"
+                     "a=x-nv-vqos[0].drc.enable:0 \n"
+                     "a=x-nv-general.enableRecoveryMode:0 \n"
+                     "a=x-nv-video[0].videoEncoderSlicesPerFrame:1 \n"
+                     "a=x-nv-clientSupportHevc:0 \n"
+                     "a=x-nv-vqos[0].bitStreamFormat:0 \n"
+                     "a=x-nv-video[0].dynamicRangeMode:0 \n"
+                     "a=x-nv-video[0].maxNumReferenceFrames:1 \n"
+                     "a=x-nv-video[0].clientRefreshRateX100:0 \n"
+                     "a=x-nv-audio.surround.numChannels:2 \n"
+                     "a=x-nv-audio.surround.channelMask:3 \n"
+                     "a=x-nv-audio.surround.enable:0 \n"
+                     "a=x-nv-audio.surround.AudioQuality:0 \n"
+                     "a=x-nv-aqos.packetDuration:5 \n"
+                     "a=x-nv-video[0].encoderCscMode:0 \n"
+                     "t=0 0\n"
+                     "m=video 47998 \n"sv,
+                     [](std::optional<RTSP_PACKET> response) {
+                       REQUIRE(response.has_value());
+                       REQUIRE(response.value().response.status_code == 200);
+                       REQUIRE(response.value().seq_number == 6);
+                     });
+  }
+
+  SECTION("Non valid payload") {
+    wolf_client->run("ANNOUNCE streamid=control/13/0 RTSP/1.0\n"
+                     "CSeq: 7\n"
+                     "X-GS-ClientVersion: 14\n"
+                     "Host: 0.0.0.0\n"
+                     "Session:  DEADBEEFCAFE\n"
+                     "Content-type: application/sdp\n"
+                     "Content-length: 170\n"
+                     "\n"
+                     "v=0\n"
+                     "a=x-nv-video[0].timeoutLengthM\n" // Missing :
+                     "a=x-nv-vqos[0].fec.enable:YES\n"  // Non number after :
+                     // The following are required fields
+                     "a=x-nv-video[0].clientViewportWd:1920 \n"
+                     "a=x-nv-video[0].clientViewportHt:1080 \n"
+                     "a=x-nv-video[0].maxFPS:60 \n"
+                     "\n\n\n\n"sv,
+                     [](std::optional<RTSP_PACKET> response) {
+                       REQUIRE(response.has_value());
+                       REQUIRE(response.value().response.status_code == 200);
+                       REQUIRE(response.value().seq_number == 7);
+                     });
+  }
+}
+
+TEST_CASE("Commands (IP Matching)", "[RTSP]") {
+  constexpr int port = 8080;
+  boost::asio::io_context ioc;
+  auto state = test_init_state();
+  auto wolf_server = tcp_server(ioc, port, state);
+  auto wolf_client = tcp_tester::create_client(ioc, port, state);
+
+  SECTION("MissingNo") {
+    wolf_client->run("MissingNo rtsp://127.0.0.1:48010 RTSP/1.0\r\n"
+                     "CSeq: 1\r\n\r\n"sv,
+                     [](std::optional<RTSP_PACKET> response) {
+                       REQUIRE(response.has_value());
+                       REQUIRE(response.value().response.status_code == 404);
+                       REQUIRE(response.value().seq_number == 1);
+                     });
+  }
+
+  SECTION("OPTION") {
+    wolf_client->run("OPTIONS rtsp://127.0.0.1:48010 RTSP/1.0\r\n"
+                     "CSeq: 1\r\n"
+                     "X-GS-ClientVersion: 14\r\n"
+                     "Host: 0.0.0.0"
+                     "\r\n\r\n"sv,
+                     [](std::optional<RTSP_PACKET> response) {
+                       REQUIRE(response.has_value());
+                       REQUIRE(response.value().response.status_code == 200);
+                       REQUIRE(response.value().seq_number == 1);
+                     });
+  }
+
+  SECTION("DESCRIBE") {
+    wolf_client->run("DESCRIBE rtsp://127.0.0.1:48010 RTSP/1.0\n"
+                     "CSeq: 2\n"
+                     "X-GS-ClientVersion: 14\n"
+                     "Host: 0.0.0.0\n"
+                     "Accept: application/sdp"
+                     "\r\n\r\n"sv,
+                     [](std::optional<RTSP_PACKET> response) {
+                       REQUIRE(response);
+                       REQUIRE(response.value().response.status_code == 200);
+                       REQUIRE(response.value().seq_number == 2);
+                       REQUIRE(response.value().payloads.size() == 5);
+                       REQUIRE_THAT(response.value().payloads[0].first, Equals("sprop-parameter-sets"));
+                       REQUIRE_THAT(response.value().payloads[0].second, Equals("AAAAAU"));
+                       REQUIRE_THAT(response.value().payloads[1].second, Equals("fmtp:97 surround-params=21101"));
+                       REQUIRE_THAT(response.value().payloads[2].second, Equals("fmtp:97 surround-params=642014235"));
+                       REQUIRE_THAT(response.value().payloads[3].second, Equals("fmtp:97 surround-params=85301423675"));
+                       REQUIRE_THAT(response.value().payloads[4].second, Equals("x-ss-general.featureFlags: 3"));
+                     });
+  }
+
+  SECTION("SETUP audio") {
+    wolf_client->run("SETUP streamid=audio/0/0 RTSP/1.0\n"
+                     "CSeq: 3\n"
+                     "X-GS-ClientVersion: 14\n"
+                     "Host: 0.0.0.0\n"
+                     "Transport: unicast;X-GS-ClientPort=50000-50001\n"
+                     "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 GMT"
+                     "\r\n\r\n"sv,
+                     [](std::optional<RTSP_PACKET> response) {
+                       REQUIRE(response.has_value());
+                       REQUIRE(response.value().response.status_code == 200);
+                       REQUIRE(response.value().seq_number == 3);
+
+                       REQUIRE_THAT(response.value().options["Session"], Equals("DEADBEEFCAFE;timeout = 90"));
+                       REQUIRE_THAT(response.value().options["Transport"], Equals(fmt::format("server_port={}", 1235)));
+                     });
+  }
+
+  SECTION("SETUP video") {
+    wolf_client->run("SETUP streamid=video/0/0 RTSP/1.0\n"
+                     "CSeq: 4\n"
+                     "X-GS-ClientVersion: 14\n"
+                     "Host: 0.0.0.0\n"
+                     "Session:  DEADBEEFCAFE\n"
+                     "Transport: unicast;X-GS-ClientPort=50000-50001\n"
+                     "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 GMT"
+                     "\r\n\r\n"sv,
+                     [](std::optional<RTSP_PACKET> response) {
+                       REQUIRE(response.has_value());
+                       REQUIRE(response.value().response.status_code == 200);
+                       REQUIRE(response.value().seq_number == 4);
+
+                       REQUIRE_THAT(response.value().options["Session"], Equals("DEADBEEFCAFE;timeout = 90"));
+                       REQUIRE_THAT(response.value().options["Transport"], Equals(fmt::format("server_port={}", 1234)));
+                     });
+  }
+
+  SECTION("SETUP control") {
+    wolf_client->run("SETUP streamid=control/0/0 RTSP/1.0\n"
+                     "CSeq: 5\n"
+                     "X-GS-ClientVersion: 14\n"
+                     "Host: 0.0.0.0\n"
                      "Session:  DEADBEEFCAFE\n"
                      "Transport: unicast;X-GS-ClientPort=50000-50001\n"
                      "If-Modified-Since: Thu, 01 Jan 1970 00:00:00 GMT"
@@ -433,7 +621,7 @@ TEST_CASE("Commands", "[RTSP]") {
     wolf_client->run("ANNOUNCE streamid=control/13/0 RTSP/1.0\n"
                      "CSeq: 7\n"
                      "X-GS-ClientVersion: 14\n"
-                     "Host: 192.168.1.227\n"
+                     "Host: 0.0.0.0\n"
                      "Session:  DEADBEEFCAFE\n"
                      "Content-type: application/sdp\n"
                      "Content-length: 170\n"


### PR DESCRIPTION
This PR adds support for matching Moonlight clients without relying solely on the IP. This will help when users are running behind CGNAT and it's required in order to "proxy" between multiple Wolf instances in [Fenrir](https://github.com/games-on-whales/fenrir).  
Main features:
 - implements `X-SS-*` protocol extensions as defined in https://github.com/LizardByte/Sunshine/pull/1945
 - For `HTTPs` -> `RTSP` IP-less matching we send a fake unique IP as the `sessionUrl0` in `/launch` or `/resume`. Moonlight [doesn't seem to actually use that IP](https://github.com/moonlight-stream/moonlight-common-c/blob/master/src/RtspConnection.c#L954-L970) and it'll just parrot it back as the `Host` when sending back RTSP requests.
 - With all the above we are now able to **stream to multiple clients with just one port open** so now `48100/udp` for Video and `48200/udp` for audio is all you need for as many client as possible!


Continues https://github.com/games-on-whales/wolf/pull/181

fixes #184
fixes #54 
fixes #116 
fixes #19 
