### PR TITLE
enhancement: Update API version from 1.40 to 1.50

### DIFF
--- a/docs/modules/user/pages/configuration.adoc
+++ b/docs/modules/user/pages/configuration.adoc
@@ -277,7 +277,7 @@ base_create_json = """
 
 <1> *mounts*: Here you can define any additional mount that you want to add to the container.
 For example, you can add `mounts = ["/media/data/games:/games:rw"]` if you want to share games files between host and app container.
-<2> *base_create_json*: here you can re-define any property that's defined in the docker API JSON format, see: https://docs.docker.com/engine/api/v1.40/#tag/Container/operation/ContainerCreate[docs.docker.com/engine/api/v1.40]
+<2> *base_create_json*: here you can re-define any property that's defined in the docker API JSON format, see: https://docs.docker.com/engine/api/v1.50/#tag/Container/operation/ContainerCreate[docs.docker.com/engine/api/v1.50]
 
 [#_gstreamer]
 === Gstreamer

--- a/src/core/src/core/docker.hpp
+++ b/src/core/src/core/docker.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 namespace wolf::core::docker {
-constexpr auto DOCKER_API_VERSION = "v1.40";
+constexpr auto DOCKER_API_VERSION = "v1.50";
 
 enum ContainerStatus {
   CREATED,
@@ -140,7 +140,7 @@ public:
 
   /**
    * Get the container logs
-   * https://docs.docker.com/engine/api/v1.40/#tag/Container/operation/ContainerLogs
+   * https://docs.docker.com/engine/api/v1.50/#tag/Container/operation/ContainerLogs
    */
   std::string get_logs(std::string_view id,
                        bool get_stdout = true,


### PR DESCRIPTION
Docker recently pushed an update that doesn't allow the current version to work. API is basically intact, so a simple version rewrite is sufficient.