### PR TITLE
Simplifying mount and starting options

### DIFF
--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -108,8 +108,7 @@ RUN mkdir -p $WOLF_CFG_FOLDER
 COPY --from=wolf-builder /wolf/wolf /wolf/wolf
 COPY --from=wolf-builder /wolf/fake-udev /wolf/fake-udev
 
-ENV XDG_RUNTIME_DIR=/tmp/sockets \
-    GST_GL_API=gles2 \
+ENV GST_GL_API=gles2 \
     GST_GL_WINDOW=surfaceless \
     WOLF_USE_ZERO_COPY=TRUE \
     WOLF_LOG_LEVEL=INFO \
@@ -127,6 +126,10 @@ ENV XDG_RUNTIME_DIR=/tmp/sockets \
     PUID=0 \
     PGID=0 \
     UNAME="root"
+
+# Setting up XDG_RUNTIME_DIR this will automatically create a volume when starting the container
+VOLUME /run/user/wolf/
+ENV XDG_RUNTIME_DIR=/run/user/wolf
 
 # HTTPS
 EXPOSE 47984/tcp

--- a/docs/modules/user/pages/configuration.adoc
+++ b/docs/modules/user/pages/configuration.adoc
@@ -45,7 +45,7 @@ Wolf is configured via a TOML config file and some additional optional ENV varia
 
 |HOST_APPS_STATE_FOLDER
 |/etc/wolf
-|The base folder in the host where the running apps will store permanent state
+|The base folder in the host where the running apps will store permanent state, if not set Wolf will automatically use the path that is mounted in the docker container
 
 |WOLF_RENDER_NODE
 |/dev/dri/renderD128
