### PR TITLE
Fix missing video_producer_buffer_caps field in API schema and handlers

### DIFF
--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -96,14 +96,18 @@ void UnixSocketServer::endpoint_AddApp(const HTTPRequest &req, std::shared_ptr<U
       auto runner =
           state::get_runner(app.runner, this->state_->app_state->event_bus, this->state_->app_state->running_sessions);
       return apps.push_back(events::App{
-          .base =
-              {.title = app.title, .id = app.id, .support_hdr = app.support_hdr, .icon_png_path = app.icon_png_path},
-          .h264_gst_pipeline = app.h264_gst_pipeline,
-          .hevc_gst_pipeline = app.hevc_gst_pipeline,
-          .av1_gst_pipeline = app.av1_gst_pipeline,
-          .render_node = app.render_node,
-          .opus_gst_pipeline = app.opus_gst_pipeline,
-          .start_virtual_compositor = app.start_virtual_compositor,
+          .base = {.title = app.title,
+                   .id = app.id,
+                   .support_hdr = app.support_hdr.value_or(false), // Default to false
+                   .icon_png_path = app.icon_png_path},
+          .video_producer_buffer_caps = app.video_producer_buffer_caps.value_or("video/x-raw(memory:DMABuf)"), // Default for NVIDIA GPU zero-copy
+          .h264_gst_pipeline = app.h264_gst_pipeline.value_or("interpipesrc listen-to={session_id}_video is-live=true stream-sync=restart-ts max-bytes=0 max-buffers=1 leaky-type=downstream ! video/x-raw, width={width}, height={height}, framerate={fps}/1 ! nvh264enc preset=low-latency-hq zerolatency=true gop-size=0 rc-mode=cbr-ld-hq bitrate={bitrate} aud=false ! h264parse ! video/x-h264, profile=main, stream-format=byte-stream ! rtpmoonlightpay_video name=moonlight_pay payload_size={payload_size} fec_percentage={fec_percentage} min_required_fec_packets={min_required_fec_packets} ! appsink sync=false name=wolf_udp_sink"),
+          .hevc_gst_pipeline = app.hevc_gst_pipeline.value_or(""),  // Empty when HEVC not available (matches TOML)
+          .av1_gst_pipeline = app.av1_gst_pipeline.value_or(""),    // Empty when AV1 not available (matches TOML)
+          .render_node = app.render_node.value_or("/dev/dri/renderD128"),  // Use system default
+          .opus_gst_pipeline = app.opus_gst_pipeline.value_or("interpipesrc listen-to={session_id}_audio is-live=true stream-sync=restart-ts max-bytes=0 max-buffers=3 block=false ! queue max-size-buffers=3 leaky=downstream ! audiorate ! audioconvert ! opusenc bitrate={bitrate} bitrate-type=cbr frame-size={packet_duration} bandwidth=fullband audio-type=restricted-lowdelay max-payload-size=1400 ! rtpmoonlightpay_audio name=moonlight_pay packet_duration={packet_duration} encrypt={encrypt} aes_key=\"{aes_key}\" aes_iv=\"{aes_iv}\" ! appsink name=wolf_udp_sink"),
+          .start_virtual_compositor = app.start_virtual_compositor.value_or(true), // Default to true
+          .start_audio_server = app.start_audio_server.value_or(true), // Default to true
           .runner = runner,
       });
     });

