### PR TITLE
Add IPv6 Support for Linux

### DIFF
--- a/.github/workflows/linux-build-test.yml
+++ b/.github/workflows/linux-build-test.yml
@@ -73,6 +73,7 @@ jobs:
                 -DTEST_NVIDIA=OFF \
                 -DTEST_EXCEPTIONS=OFF \
                 -DTEST_UHID=OFF \
+                -DTEST_LINUX_NETWORK=ON \
                 -G Ninja
 
       - name: Build tests + lib

--- a/src/moonlight-server/control/control.cpp
+++ b/src/moonlight-server/control/control.cpp
@@ -41,7 +41,9 @@ enet_host create_host(std::string_view host, std::uint16_t port, std::size_t pee
   enet_address_set_host(&addr, host.data());
   enet_address_set_port(&addr, port);
 
-  auto enet_host = enet_host_create(AF_INET, &addr, peers, 0, 0, 0);
+  // host may be ipv6 or ipv4
+  // when ipv6, enet will try to enable dual-stack mode
+  auto enet_host = enet_host_create(addr.address.ss_family, &addr, peers, 0, 0, 0);
   if (enet_host == nullptr) {
     logs::log(logs::error, "An error occurred while trying to create an ENet server host.");
   }

--- a/src/moonlight-server/control/control.hpp
+++ b/src/moonlight-server/control/control.hpp
@@ -19,7 +19,7 @@ void run_control(int port,
                  const std::shared_ptr<events::EventBusType> &event_bus,
                  int peers = 20,
                  std::chrono::milliseconds timeout = 1000ms,
-                 const std::string &host_ip = "0.0.0.0");
+                 const std::string &host_ip = "::");
 
 using enet_clients_map = immer::map<ENetPeer *, immer::box<events::StreamSession>>;
 

--- a/src/moonlight-server/platforms/hw_linux.cpp
+++ b/src/moonlight-server/platforms/hw_linux.cpp
@@ -1,5 +1,6 @@
 #include "hw.hpp"
 #include <arpa/inet.h>
+#include <boost/asio/ip/address.hpp>
 #include <fcntl.h>
 #include <filesystem>
 #include <fmt/core.h>