@@ -77,19 +77,18 @@ Additional env variables useful when debugging:
 [#data_setup]
 == Where apps will store permanent data?
 
-Since Wolf supports multiple streaming sessions at the same time and each session can run a different app, we need to make sure that each app has its own folder where it can store permanent data. +
-To achieve this, for each running app, Wolf will create a folder structure like this:
+Wolf is designed to support multiple streaming sessions simultaneously, each potentially running a different app.
+To ensure that each app’s data remains persistent and isolated, Wolf automatically creates a dedicated folder structure for every app instance.
 
-[source]
-----
-${HOST_APPS_STATE_FOLDER}/${app_state_folder}/${app_title}
-----
+When using the configuration provided in the quickstart guide, this structure is located at `/etc/wolf/${app_state_folder}/${app_title}` on the host system.
+This folder is then mounted as the home directory (`/home/retro`) inside the app’s Docker container, using a bind mount like `-v /etc/wolf/${app_state_folder}/${app_title}:/home/retro`.
 
-and then mount that as the home (`/home/retro`) for the docker container that will run the selected app. +
+The magic of Wolf lies in its ability to dynamically resolve the host path, regardless of where `/etc/wolf` is actually located. +
+For example, if you run Wolf mounting `/etc/wolf` to a custom location on your host such as `-v /mnt/drive/wolf:/etc/wolf:rw` Wolf will automatically adjust the mount path for each app.
+In this case, the app’s data will be stored in `/mnt/drive/wolf/${app_state_folder}/${app_title}` on the host, but still appear as `/home/retro` inside the app container.
 
-These 3 variables are defined as follows:
+These two variables are defined as follows:
 
-* `HOST_APPS_STATE_FOLDER`: defaults to `/etc/wolf`, can be changed via ENV
 * `app_state_folder`: defaults to a unique identifier for each client so that every Moonlight session will have its own folder.
 Can be changed in the `config.toml` file
 * `app_title`: the title of the app as defined in the `config.toml` file
@@ -114,20 +113,6 @@ app_state_folder = "common"               # <-- !!!
 ....
 
 This way, when running any app from those two clients, they will share the same home folder by mounting `${HOST_APPS_STATE_FOLDER}/common/${app_title}` as `/home/retro` in the docker container.
-
-=== Change the `HOST_APPS_STATE_FOLDER`
-
-Changing this folder via ENV variable is not enough; Wolf expects to be able to access files under this folder, so you need to make sure that the new folder is created and mounted in the Wolf container. +
-
-For example, if you want to change the `HOST_APPS_STATE_FOLDER` to `/mnt/drive/wolf` you need to change the docker run command with:
-
-* `-e HOST_APPS_STATE_FOLDER=/mnt/drive/wolf`
-* `-v /mnt/drive/wolf:/mnt/drive/wolf:rw`
-
-Keeping `HOST_APPS_STATE_FOLDER` unchanged and only modifying `-v /mnt/drive/wolf:/etc/wolf:rw` is not sufficient.
-Because app container mount home directory according to `HOST_APPS_STATE_FOLDER` (i.e. `-v ${HOST_APPS_STATE_FOLDER}/${app_state_folder}/${app_title}:/home/retro`)
-
-Since Wolf keeps the configuration in `/etc/wolf/cfg`, you need to add an additional mount to ensure that Wolf's configuration is persistently stored (i.e., -v `/mnt/drive/wolf/cfg:/etc/wolf/cfg:rw`).
 
 == TOML file
 
@@ -456,10 +441,6 @@ video/x-raw, framerate={fps}/1
 
 In case you have two GPUs that will use the same encoder pipeline (example: an AMD iGPU and an AMD GPU card) you can override the `video_params` with the corresponding encoder plugin; see:
 https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1167[gstreamer/issues/1167].
-
-== Directly launch a Steam game
-
-This has been moved to the xref:steam.adoc[] page.
 
 == Changing and Switching Keyboard Layouts in wolf Apps Containers
 

--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -17,9 +17,6 @@ Docker CLI:
 docker run \
     --name wolf \
     --network=host \
-    -e XDG_RUNTIME_DIR=/tmp/sockets \
-    -v /tmp/sockets:/tmp/sockets:rw \
-    -e HOST_APPS_STATE_FOLDER=/etc/wolf \
     -v /etc/wolf:/etc/wolf:rw \
     -v /var/run/docker.sock:/var/run/docker.sock:rw \
     --device /dev/dri/ \
@@ -39,12 +36,8 @@ version: "3"
 services:
   wolf:
     image: ghcr.io/games-on-whales/wolf:stable
-    environment:
-      - XDG_RUNTIME_DIR=/tmp/sockets
-      - HOST_APPS_STATE_FOLDER=/etc/wolf
     volumes:
       - /etc/wolf/:/etc/wolf
-      - /tmp/sockets:/tmp/sockets:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - /dev/:/dev/:rw
       - /run/udev:/run/udev:rw
@@ -89,9 +82,6 @@ Docker CLI:
 docker run \
     --name wolf \
     --network=host \
-    -e XDG_RUNTIME_DIR=/tmp/sockets \
-    -v /tmp/sockets:/tmp/sockets:rw \
-    -e HOST_APPS_STATE_FOLDER=/etc/wolf \
     -v /etc/wolf:/etc/wolf:rw \
     -v /var/run/docker.sock:/var/run/docker.sock:rw \
     -e NVIDIA_DRIVER_CAPABILITIES=all \
@@ -115,13 +105,10 @@ services:
   wolf:
     image: ghcr.io/games-on-whales/wolf:stable
     environment:
-      - XDG_RUNTIME_DIR=/tmp/sockets
-      - HOST_APPS_STATE_FOLDER=/etc/wolf
       - NVIDIA_DRIVER_CAPABILITIES=all
       - NVIDIA_VISIBLE_DEVICES=all
     volumes:
       - /etc/wolf/:/etc/wolf
-      - /tmp/sockets:/tmp/sockets:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - /dev/:/dev/:rw
       - /run/udev:/run/udev:rw
@@ -234,11 +221,8 @@ You can now finally start the container; Docker CLI:
 docker run \
     --name wolf \
     --network=host \
-    -e XDG_RUNTIME_DIR=/tmp/sockets \
-    -v /tmp/sockets:/tmp/sockets:rw \
     -e NVIDIA_DRIVER_VOLUME_NAME=nvidia-driver-vol \
     -v nvidia-driver-vol:/usr/nvidia:rw \
-    -e HOST_APPS_STATE_FOLDER=/etc/wolf \
     -v /etc/wolf:/etc/wolf:rw \
     -v /var/run/docker.sock:/var/run/docker.sock:rw \
     --device /dev/nvidia-uvm \
@@ -266,12 +250,9 @@ services:
   wolf:
     image: ghcr.io/games-on-whales/wolf:stable
     environment:
-      - XDG_RUNTIME_DIR=/tmp/sockets
       - NVIDIA_DRIVER_VOLUME_NAME=nvidia-driver-vol
-      - HOST_APPS_STATE_FOLDER=/etc/wolf
     volumes:
       - /etc/wolf/:/etc/wolf:rw
-      - /tmp/sockets:/tmp/sockets:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - /dev/:/dev/:rw
       - /run/udev:/run/udev:rw
@@ -396,9 +377,6 @@ This should work for AMD/Intel users.
 docker run \
     --name wolf \
     --network=host \
-    -e XDG_RUNTIME_DIR=/tmp/sockets \
-    -v /tmp/sockets:/tmp/sockets:rw \
-    -e HOST_APPS_STATE_FOLDER=/etc/wolf \
     -v /etc/wolf:/etc/wolf:rw \
     -v /var/run/docker.sock:/var/run/docker.sock:rw \
     --device /dev/dri/ \

--- a/src/core/src/platforms/all/docker/docker/json_formatters.hpp
+++ b/src/core/src/platforms/all/docker/docker/json_formatters.hpp
@@ -38,12 +38,11 @@ void tag_invoke(value_from_tag, value &jv, const docker::MountPoint &mount) {
 }
 
 docker::MountPoint tag_invoke(value_to_tag<docker::MountPoint>, value const &jv) {
-  // ex: /home/ale/repos/gow/local_state:/home/retro:rw
-  auto bind = utils::split(std::string_view{jv.as_string().data(), jv.as_string().size()}, ':');
+  object const &obj = jv.as_object();
   return docker::MountPoint{
-      .source = utils::to_string(bind[0]),
-      .destination = utils::to_string(bind[1]),
-      .mode = utils::to_string(bind.size() == 3 ? bind[2] : "rw"),
+      .source = json::value_to<std::string>(obj.at("Source")),
+      .destination = json::value_to<std::string>(obj.at("Destination")),
+      .mode = json::value_to<std::string>(obj.at("Mode")),
   };
 }
 
@@ -114,8 +113,8 @@ docker::Container tag_invoke(value_to_tag<docker::Container>, value const &jv) {
   }
 
   std::vector<docker::MountPoint> mounts;
-  if (!host_config.at("Binds").is_null()) { // This can be `null` in the APIs for some reason
-    mounts = json::value_to<std::vector<docker::MountPoint>>(host_config.at("Binds"));
+  if (!obj.at("Mounts").is_null()) { // This can be `null` in the APIs for some reason
+    mounts = json::value_to<std::vector<docker::MountPoint>>(obj.at("Mounts"));
   }
 
   std::vector<docker::Device> devices;

--- a/src/moonlight-server/CMakeLists.txt
+++ b/src/moonlight-server/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries_system(wolf_runner PUBLIC dp::eventbus)
 FetchContent_Declare(
         tomlplusplus
         GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
-        GIT_TAG        v3.4.0
+        GIT_TAG v3.4.0
         OVERRIDE_FIND_PACKAGE
 )
 FetchContent_MakeAvailable(tomlplusplus)
@@ -96,9 +96,9 @@ endif ()
 set(ZSTD_BUILD_SHARED ${BUILD_SHARED_LIBS})
 set(ZSTD_BUILD_STATIC OFF)
 
-if(NOT BUILD_SHARED_LIBS)
+if (NOT BUILD_SHARED_LIBS)
     set(ZSTD_BUILD_STATIC ON)
-endif()
+endif ()
 FetchContent_MakeAvailable(cpptrace)
 
 ##############################
@@ -131,7 +131,8 @@ file(GLOB SRC_LIST SRCS
         rtsp/*.cpp
         runners/*.cpp
         state/*.cpp
-        streaming/*.cpp)
+        streaming/*.cpp
+        introspect/*.cpp)
 
 if (UNIX AND NOT APPLE)
     message(STATUS "Adding input implementation for LINUX")

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -231,7 +231,8 @@ struct StreamSession {
   std::shared_ptr<EventBusType> event_bus;
   immer::box<wolf::config::ClientSettings> client_settings;
   std::shared_ptr<App> app;
-  std::string app_state_folder;
+  std::string app_local_state_folder;
+  std::string app_host_state_folder;
 
   // gcm encryption keys
   std::string aes_key;

--- a/src/moonlight-server/introspect/introspect.cpp
+++ b/src/moonlight-server/introspect/introspect.cpp
@@ -1,0 +1,63 @@
+#include <filesystem>
+#include <fstream>
+#include <helpers/logger.hpp>
+#include <helpers/utils.hpp>
+#include <introspect/introspect.hpp>
+#include <regex>
+
+namespace introspect {
+
+std::optional<wolf::core::docker::Container> get_current_container(const wolf::core::docker::DockerAPI &docker_api) {
+  // The trick here is to look for the mount points under /proc/self/mountinfo
+  // With Docker, you'll get something like:
+  // /var/lib/docker/containers/f8b41e030e791cf45c52855fa310b86ac32cae06d8c4474a2903fc0a9ce3b926/hostname
+  // where `f8b41e030e791cf45c52855fa310b86ac32cae06d8c4474a2903fc0a9ce3b926` is the actual container ID
+
+  std::ifstream mountinfo("/proc/self/mountinfo");
+  if (!mountinfo.is_open()) {
+    logs::log(logs::warning, "Failed to open /proc/self/mountinfo");
+    return std::nullopt;
+  }
+
+  // Look for HEX strings of at least 64 character in size that ends with `/host`
+  // (we should capture `/hosts` and `/hostname` this way)
+  std::regex container_id_pattern("/([a-fA-F0-9]{64,})/.*/host");
+  std::string line;
+  while (std::getline(mountinfo, line)) {
+    std::smatch matches;
+    if (std::regex_search(line, matches, container_id_pattern) && matches.size() > 1) {
+      std::string container_id = matches[1].str();
+      if (auto container = docker_api.get_by_id(container_id)) {
+        logs::log(logs::debug, "We are running as container ID {}", container_id);
+        return container;
+      } else {
+        logs::log(logs::debug, "Unable to find a valid Docker container ID in {}, checked {}", line, container_id);
+      }
+    }
+  }
+
+  logs::log(logs::warning, "No valid container ID found in mountinfo, are we running in Docker?");
+
+  return std::nullopt;
+}
+
+std::optional<std::string> get_host_path_for(const wolf::core::docker::Container &container,
+                                             std::string_view local_path) {
+  // return the first mount that matches local_path as the target
+  for (const auto &m : container.mounts) {
+    if (m.destination.find(local_path) != std::string::npos) {
+      // found a partial match, we have to check that the path is actually the same.
+      // for example if destination is `/etc/wolf/cfg/` and local_path is `/etc/wolf/` we should discard this
+      if (std::filesystem::path(local_path) == std::filesystem::path(m.destination)) {
+        logs::log(logs::info, "Detected mounted {} in the host as {}", local_path, m.source);
+        return m.source;
+      } else {
+        logs::log(logs::debug, "Found partial match but {} != {}", local_path, m.destination);
+      }
+    }
+  }
+  logs::log(logs::error, "Unable to find docker mount for path: {}", local_path);
+
+  return std::nullopt;
+}
+} // namespace introspect

--- a/src/moonlight-server/introspect/introspect.hpp
+++ b/src/moonlight-server/introspect/introspect.hpp
@@ -12,6 +12,7 @@ std::optional<wolf::core::docker::Container> get_current_container(const wolf::c
 /**
  * Resolves the host path corresponding to a given local path (if externally mounted).
  */
-std::optional<std::string> get_host_path_for(const wolf::core::docker::Container &container, std::string_view local_path);
+std::optional<std::string> get_host_path_for(const wolf::core::docker::Container &container,
+                                             std::string_view local_path);
 
 } // namespace introspect

--- a/src/moonlight-server/introspect/introspect.hpp
+++ b/src/moonlight-server/introspect/introspect.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <core/docker.hpp>
+
+namespace introspect {
+
+/**
+ * Returns the Docker container currently running this program (if any)
+ */
+std::optional<wolf::core::docker::Container> get_current_container(const wolf::core::docker::DockerAPI &docker_api);
+
+/**
+ * Resolves the host path corresponding to a given local path (if externally mounted).
+ */
+std::optional<std::string> get_host_path_for(const wolf::core::docker::Container &container, std::string_view local_path);
+
+} // namespace introspect

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -411,8 +411,7 @@ void appasset(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>
       response->write(SimpleWeb::StatusCode::client_error_not_found, "asset not found");
     }
   } else { // Assume it's a relative path (legacy setting)
-    std::string host_state_folder = utils::get_env("HOST_APPS_STATE_FOLDER", "/etc/wolf");
-    auto asset_path = std::filesystem::path(host_state_folder) / icon_path;
+    auto asset_path = std::filesystem::path(state->host->local_base_state_folder) / icon_path;
     if (auto file_content = get_file_content(asset_path)) {
       response->write(SimpleWeb::StatusCode::success_ok, file_content.value(), asset_headers);
     } else {

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -76,8 +76,6 @@ void RunDocker::run(std::size_t session_id,
         std::filesystem::permissions(udev_ctrl_path, std::filesystem::perms::all); // set 777
       }
     }
-    mounts.push_back(MountPoint{.source = udev_base_path.string(), .destination = "/run/udev/", .mode = "rw"});
-    mounts.push_back(MountPoint{.source = fake_udev_cli_path, .destination = "/usr/bin/fake-udev", .mode = "ro"});
   } else {
     logs::log(logs::warning,
               "[DOCKER] Unable to use fake-udev, check the env variable WOLF_DOCKER_FAKE_UDEV_PATH and the file at {}",

--- a/src/moonlight-server/state/data-structures.hpp
+++ b/src/moonlight-server/state/data-structures.hpp
@@ -111,6 +111,11 @@ struct Host {
    * The path in the current Wolf context (probably a container) where we are allowed to store data
    */
   std::string local_base_state_folder;
+
+  /**
+   * The path (or usually the Docker volume) on the host where we'll put the audio/video sockets
+   */
+  std::string host_xdg_runtime_dir;
 };
 
 enum class PAIR_PHASE {

--- a/src/moonlight-server/state/data-structures.hpp
+++ b/src/moonlight-server/state/data-structures.hpp
@@ -101,6 +101,16 @@ struct Host {
   // Network information can be manually set by users, if not, we'll automatically gather them
   std::optional<std::string> internal_ip;
   std::optional<std::string> mac_address;
+
+  /**
+   * The base path on the host where we are allowed to store data
+   */
+  std::string host_base_state_folder;
+
+  /**
+   * The path in the current Wolf context (probably a container) where we are allowed to store data
+   */
+  std::string local_base_state_folder;
 };
 
 enum class PAIR_PHASE {

--- a/src/moonlight-server/state/sessions.hpp
+++ b/src/moonlight-server/state/sessions.hpp
@@ -43,8 +43,8 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
                                                                     int audio_channel_count,
                                                                     const std::string &aes_key,
                                                                     const std::string &aes_iv) {
-  std::string host_state_folder = utils::get_env("HOST_APPS_STATE_FOLDER", "/etc/wolf");
-  auto full_path = std::filesystem::path(host_state_folder) / current_client.app_state_folder / run_app.base.title;
+  auto full_path = std::filesystem::path(state->host->local_base_state_folder) / current_client.app_state_folder /
+                   run_app.base.title;
   logs::log(logs::debug, "Host app state folder: {}, creating paths", full_path.string());
   std::filesystem::create_directories(full_path);
 
@@ -62,26 +62,29 @@ inline std::shared_ptr<events::StreamSession> create_stream_session(immer::box<s
   std::uniform_int_distribution<> ints(0, 255);
   auto rtsp_fake_ip = fmt::format("{}.{}.{}.{}", ints(generator), ints(generator), ints(generator), ints(generator));
 
-  auto session = events::StreamSession{.display_mode = display_mode,
-                                       .audio_channel_count = audio_channel_count,
-                                       .event_bus = state->event_bus,
-                                       .client_settings = current_client.settings,
-                                       .app = std::make_shared<events::App>(run_app),
-                                       .app_state_folder = full_path.string(),
+  auto session = events::StreamSession{
+      .display_mode = display_mode,
+      .audio_channel_count = audio_channel_count,
+      .event_bus = state->event_bus,
+      .client_settings = current_client.settings,
+      .app = std::make_shared<events::App>(run_app),
+      .app_local_state_folder = full_path.string(),
+      .app_host_state_folder = std::filesystem::path(state->host->host_base_state_folder) /
+                               current_client.app_state_folder / run_app.base.title,
 
-                                       .aes_key = aes_key,
-                                       .aes_iv = aes_iv,
+      .aes_key = aes_key,
+      .aes_iv = aes_iv,
 
-                                       // Moonlight protocol extension to support IP-less connections
-                                       .rtp_secret_payload = rtp_secret_payload,
-                                       .enet_secret_payload = uints(generator),
-                                       .rtsp_fake_ip = rtsp_fake_ip,
+      // Moonlight protocol extension to support IP-less connections
+      .rtp_secret_payload = rtp_secret_payload,
+      .enet_secret_payload = uints(generator),
+      .rtsp_fake_ip = rtsp_fake_ip,
 
-                                       // client info
-                                       .session_id = get_client_id(current_client),
-                                       .video_stream_port = static_cast<unsigned short>(get_port(VIDEO_PING_PORT)),
-                                       .audio_stream_port = static_cast<unsigned short>(get_port(AUDIO_PING_PORT)),
-                                       .control_stream_port = static_cast<unsigned short>(get_port(CONTROL_PORT))};
+      // client info
+      .session_id = get_client_id(current_client),
+      .video_stream_port = static_cast<unsigned short>(get_port(VIDEO_PING_PORT)),
+      .audio_stream_port = static_cast<unsigned short>(get_port(AUDIO_PING_PORT)),
+      .control_stream_port = static_cast<unsigned short>(get_port(CONTROL_PORT))};
 
   return std::make_shared<events::StreamSession>(session);
 }

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -10,6 +10,7 @@
 #include <immer/array_transient.hpp>
 #include <immer/map_transient.hpp>
 #include <immer/vector_transient.hpp>
+#include <introspect/introspect.hpp>
 #include <mdns_cpp/logger.hpp>
 #include <mdns_cpp/mdns.hpp>
 #include <memory>
@@ -60,12 +61,26 @@ state::Host get_host_config(std::string_view pkey_filename, std::string_view cer
     mac_address = override_mac;
   }
 
+  std::string local_base_state_folder = utils::get_env("HOST_APPS_STATE_FOLDER", "/etc/wolf");
+  std::string host_base_state_folder = local_base_state_folder;
+
+  docker::DockerAPI docker_api(utils::get_env("WOLF_DOCKER_SOCKET", "/var/run/docker.sock"));
+  if (auto container = introspect::get_current_container(docker_api)) {
+    host_base_state_folder =
+        introspect::get_host_path_for(*container, local_base_state_folder).value_or(local_base_state_folder);
+  } else {
+    logs::log(logs::warning,
+              "Unable to get the container that is running Wolf, automatic mounts matching is disabled.");
+  }
+
   return {state::DISPLAY_CONFIGURATIONS,
           state::AUDIO_CONFIGURATIONS,
           server_cert,
           server_pkey,
           internal_ip,
-          mac_address};
+          mac_address,
+          host_base_state_folder,
+          local_base_state_folder};
 }
 
 /**
@@ -333,7 +348,7 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
           }
 
           /* Adding custom state folder */
-          mounted_paths.push_back({session->app_state_folder, "/home/retro"});
+          mounted_paths.push_back({session->app_host_state_folder, "/home/retro"});
 
           /* GPU specific adjustments */
           auto render_node = session->app->render_node;
@@ -360,7 +375,7 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
           } else {
             /* Finally run the app, this will stop here until over */
             run_session->runner->run(session->session_id,
-                                     session->app_state_folder,
+                                     session->app_local_state_folder,
                                      *devices_q,
                                      all_devices.persistent(),
                                      mounted_paths.persistent(),

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -63,11 +63,14 @@ state::Host get_host_config(std::string_view pkey_filename, std::string_view cer
 
   std::string local_base_state_folder = utils::get_env("HOST_APPS_STATE_FOLDER", "/etc/wolf");
   std::string host_base_state_folder = local_base_state_folder;
+  std::string host_xdg_runtime_dir = utils::get_env("XDG_RUNTIME_DIR", "/tmp/sockets");
 
   docker::DockerAPI docker_api(utils::get_env("WOLF_DOCKER_SOCKET", "/var/run/docker.sock"));
   if (auto container = introspect::get_current_container(docker_api)) {
     host_base_state_folder =
         introspect::get_host_path_for(*container, local_base_state_folder).value_or(local_base_state_folder);
+    host_xdg_runtime_dir =
+        introspect::get_host_path_for(*container, host_xdg_runtime_dir).value_or(host_xdg_runtime_dir);
   } else {
     logs::log(logs::warning,
               "Unable to get the container that is running Wolf, automatic mounts matching is disabled.");
@@ -80,7 +83,8 @@ state::Host get_host_config(std::string_view pkey_filename, std::string_view cer
           internal_ip,
           mac_address,
           host_base_state_folder,
-          local_base_state_folder};
+          local_base_state_folder,
+          host_xdg_runtime_dir};
 }
 
 /**
@@ -112,7 +116,7 @@ struct AudioServer {
  * if that fails, we run our own PulseAudio container and connect to it
  * if that fails, we can't return an AudioServer, hence the optional!
  */
-std::optional<AudioServer> setup_audio_server(const std::string &runtime_dir) {
+std::optional<AudioServer> setup_audio_server(const std::string &host_runtime_dir, const std::string &runtime_dir) {
   auto audio_server = audio::connect();
   if (audio::connected(audio_server)) {
     return {{.server = audio_server}};
@@ -132,7 +136,7 @@ std::optional<AudioServer> setup_audio_server(const std::string &runtime_dir) {
             .image = utils::get_env("WOLF_PULSE_IMAGE", "ghcr.io/games-on-whales/pulseaudio:master"),
             .status = docker::CREATED,
             .ports = {},
-            .mounts = {docker::MountPoint{.source = runtime_dir, .destination = "/tmp/pulse/", .mode = "rw"}},
+            .mounts = {docker::MountPoint{.source = host_runtime_dir, .destination = "/tmp/pulse/", .mode = "rw"}},
             .env = {"XDG_RUNTIME_DIR=/tmp/pulse/", "UNAME=retro", "UID=1000", "GID=1000"}},
         // The following is needed when using podman (or any container that uses SELINUX). This way we can access the
         // socket that is created by PulseAudio from other containers (including this one).
@@ -331,10 +335,15 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
 
           auto pulse_sink_name = fmt::format("virtual_sink_{}", session->session_id);
           auto audio_server_name = audio_server ? audio::get_server_name(audio_server->server) : "";
+          // TODO: properly separate XDG_RUNTIME_DIR from <pulse socket path>
+          // for example on my dev machine it's ${XDG_RUNTIME_DIR}/pulse/native
+          // but we know that on our images it's ${XDG_RUNTIME_DIR}/pulse-socket so this should be fine..
+          auto audio_server_on_host = std::filesystem::path(app_state->host->host_xdg_runtime_dir) /
+                                      std::filesystem::path(audio_server_name).filename();
           full_env.set("PULSE_SINK", pulse_sink_name);
           full_env.set("PULSE_SOURCE", pulse_sink_name + ".monitor");
           full_env.set("PULSE_SERVER", audio_server_name);
-          mounted_paths.push_back({audio_server_name, audio_server_name});
+          mounted_paths.push_back({audio_server_on_host, audio_server_name});
 
           full_env.set("GAMESCOPE_WIDTH", std::to_string(session->display_mode.width));
           full_env.set("GAMESCOPE_HEIGHT", std::to_string(session->display_mode.height));
@@ -342,8 +351,9 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
 
           if (auto w_display = run_session->stream_session->wayland_display.get()) {
             auto socket_name = virtual_display::get_wayland_socket_name(*w_display->load().get());
-            auto wayland_socket = std::filesystem::path(runtime_dir) / socket_name;
-            mounted_paths.push_back({wayland_socket, wayland_socket});
+            auto local_wayland_socket = std::filesystem::path(runtime_dir) / socket_name;
+            auto host_wayland_socket = std::filesystem::path(app_state->host->host_xdg_runtime_dir) / socket_name;
+            mounted_paths.push_back({host_wayland_socket, local_wayland_socket});
             full_env.set("WAYLAND_DISPLAY", socket_name);
           }
 
@@ -502,7 +512,7 @@ void run() {
     }
   }).detach();
 
-  auto audio_server = setup_audio_server(runtime_dir);
+  auto audio_server = setup_audio_server(local_state->host->host_xdg_runtime_dir, runtime_dir);
   auto sess_handlers = setup_sessions_handlers(local_state, runtime_dir, audio_server);
 
   http_thread.join(); // Let's park the main thread over here

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -378,6 +378,11 @@ auto setup_sessions_handlers(const immer::box<state::AppState> &app_state,
           full_env.set("PUID", std::to_string(session->client_settings->run_uid));
           full_env.set("PGID", std::to_string(session->client_settings->run_gid));
 
+          // Add fake-udev and udev mounts
+          mounted_paths.push_back(
+              {std::filesystem::path(app_state->host->host_base_state_folder) / "fake-udev", "/usr/bin/fake-udev"});
+          mounted_paths.push_back({std::filesystem::path(session->app_host_state_folder) / "udev", "/run/udev/"});
+
           auto devices_q = plugged_devices_queue->load()->find(session->session_id);
           if (!devices_q) {
             logs::log(logs::warning, "No devices queue found for session {}", session->session_id);

--- a/tests/docker/testDocker.cpp
+++ b/tests/docker/testDocker.cpp
@@ -359,7 +359,7 @@ TEST_CASE("Parse nulls in json reply", "[DOCKER]") {
   REQUIRE(parsed_container.mounts.size() == 1);
   REQUIRE_THAT(parsed_container.mounts[0].source, Equals("/tmp/sockets"));
   REQUIRE_THAT(parsed_container.mounts[0].destination, Equals("/tmp/pulse/"));
-  REQUIRE_THAT(parsed_container.mounts[0].mode, Equals("rw,rprivate,rbind"));
+  REQUIRE_THAT(parsed_container.mounts[0].mode, Equals(""));
 
   REQUIRE(parsed_container.devices.size() == 0);
 


### PR DESCRIPTION
In this PR:
 - Removed the need for `HOST_APPS_STATE_FOLDER` and automagically detect where `/etc/wolf` is mounted so that you can just mount `/a/folder:/etc/wolf` and Wolf will automatically detect that `/a/folder` is the path on the host and adjust the app mounts accordingly.
 - Removed the need to set and mount `XDG_RUNTIME_DIR`, Docker will automatically create a volume and Wolf can automagically detect which volume it is and mount the right sockets to the corresponding app containers.


TODO:
- [x] Update docs
- [x] Test and feedback?

