### PR TITLE
Support 2/6/8 channel audio with correct GStreamer masks in  streamin…

### DIFF
--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -116,16 +116,23 @@ void start_audio_producer(std::size_t session_id,
                           const std::string &sink_name,
                           const std::string &server_name) {
   std::string channel_mask;
-  switch(channel_count) {
-    case 2: channel_mask = "0x3"; break;
-    case 6: channel_mask = "0x3f"; break;
-    case 8: channel_mask = "0xc3f"; break;
-    default: channel_mask = "";
+  switch (channel_count) {
+  case 2:
+    channel_mask = "0x3";
+    break;
+  case 6:
+    channel_mask = "0x3f";
+    break;
+  case 8:
+    channel_mask = "0xc3f";
+    break;
+  default:
+    channel_mask = "";
   }
-  
-  auto pipeline = fmt::format("pulsesrc device=\"{sink_name}\" server=\"{server_name}\" ! " //
-                              "audio/x-raw, channels={channels}, channel-mask=(bitmask){channel_mask}, rate=48000 ! "             //
-                              "queue leaky=downstream max-size-buffers=3 ! "                //
+
+  auto pipeline = fmt::format("pulsesrc device=\"{sink_name}\" server=\"{server_name}\" ! "                           //
+                              "audio/x-raw, channels={channels}, channel-mask=(bitmask){channel_mask}, rate=48000 ! " //
+                              "queue leaky=downstream max-size-buffers=3 ! "                                          //
                               "interpipesink name=\"{session_id}_audio\" sync=true async=false max-buffers=3",
                               fmt::arg("session_id", session_id),
                               fmt::arg("channels", channel_count),

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -115,12 +115,21 @@ void start_audio_producer(std::size_t session_id,
                           int channel_count,
                           const std::string &sink_name,
                           const std::string &server_name) {
+  std::string channel_mask;
+  switch(channel_count) {
+    case 2: channel_mask = "0x3"; break;
+    case 6: channel_mask = "0x3f"; break;
+    case 8: channel_mask = "0xc3f"; break;
+    default: channel_mask = "";
+  }
+  
   auto pipeline = fmt::format("pulsesrc device=\"{sink_name}\" server=\"{server_name}\" ! " //
-                              "audio/x-raw, channels={channels}, rate=48000 ! "             //
+                              "audio/x-raw, channels={channels}, channel-mask=(bitmask){channel_mask}, rate=48000 ! "             //
                               "queue leaky=downstream max-size-buffers=3 ! "                //
                               "interpipesink name=\"{session_id}_audio\" sync=true async=false max-buffers=3",
                               fmt::arg("session_id", session_id),
                               fmt::arg("channels", channel_count),
+                              fmt::arg("channel_mask", channel_mask),
                               fmt::arg("sink_name", sink_name),
                               fmt::arg("server_name", server_name));
   logs::log(logs::debug, "[GSTREAMER] Starting audio producer: {}", pipeline);


### PR DESCRIPTION
…g.cpp

### What this PR does
- Adds dynamic channel mask support in `start_audio_producer()` based on the number of channels.
- When `channel_count = 2`, applies standard stereo mask (`0x3`).
- When `channel_count = 6`, applies 5.1 surround mask (`0x3f`).
- When `channel_count = 8`, applies 7.1 surround mask (`0xc3f`).

### Why this is needed
- Ensures proper channel mapping when processing multi-channel audio in GStreamer.
- Prevents undefined behavior with unmasked multi-channel audio.
- Keeps compatibility with standard surround sound layouts.