@@ -209,6 +210,19 @@ std::string get_ip_address(ifaddrs *ifa) {
 }
 
 std::string get_mac_address(std::string_view local_ip) {
+
+  boost::asio::ip::address addr;
+  try {
+    addr = boost::asio::ip::make_address(local_ip);
+    // handle IPv6 addresses like ::ffff:127.0.0.1
+    if (addr.is_v6() && addr.to_v6().is_v4_mapped()) {
+      addr = addr.to_v6().to_v4();
+    }
+  } catch (const boost::system::system_error &e) {
+    logs::log(logs::warning, "Invalid IP address '{}': {}", local_ip, e.what());
+    return "00:00:00:00:00:00";
+  }
+
   ifaddrs *ifaddrptr = nullptr;
   if (getifaddrs(&ifaddrptr) == -1) {
     logs::log(logs::warning,
@@ -222,8 +236,23 @@ std::string get_mac_address(std::string_view local_ip) {
   // First: search for the interface name that has the same IP address
   std::string interface = "";
   for (auto ifa = ifAddrStruct.get(); ifa != NULL; ifa = ifa->ifa_next) {
-    if (ifa->ifa_addr && local_ip == get_ip_address(ifa)) {
-      interface = ifa->ifa_name;
+    if (!ifa->ifa_addr)
+      continue;
+
+    if (addr.is_v4() && ifa->ifa_addr->sa_family == AF_INET) {
+      auto &v4_addr = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
+      auto addr_bytes = addr.to_v4().to_bytes();
+      if (memcmp(&v4_addr, addr_bytes.data(), sizeof(v4_addr)) == 0) {
+        interface = ifa->ifa_name;
+        break;
+      }
+    } else if (addr.is_v6() && ifa->ifa_addr->sa_family == AF_INET6) {
+      auto &v6_addr = ((struct sockaddr_in6 *)ifa->ifa_addr)->sin6_addr;
+      auto addr_bytes = addr.to_v6().to_bytes();
+      if (memcmp(&v6_addr, addr_bytes.data(), sizeof(v6_addr)) == 0) {
+        interface = ifa->ifa_name;
+        break;
+      }
     }
   }
 

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -44,7 +44,13 @@ void not_found(const std::shared_ptr<typename SimpleWeb::Server<T>::Response> &r
 template <class T>
 std::string get_host_ip(const std::shared_ptr<typename SimpleWeb::Server<T>::Request> &request,
                         const immer::box<state::AppState> &state) {
-  return state->host->internal_ip.value_or(request->local_endpoint().address().to_string());
+  if (state->host->internal_ip) {
+    return *state->host->internal_ip;
+  }
+
+  auto addr = request->local_endpoint().address();
+  // Convert IPv4-mapped IPv6 addresses to IPv4
+  return (addr.is_v6() && addr.to_v6().is_v4_mapped()) ? addr.to_v6().to_v4().to_string() : addr.to_string();
 }
 
 template <class T>

--- a/src/moonlight-server/rest/rest.hpp
+++ b/src/moonlight-server/rest/rest.hpp
@@ -44,7 +44,7 @@ using XML = moonlight::XML;
 
 namespace HTTPServers {
 
-void startServer(HttpServer *server, const immer::box<state::AppState> state, int port);
+void startServer(HttpServer *server, const immer::box<state::AppState> state, int port, const char *address = "::");
 
-void startServer(HttpsServer *server, const immer::box<state::AppState> state, int port);
+void startServer(HttpsServer *server, const immer::box<state::AppState> state, int port, const char *address = "::");
 } // namespace HTTPServers

--- a/src/moonlight-server/rest/servers.cpp
+++ b/src/moonlight-server/rest/servers.cpp
@@ -21,7 +21,7 @@ using namespace wolf::core;
  * @brief Start the generic server on the specified port
  * @return std::thread: the thread where this server will run
  */
-void startServer(HttpServer *server, const immer::box<state::AppState> state, int port, const char* address) {
+void startServer(HttpServer *server, const immer::box<state::AppState> state, int port, const char *address) {
   server->config.port = port;
   server->config.address = address;
   server->default_resource["GET"] = endpoints::not_found<SimpleWeb::HTTP>;
@@ -74,7 +74,12 @@ void startServer(HttpServer *server, const immer::box<state::AppState> state, in
       [pairing_atom](const immer::box<events::PairSignal> pair_sig) {
         pairing_atom->update([&pair_sig](const immer::map<std::string, immer::box<events::PairSignal>> &m) {
           auto secret = crypto::str_to_hex(crypto::random(8));
-          logs::log(logs::info, "Insert pin at http://{}:47989/pin/#{}", pair_sig->host_ip, secret);
+          if (pair_sig->host_ip.find(':') != std::string::npos) {
+            // ipv6 format
+            logs::log(logs::info, "Insert pin at http://[{}]:47989/pin/#{}", pair_sig->host_ip, secret);
+          } else {
+            logs::log(logs::info, "Insert pin at http://{}:47989/pin/#{}", pair_sig->host_ip, secret);
+          }
           // filter out any other (dangling) pair request from the same client
           auto t_map = m.transient();
           for (auto [key, value] : m) {
@@ -114,7 +119,7 @@ void reply_unauthorized(const std::shared_ptr<typename SimpleWeb::ServerBase<Sim
   send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::client_error_unauthorized, xml);
 }
 
-void startServer(HttpsServer *server, const immer::box<state::AppState> state, int port, const char* address) {
+void startServer(HttpsServer *server, const immer::box<state::AppState> state, int port, const char *address) {
   server->config.port = port;
   server->config.address = address;
   server->default_resource["GET"] = endpoints::not_found<SimpleWeb::HTTPS>;

--- a/src/moonlight-server/rest/servers.cpp
+++ b/src/moonlight-server/rest/servers.cpp
@@ -21,9 +21,9 @@ using namespace wolf::core;
  * @brief Start the generic server on the specified port
  * @return std::thread: the thread where this server will run
  */
-void startServer(HttpServer *server, const immer::box<state::AppState> state, int port) {
+void startServer(HttpServer *server, const immer::box<state::AppState> state, int port, const char* address) {
   server->config.port = port;
-  server->config.address = "0.0.0.0";
+  server->config.address = address;
   server->default_resource["GET"] = endpoints::not_found<SimpleWeb::HTTP>;
   server->default_resource["POST"] = endpoints::not_found<SimpleWeb::HTTP>;
 
@@ -114,9 +114,9 @@ void reply_unauthorized(const std::shared_ptr<typename SimpleWeb::ServerBase<Sim
   send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::client_error_unauthorized, xml);
 }
 
-void startServer(HttpsServer *server, const immer::box<state::AppState> state, int port) {
+void startServer(HttpsServer *server, const immer::box<state::AppState> state, int port, const char* address) {
   server->config.port = port;
-  server->config.address = "0.0.0.0";
+  server->config.address = address;
   server->default_resource["GET"] = endpoints::not_found<SimpleWeb::HTTPS>;
   server->default_resource["POST"] = endpoints::not_found<SimpleWeb::HTTPS>;
 

--- a/src/moonlight-server/rtp/udp-ping.cpp
+++ b/src/moonlight-server/rtp/udp-ping.cpp
@@ -43,9 +43,12 @@ void start_rtp_ping(unsigned short video_port,
   auto io_context = std::make_shared<boost::asio::io_context>();
 
   try {
-    logs::log(logs::info, "[RTP] Starting RTP ping server on ports {} and {}", video_port, audio_port);
-    auto video_socket = std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), video_port));
-    auto audio_socket = std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v4(), audio_port));
+    logs::log(logs::info,
+              "[RTP] Starting RTP ping IPv6 dual-stack mode server on ports {} and {}",
+              video_port,
+              audio_port);
+    auto video_socket = std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v6(), video_port));
+    auto audio_socket = std::make_shared<udp::socket>(*io_context, udp::endpoint(udp::v6(), audio_port));
 
     std::thread([io_context, video_socket, audio_socket, event_bus]() {
       UDP_Server video_server(video_socket, [event_bus, video_socket](const RTPPingEvent &ping) {

--- a/src/moonlight-server/rtsp/net.hpp
+++ b/src/moonlight-server/rtsp/net.hpp
@@ -208,9 +208,8 @@ protected:
  */
 class tcp_server {
 public:
-  tcp_server(boost::asio::io_context &io_context, int port, state::SessionsAtoms state)
-      : io_context_(io_context), acceptor_(io_context, tcp::endpoint(tcp::v4(), port)),
-        stream_sessions(std::move(state)) {
+  tcp_server(boost::asio::io_context &io_context, const tcp::endpoint &endpoint, const state::SessionsAtoms &state)
+      : io_context_(io_context), acceptor_(io_context, endpoint), stream_sessions(state) {
     acceptor_.set_option(boost::asio::socket_base::reuse_address{true});
     acceptor_.listen(4096);
     start_accept();
@@ -252,9 +251,9 @@ private:
 void run_server(int port, const state::SessionsAtoms &running_sessions) {
   try {
     boost::asio::io_context io_context;
-    tcp_server server(io_context, port, running_sessions);
+    tcp_server server(io_context, tcp::endpoint(tcp::v6(), port), running_sessions);
 
-    logs::log(logs::info, "RTSP server started on port: {}", port);
+    logs::log(logs::info, "[RTSP] Using IPv6 dual-stack mode on port {}", port);
 
     // This will block here until the context is stopped
     io_context.run();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,11 @@ if (UNIX AND NOT APPLE)
                 "platforms/linux/libinput.h"
                 "platforms/linux/inputtino.cpp")
     endif ()
+
+    option(TEST_LINUX_NETWORK "Enable Linux network test" OFF)
+    if (TEST_LINUX_NETWORK)
+        list(APPEND SRC_LIST "platforms/linux/network.cpp")
+    endif ()
 endif ()
 
 find_package(CURL)

--- a/tests/platforms/linux/network.cpp
+++ b/tests/platforms/linux/network.cpp
@@ -1,0 +1,308 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <boost/asio/ip/address.hpp>
+#include <platforms/hw.hpp>
+#include <regex>
+#include <cstdlib>
+#include <string>
+#include <stdexcept>
+#include <fstream>
+#include <unistd.h>
+
+using Catch::Matchers::Equals;
+
+bool is_valid_mac_format(const std::string& mac) {
+    std::regex mac_pattern("^([0-9a-f]{2}:){5}[0-9a-f]{2}$");
+    return std::regex_match(mac, mac_pattern);
+}
+
+bool is_default_mac(const std::string& mac) {
+    return mac == "00:00:00:00:00:00";
+}
+
+class DummyInterface {
+private:
+    std::string interface_name;
+    std::string mac_address;
+    bool created = false;
+    
+    int run_command(const std::string& cmd) {
+        return std::system((cmd + " 2>/dev/null").c_str());
+    }
+    
+    bool create_interface() {
+        if (created) {
+            return true;
+        }
+        
+        run_command("modprobe dummy");
+        
+        if (run_command("ip link add " + interface_name + " type dummy") != 0) {
+            return false;
+        }
+        
+        if (run_command("ip link set " + interface_name + " up") != 0) {
+            run_command("ip link delete " + interface_name);
+            return false;
+        }
+        
+        created = true;
+        return true;
+    }
+    
+    void fetch_mac_address() {
+        if (created) {
+            mac_address = get_mac_address_for_interface();
+        }
+    }
+    
+    std::string get_mac_address_for_interface() {
+        // Read MAC address directly from sysfs
+        std::string mac_path = "/sys/class/net/" + interface_name + "/address";
+        std::ifstream mac_file(mac_path);
+        if (mac_file.is_open()) {
+            std::string mac;
+            std::getline(mac_file, mac);
+            mac_file.close();
+            return mac;
+        }
+        return "00:00:00:00:00:00";
+    }
+
+public:
+    explicit DummyInterface(const std::string& name) : interface_name(name) {
+        if (!create_interface()) {
+            throw std::runtime_error("Failed to create dummy interface: " + name);
+        }
+        fetch_mac_address();
+    }
+    
+    DummyInterface(const std::string& name, const std::string& ipv4_address) : interface_name(name) {
+        if (!create_interface()) {
+            throw std::runtime_error("Failed to create dummy interface: " + name);
+        }
+        if (!add_ipv4_address(ipv4_address)) {
+            throw std::runtime_error("Failed to add IPv4 address " + ipv4_address + " to interface " + name);
+        }
+        fetch_mac_address();
+    }
+    
+    ~DummyInterface() {
+        if (created) {
+            run_command("ip link delete " + interface_name);
+        }
+    }
+    
+    DummyInterface(const DummyInterface&) = delete;
+    DummyInterface& operator=(const DummyInterface&) = delete;
+    
+    DummyInterface(DummyInterface&& other) noexcept 
+        : interface_name(std::move(other.interface_name)), 
+          mac_address(std::move(other.mac_address)),
+          created(other.created) {
+        other.created = false;
+    }
+    
+    DummyInterface& operator=(DummyInterface&& other) noexcept {
+        if (this != &other) {
+            if (created) {
+                run_command("ip link delete " + interface_name);
+            }
+            
+            interface_name = std::move(other.interface_name);
+            mac_address = std::move(other.mac_address);
+            created = other.created;
+            other.created = false;
+        }
+        return *this;
+    }
+    
+    bool add_ipv4_address(const std::string& ipv4_address) {
+        if (!created) {
+            return false;
+        }
+        
+        return run_command("ip addr add " + ipv4_address + "/24 dev " + interface_name) == 0;
+    }
+    
+    bool add_ipv6_address(const std::string& ipv6_address) {
+        if (!created) {
+            return false;
+        }
+        
+        return run_command("ip addr add " + ipv6_address + "/64 dev " + interface_name) == 0;
+    }
+    
+    const std::string& name() const { return interface_name; }
+    const std::string& mac() const { return mac_address; }
+    bool is_created() const { return created; }
+};
+
+TEST_CASE("get_mac_address: Valid IP addresses", "[hw_linux]") {
+    if (geteuid() != 0) {
+        SKIP("Root privileges required for dummy interface tests");
+    }
+    
+    SECTION("Valid IPv4 addresses should return non-default MAC") {
+        DummyInterface dummy("test_ipv4", "192.168.100.1");
+        
+        REQUIRE(is_valid_mac_format(dummy.mac()));
+        REQUIRE_FALSE(is_default_mac(dummy.mac()));
+        
+        auto result = get_mac_address("192.168.100.1");
+
+        REQUIRE_THAT(result, Equals(dummy.mac()));
+    }
+    
+    SECTION("Valid IPv6 addresses should return non-default MAC") {
+        DummyInterface dummy("test_ipv6");
+        REQUIRE(dummy.add_ipv6_address("2001:db8::1"));
+        
+        REQUIRE(is_valid_mac_format(dummy.mac()));
+        REQUIRE_FALSE(is_default_mac(dummy.mac()));
+        
+        auto result = get_mac_address("2001:db8::1");
+
+        REQUIRE_THAT(result, Equals(dummy.mac()));
+    }
+    
+    SECTION("IPv4-mapped IPv6 consistency") {
+        DummyInterface dummy("test_mapped", "192.168.100.10");
+        
+        auto ipv4_result = get_mac_address("192.168.100.10");
+        auto ipv6_mapped_result = get_mac_address("::ffff:192.168.100.10");
+        
+        REQUIRE(is_valid_mac_format(ipv4_result));
+        REQUIRE(is_valid_mac_format(ipv6_mapped_result));
+        REQUIRE_THAT(ipv6_mapped_result, Equals(ipv4_result));
+        REQUIRE_THAT(ipv4_result, Equals(dummy.mac()));
+        REQUIRE_THAT(ipv6_mapped_result, Equals(dummy.mac()));
+    }
+    
+    SECTION("Multiple IPv4-mapped IPv6 formats") {
+        DummyInterface dummy("test_formats", "10.0.0.100");
+        
+        std::vector<std::pair<std::string, std::string>> format_pairs = {
+            {"10.0.0.100", "::ffff:10.0.0.100"},
+            {"10.0.0.100", "::ffff:0a00:0064"},
+        };
+        
+        for (const auto& [ipv4, ipv6_mapped] : format_pairs) {
+            DYNAMIC_SECTION("Testing " << ipv4 << " vs " << ipv6_mapped) {
+                auto ipv4_result = get_mac_address(ipv4);
+                auto ipv6_result = get_mac_address(ipv6_mapped);
+                
+                REQUIRE(is_valid_mac_format(ipv4_result));
+                REQUIRE(is_valid_mac_format(ipv6_result));
+                REQUIRE_THAT(ipv6_result, Equals(ipv4_result));
+                REQUIRE_THAT(ipv4_result, Equals(dummy.mac()));
+                REQUIRE_THAT(ipv6_result, Equals(dummy.mac()));
+            }
+        }
+    }
+    
+    SECTION("Different interfaces should have different MAC addresses") {
+        DummyInterface dummy1("test_diff1", "192.168.101.1");
+        DummyInterface dummy2("test_diff2", "192.168.102.1");
+        
+        auto mac1 = get_mac_address("192.168.101.1");
+        auto mac2 = get_mac_address("192.168.102.1");
+        
+        REQUIRE(is_valid_mac_format(mac1));
+        REQUIRE(is_valid_mac_format(mac2));
+        REQUIRE_THAT(mac1, Equals(dummy1.mac()));
+        REQUIRE_THAT(mac2, Equals(dummy2.mac()));
+        REQUIRE_FALSE(dummy1.mac() == dummy2.mac());
+    }
+    
+    SECTION("Interface with both IPv4 and IPv6 addresses") {
+        DummyInterface dummy("test_dual", "192.168.103.1");
+        REQUIRE(dummy.add_ipv6_address("2001:db8::100"));
+        
+        auto ipv4_mac = get_mac_address("192.168.103.1");
+        auto ipv6_mac = get_mac_address("2001:db8::100");
+        
+        REQUIRE(is_valid_mac_format(ipv4_mac));
+        REQUIRE(is_valid_mac_format(ipv6_mac));
+        REQUIRE_THAT(ipv4_mac, Equals(dummy.mac()));
+        REQUIRE_THAT(ipv6_mac, Equals(dummy.mac()));
+        REQUIRE_THAT(ipv6_mac, Equals(ipv4_mac));
+    }
+}
+
+TEST_CASE("get_mac_address: Non-existent IP addresses", "[hw_linux]") {
+    SECTION("Non-existent IPv4 addresses should return default MAC") {
+        std::vector<std::string> non_existent_ipv4 = {
+            "192.0.2.1",
+            "203.0.113.1",
+            "198.51.100.1",
+            "172.16.254.254",
+            "10.255.255.254",
+        };
+        
+        for (const auto& ip : non_existent_ipv4) {
+            DYNAMIC_SECTION("Testing non-existent IPv4: " << ip) {
+                auto result = get_mac_address(ip);
+                REQUIRE(is_default_mac(result));
+            }
+        }
+    }
+    
+    SECTION("Non-existent IPv6 addresses should return default MAC") {
+        std::vector<std::string> non_existent_ipv6 = {
+            "2001:db8::2",
+            "2001:db8:1::1",
+            "fc00::1",
+            "fd12:3456:789a::1",
+            "2001:0db8:85a3::8a2e:0370:7334",
+        };
+        
+        for (const auto& ip : non_existent_ipv6) {
+            DYNAMIC_SECTION("Testing non-existent IPv6: " << ip) {
+                auto result = get_mac_address(ip);
+                REQUIRE(is_default_mac(result));
+            }
+        }
+    }
+    
+    SECTION("Non-existent IPv4-mapped IPv6 addresses should return default MAC") {
+        std::vector<std::string> non_existent_mapped = {
+            "::ffff:192.0.2.1",
+            "::ffff:203.0.113.1",
+            "::ffff:198.51.100.1",
+            "::ffff:c000:0201",
+        };
+        
+        for (const auto& ip : non_existent_mapped) {
+            DYNAMIC_SECTION("Testing non-existent IPv4-mapped IPv6: " << ip) {
+                auto result = get_mac_address(ip);
+                REQUIRE(is_default_mac(result));
+            }
+        }
+    }
+}
+
+TEST_CASE("get_mac_address: Malformed IP addresses", "[hw_linux]") {
+    
+    SECTION("Malformed addresses should return default MAC") {
+        std::vector<std::string> malformed = {
+            "192.168.1.1:8080",
+            "http://192.168.1.1",
+            "192.168.1.1/24",
+            "::ffff:999.999.999.999",
+            "[2001:db8::1]",
+            "2001:db8::1%eth0",
+            "2001:db8::gggg",
+            "",
+            "not.an.ip",
+        };
+        
+        for (const auto& ip : malformed) {
+            DYNAMIC_SECTION("Testing malformed address: " << ip) {
+                auto result = get_mac_address(ip);
+                REQUIRE(is_valid_mac_format(result));
+                REQUIRE(is_default_mac(result));
+            }
+        }
+    }
+}

--- a/tests/testRTSP.cpp
+++ b/tests/testRTSP.cpp
@@ -271,7 +271,7 @@ TEST_CASE("Commands (Payload matching)", "[RTSP]") {
   constexpr int port = 8080;
   boost::asio::io_context ioc;
   auto state = test_init_state();
-  auto wolf_server = tcp_server(ioc, port, state);
+  auto wolf_server = tcp_server(ioc, tcp::endpoint(tcp::v4(), port), state);
   auto wolf_client = tcp_tester::create_client(ioc, port, state);
 
   SECTION("MissingNo") {
@@ -457,7 +457,7 @@ TEST_CASE("Commands (IP Matching)", "[RTSP]") {
   constexpr int port = 8080;
   boost::asio::io_context ioc;
   auto state = test_init_state();
-  auto wolf_server = tcp_server(ioc, port, state);
+  auto wolf_server = tcp_server(ioc, tcp::endpoint(tcp::v4(), port), state);
   auto wolf_client = tcp_tester::create_client(ioc, port, state);
 
   SECTION("MissingNo") {


### PR DESCRIPTION
Implements https://github.com/games-on-whales/wolf/issues/136

Changes:
- use "::" instead of "0.0.0.0" when possible
- parse ipv6 string for some formatting cases
- enhance `get_mac_address` to cover ipv6 cases