### PR TITLE
Update GPU deployment configuration in quickstart

### DIFF
--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -118,12 +118,13 @@ services:
       - /dev/dri
       - /dev/uinput
       - /dev/uhid
-    runtime: nvidia
     deploy:
       resources:
         reservations:
           devices:
-            - capabilities: [gpu]
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     network_mode: host
     restart: unless-stopped
 ....


### PR DESCRIPTION
`runtime: nvidia` is deprecated

Tested, working

```sh
[2025-10-23 22:01:37] 
[2025-10-23 22:01:37] [ /etc/cont-init.d/10-setup_user.sh: executing... ]
[2025-10-23 22:01:37] **** Configure default user ****
[2025-10-23 22:01:37] Container running as root. Nothing to do.
[2025-10-23 22:01:37] DONE
[2025-10-23 22:01:37] 
[2025-10-23 22:01:37] [ /etc/cont-init.d/15-setup_devices.sh: executing... ]
[2025-10-23 22:01:37] **** Configure devices ****
[2025-10-23 22:01:37] Exec device groups
[2025-10-23 22:01:37] Adding user 'root' to groups: polkitd,root
[2025-10-23 22:01:37] DONE
[2025-10-23 22:01:37] 
[2025-10-23 22:01:37] [ /etc/cont-init.d/30-nvidia.sh: executing... ]
[2025-10-23 22:01:37] Nvidia driver detected, assuming it's using the nvidia driver volume
[2025-10-23 22:01:37] Creating symlink to nvidia-drm_gbm.so
'/usr/lib/x86_64-linux-gnu/gbm/nvidia-drm_gbm.so' -> '../libnvidia-allocator.so.1'
[2025-10-23 22:01:37] Creating json 10_nvidia.json file
[2025-10-23 22:01:37] Creating json nvidia_icd.json file
[2025-10-23 22:01:37] 
[2025-10-23 22:01:37] [ /etc/cont-init.d/init-gamescope.sh: executing... ]
[2025-10-23 22:01:37] Launching the container's startup script as user 'root'
0:00:00.013025725    99 0x5813a25945c0 WARN                 default gstvaapi.c:232:plugin_init: Cannot create a VA display
0:00:00.022500872    99 0x5813a25945c0 WARN               vadisplay gstvadisplay.c:401:gst_va_display_initialize:<vadisplaydrm0> vaInitialize: unknown libva error
0:00:00.041102913    99 0x5813a25945c0 WARN               vadisplay gstvadisplay.c:401:gst_va_display_initialize:<vadisplaydrm1> vaInitialize: unknown libva error
0:00:00.058044160    99 0x5813a25945c0 WARN                 default ges-meta-container.c:238:_set_value:<GESAsset@0x5813a28ec480> Could not set value on item: format-version
0:00:00.058059119    99 0x5813a25945c0 WARN                 default ges-meta-container.c:238:_set_value:<GESAsset@0x5813a28ecdb0> Could not set value on item: format-version
0:00:00.058063867    99 0x5813a25945c0 WARN                 default ges-meta-container.c:238:_set_value:<GESAsset@0x5813a28ed620> Could not set value on item: format-version
0:00:00.058318737    99 0x5813a25945c0 WARN               structure gststructure.c:3372:priv_gst_structure_parse_fields: Failed to find delimiter, r=mimetype
0:00:00.092684521    99 0x5813a25945c0 WARN               cudanvrtc gstcudanvrtc.cpp:179:gst_cuda_nvrtc_load_library_once: Failed to load 'nvrtcGetCUBINSize', 'nvrtcGetCUBINSize': /usr/local/nvidia/lib/libnvrtc.so: undefined symbol: nvrtcGetCUBINSize
0:00:01.157713089    99 0x5813a25945c0 WARN            nvav1encoder gstnvav1encoder.cpp:1429:gst_nv_av1_encoder_create_class_data:<cudacontext0> New preset is not supported
0:00:01.516760115    99 0x5813a25945c0 WARN             msdkcontext gstmsdkcontext.c:178:gst_msdk_context_use_vaapi: Couldn't find a drm device node to open
0:00:01.542659998    99 0x5813a25945c0 WARN      GST_PLUGIN_LOADING gstplugin.c:546:gst_plugin_register_func: plugin "/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/validate/libgstvalidatessim.so" failed to initialise
0:00:01.545290515    99 0x5813a25945c0 WARN      GST_PLUGIN_LOADING gstplugin.c:546:gst_plugin_register_func: plugin "/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvalidatessim.so" failed to initialise
0:00:01.549981666     1 0x610c98ae59b0 WARN            GST_REGISTRY gstregistry.c:457:gst_registry_add_plugin:<registry0> Not replacing plugin because new one (/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvalidatessim.so) is blacklisted but for a different location than existing one (/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/validate/libgstvalidatessim.so)
0:00:01.554918941    99 0x5813a25945c0 WARN      GST_PLUGIN_LOADING gstplugin.c:546:gst_plugin_register_func: plugin "/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/validate/libgstvalidatessim.so" failed to initialise
0:00:01.554959136    99 0x5813a25945c0 WARN      GST_PLUGIN_LOADING gstplugin.c:546:gst_plugin_register_func: plugin "/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvalidatessim.so" failed to initialise
0:00:01.559508150     1 0x610c98ae59b0 WARN            GST_REGISTRY gstregistry.c:457:gst_registry_add_plugin:<registry0> Not replacing plugin because new one (/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/libgstvalidatessim.so) is blacklisted but for a different location than existing one (/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/validate/libgstvalidatessim.so)
21:01:39.508259656 INFO  | Gstreamer version: 1.26.2-0
21:01:39.509819279 INFO  | Reading config file from: /etc/wolf/cfg/config.toml
0:00:01.617170182     1 0x610c98ae59b0 WARN               cudanvrtc gstcudanvrtc.cpp:179:gst_cuda_nvrtc_load_library_once: Failed to load 'nvrtcGetCUBINSize', 'nvrtcGetCUBINSize': /usr/local/nvidia/lib/libnvrtc.so: undefined symbol: nvrtcGetCUBINSize
0:00:02.582049003     1 0x610c98ae59b0 WARN            nvav1encoder gstnvav1encoder.cpp:1429:gst_nv_av1_encoder_create_class_data:<cudacontext0> New preset is not supported
21:01:40.813615502 INFO  | Using H264 encoder: nvcodec
21:01:40.813808035 INFO  | Using HEVC encoder: nvcodec
0:00:02.894523099     1 0x610c98ae59b0 WARN     GST_ELEMENT_FACTORY gstelementfactory.c:712:gst_element_factory_make_with_properties: no such element factory "nvav1enc"!
21:01:40.814803817 INFO  | Using AV1 encoder: aom
21:01:40.814812593 WARN  | Software AV1 encoder detected
21:01:40.814869280 INFO  | Using zero copy pipeline on Nvidia (/dev/dri/renderD128)
21:01:40.819452318 INFO  | Detected mounted /etc/wolf in the host as /srv/gaming_appdata/wolf
21:01:40.819463860 INFO  | Detected mounted /run/user/wolf in the host as /var/lib/docker/volumes/79f86f4e9838cdb4f314e4753049ef823579aba32ff3ff2b1686ae8a464691ad/_data
21:01:40.819597933 INFO  | [RTP] Starting RTP ping server on ports 48100 and 48200
21:01:40.819674386 INFO  | RTSP server started on port: 48010
21:01:40.819807135 INFO  | Starting API server on /tmp/wolf.sock
21:01:40.819828166 INFO  | HTTP server listening on port: 47989 
21:01:40.819846710 INFO  | Starting mDNS service
21:01:40.819903187 INFO  | Control server started on port: 47999
21:01:40.820506530 WARN  | [PULSE] Unable to connect, Access denied
21:01:40.820560022 INFO  | Starting PulseAudio docker container
21:01:40.821162614 INFO  | HTTPS server listening on port: 47984 
21:01:40.821789062 WARN  | [DOCKER] Container WolfPulseAudio already present, removing first
alessio@media-server:/opt/gaming-server$ 
```