--- a/src/moonlight-server/events/reflectors.hpp
+++ b/src/moonlight-server/events/reflectors.hpp
@@ -30,18 +30,23 @@ template <> struct Reflector<events::App> {
   struct ReflType {
     const std::string title;
     const std::string id;
-    const bool support_hdr;
+    // Make support_hdr optional to match TOML config behavior
+    std::optional<bool> support_hdr;
     std::optional<std::string> icon_png_path;
 
-    std::string h264_gst_pipeline;
-    std::string hevc_gst_pipeline;
-    std::string av1_gst_pipeline;
+    // Make GStreamer pipeline fields optional to match TOML config behavior
+    // This fixes the "Field not found" errors when these are omitted (like XFCE config)
+    std::optional<std::string> h264_gst_pipeline;
+    std::optional<std::string> hevc_gst_pipeline;
+    std::optional<std::string> av1_gst_pipeline;
 
-    std::string render_node;
+    std::optional<std::string> render_node;
+    std::optional<std::string> video_producer_buffer_caps;
 
-    std::string opus_gst_pipeline;
-    bool start_virtual_compositor;
-    bool start_audio_server;
+    std::optional<std::string> opus_gst_pipeline;
+    // Make compositor/audio optional to match TOML config behavior
+    std::optional<bool> start_virtual_compositor;
+    std::optional<bool> start_audio_server;
     rfl::TaggedUnion<"type", AppCMD, AppDocker, AppChildSession> runner;
   };
 
@@ -54,6 +59,7 @@ template <> struct Reflector<events::App> {
             .hevc_gst_pipeline = v.hevc_gst_pipeline,
             .av1_gst_pipeline = v.av1_gst_pipeline,
             .render_node = v.render_node,
+            .video_producer_buffer_caps = v.video_producer_buffer_caps,
             .opus_gst_pipeline = v.opus_gst_pipeline,
             .start_virtual_compositor = v.start_virtual_compositor,
             .start_audio_server = v.start_audio_server,


### PR DESCRIPTION
  ### Problem
  API-created apps generate malformed GStreamer video producer pipelines due to missing
  `video_producer_buffer_caps` field in the API, while TOML-loaded apps work correctly.

  **Malformed pipeline example:**
  waylanddisplaysrc render_node=/dev/dri/renderD128 ! , width=3840, height=2160
  (Note the stray comma from empty buffer_format parameter)

  ### Root Cause
  The API was missing `video_producer_buffer_caps` field in three critical places:
  1. **API Schema** (reflectors.hpp): ReflType struct missing field
  2. **Response Serialization** (reflectors.hpp): from() method omitting field
  3. **Request Deserialization** (endpoints.cpp): endpoint_AddApp not populating field

  ### Solution

  #### 1. Make API Schema Match TOML Flexibility (reflectors.hpp)
  - **Add missing field**: `std::optional<std::string> video_producer_buffer_caps`
  - **Make all fields optional**: Changed required fields to `std::optional<>` to match
  TOML config behavior
    - `support_hdr`: `bool` → `std::optional<bool>`
    - `h264/hevc/av1_gst_pipeline`: `string` → `std::optional<string>`
    - `render_node`: `string` → `std::optional<string>`
    - `opus_gst_pipeline`: `string` → `std::optional<string>`
    - `start_virtual_compositor`: `bool` → `std::optional<bool>`
    - `start_audio_server`: `bool` → `std::optional<bool>`
  - **Add field to serialization**: Include `video_producer_buffer_caps` in from()
  method

  #### 2. Add Comprehensive Defaults (endpoints.cpp)
  - **video_producer_buffer_caps**: `"video/x-raw(memory:DMABuf)"` (NVIDIA GPU
  zero-copy)
  - **support_hdr**: `false`
  - **h264_gst_pipeline**: Full NVIDIA pipeline with nvh264enc
  - **hevc/av1_gst_pipeline**: `""` (empty when not available, matches TOML)
  - **render_node**: `"/dev/dri/renderD128"`
  - **opus_gst_pipeline**: Full audio pipeline with opusenc
  - **start_virtual_compositor**: `true`
  - **start_audio_server**: `true`

  ### Benefits
  - **Fixes streaming**: API-created apps now generate proper GStreamer pipelines
  - **TOML compatibility**: API behavior now matches TOML config defaults
  - **Backwards compatible**: Missing fields get sensible defaults
  - **GPU optimized**: Uses DMABuf for zero-copy performance on NVIDIA
  - **Robust**: Comprehensive defaults prevent malformed configurations

  ### Testing
  - ✅ TOML apps: Continue working as before
  - ✅ API apps: Now generate proper pipelines and stream successfully
  - ✅ Minimal requests: Work with comprehensive defaults
  - ✅ Full requests: Explicit values override defaults correctly
