### PR TITLE
Fix stuck modifier keys when triggering Wolf UI overlay combo

### DIFF
--- a/src/core/src/core/virtual-display.hpp
+++ b/src/core/src/core/virtual-display.hpp
@@ -27,6 +27,10 @@ bool add_input_device(WaylandState &w_state, const std::string &device_path);
 class WaylandMouse {
 public:
   WaylandMouse(wl_state_ptr w_state) : w_state(w_state) {};
+  WaylandMouse(WaylandMouse &&j) noexcept : w_state(nullptr) {
+    std::swap(j.w_state, w_state);
+  }
+  ~WaylandMouse();
 
   void move(int delta_x, int delta_y);
 
@@ -47,6 +51,10 @@ private:
 class WaylandKeyboard {
 public:
   WaylandKeyboard(wl_state_ptr w_state) : w_state(w_state) {};
+  WaylandKeyboard(WaylandKeyboard &&j) noexcept : w_state(nullptr) {
+    std::swap(j.w_state, w_state);
+  }
+  ~WaylandKeyboard();
 
   void press(unsigned int key_code);
 
@@ -59,6 +67,10 @@ private:
 class WaylandTouchScreen {
 public:
   WaylandTouchScreen(wl_state_ptr w_state) : w_state(w_state) {};
+  WaylandTouchScreen(WaylandTouchScreen &&j) noexcept : w_state(nullptr) {
+    std::swap(j.w_state, w_state);
+  }
+  ~WaylandTouchScreen();
 
   void down(unsigned int touch_id, double x, double y);
 

--- a/src/core/src/platforms/linux/virtual-display/gst-wayland-display.cpp
+++ b/src/core/src/platforms/linux/virtual-display/gst-wayland-display.cpp
@@ -4,6 +4,7 @@
 
 #include <core/virtual-display.hpp>
 #include <linux/input-event-codes.h>
+#include <set>
 
 namespace wolf::core::virtual_display {
 struct WaylandState {
@@ -14,6 +15,16 @@ struct WaylandState {
   gstreamer::gst_element_ptr wayland_plugin;
 
   std::string wayland_socket_name;
+
+  /**
+   * A list of currently pressed keyboard keycodes
+   */
+  std::set<unsigned int> pressed_keys;
+
+  /**
+   * A list of currently pressed mouse buttons
+   */
+  std::set<unsigned int> pressed_buttons;
 };
 
 wl_state_ptr create_wayland_display(gstreamer::gst_element_ptr wayland_plugin, const std::string &wayland_socket_name) {
@@ -66,7 +77,19 @@ unsigned int moonlight_button_to_linux(unsigned int button) {
   }
 }
 
+WaylandMouse::~WaylandMouse() {
+  if (w_state) {
+    // Release all currently pressed buttons
+    // We have to copy here because we are erasing from the set
+    std::vector keys_to_release(w_state->pressed_buttons.begin(), w_state->pressed_buttons.end());
+    for (const auto key : keys_to_release) {
+      release(key);
+    }
+  }
+}
+
 void WaylandMouse::press(unsigned int button) {
+  w_state->pressed_buttons.insert(button);
   auto msg = /* clang-format off */
                           gst_structure_new("MouseButton",
                             "button", G_TYPE_UINT, moonlight_button_to_linux(button),
@@ -77,6 +100,7 @@ void WaylandMouse::press(unsigned int button) {
 }
 
 void WaylandMouse::release(unsigned int button) {
+  w_state->pressed_buttons.erase(button);
   auto msg = /* clang-format off */
                           gst_structure_new("MouseButton",
                             "button", G_TYPE_UINT, moonlight_button_to_linux(button),
@@ -169,8 +193,21 @@ static const std::map<unsigned int, unsigned int> key_mappings = {
     {0xDE, KEY_APOSTROPHE}, {0xE2, KEY_102ND},
 };
 
+WaylandKeyboard::~WaylandKeyboard() {
+  if (w_state) {
+    // Release all currently pressed keys
+    // We have to copy here because we are erasing from the set
+    std::vector keys_to_release(w_state->pressed_keys.begin(), w_state->pressed_keys.end());
+    for (const auto key : keys_to_release) {
+      release(key);
+    }
+  }
+}
+
 void WaylandKeyboard::press(unsigned int key_code) {
   if (key_mappings.contains(key_code)) {
+    w_state->pressed_keys.insert(key_code);
+
     auto msg = /* clang-format off */
                            gst_structure_new("KeyboardKey",
                              "key", G_TYPE_UINT, key_mappings.at(key_code),
@@ -185,6 +222,9 @@ void WaylandKeyboard::press(unsigned int key_code) {
 
 void WaylandKeyboard::release(unsigned int key_code) {
   if (key_mappings.contains(key_code)) {
+    // update pressed_keys
+    w_state->pressed_keys.erase(key_code);
+
     auto msg = /* clang-format off */
                            gst_structure_new("KeyboardKey",
                              "key", G_TYPE_UINT, key_mappings.at(key_code),
@@ -194,6 +234,12 @@ void WaylandKeyboard::release(unsigned int key_code) {
     gstreamer::send_message(w_state->wayland_plugin.get(), msg);
   } else {
     logs::log(logs::warning, "Key code not found: {}", key_code);
+  }
+}
+
+WaylandTouchScreen::~WaylandTouchScreen() {
+  if (w_state) {
+    cancel();
   }
 }
 

--- a/src/moonlight-server/control/input_handler.cpp
+++ b/src/moonlight-server/control/input_handler.cpp
@@ -345,49 +345,64 @@ void mouse_h_scroll(const MOUSE_HSCROLL_PACKET &pkt, events::StreamSession &sess
 void keyboard_key(const KEYBOARD_PACKET &pkt, events::StreamSession &session) {
   // moonlight always sets the high bit; not sure why but mask it off here
   short moonlight_key = (short)boost::endian::little_to_native(pkt.key_code) & (short)0x7fff;
-  int wolf_ui_combo_pressed = 0;
-  if (session.keyboard->has_value()) {
-    if (pkt.type == KEY_PRESS) {
-      // Press the virtual modifiers
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && moonlight_key != M_SHIFT) {
-        wolf_ui_combo_pressed++;
-        std::visit([](auto &keyboard) { keyboard.press(M_SHIFT); }, session.keyboard->value());
-      }
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && moonlight_key != M_CTRL) {
-        wolf_ui_combo_pressed++;
-        std::visit([](auto &keyboard) { keyboard.press(M_CTRL); }, session.keyboard->value());
-      }
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && moonlight_key != M_ALT) {
-        wolf_ui_combo_pressed++;
-        std::visit([](auto &keyboard) { keyboard.press(M_ALT); }, session.keyboard->value());
-      }
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::META && moonlight_key != M_META)
-        std::visit([](auto &keyboard) { keyboard.press(M_META); }, session.keyboard->value());
 
-      // CTRL + ALT + SHIFT + W
-      if (wolf_ui_combo_pressed == 3 && moonlight_key == 0x57) {
-        session.event_bus->fire_event(immer::box<events::ClientWolfUIComboEvent>{
-            events::ClientWolfUIComboEvent{.session_id = session.session_id}});
-      }
-
-      // Press the actual key
-      std::visit([moonlight_key](auto &keyboard) { keyboard.press(moonlight_key); }, session.keyboard->value());
-
-      // Release the virtual modifiers
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && moonlight_key != M_SHIFT)
-        std::visit([](auto &keyboard) { keyboard.release(M_SHIFT); }, session.keyboard->value());
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && moonlight_key != M_CTRL)
-        std::visit([](auto &keyboard) { keyboard.release(M_CTRL); }, session.keyboard->value());
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && moonlight_key != M_ALT)
-        std::visit([](auto &keyboard) { keyboard.release(M_ALT); }, session.keyboard->value());
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::META && moonlight_key != M_META)
-        std::visit([](auto &keyboard) { keyboard.release(M_META); }, session.keyboard->value());
-
-    } else {
-      std::visit([moonlight_key](auto &keyboard) { keyboard.release(moonlight_key); }, session.keyboard->value());
-    }
-  } else {
+  if (!session.keyboard->has_value()) {
     logs::log(logs::warning, "Received KEYBOARD_PACKET but no keyboard device is present");
+    return;
+  }
+
+  if (pkt.type == KEY_PRESS) {
+    int wolf_ui_combo_pressed = 0;
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && moonlight_key != M_SHIFT)
+      wolf_ui_combo_pressed++;
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && moonlight_key != M_CTRL)
+      wolf_ui_combo_pressed++;
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && moonlight_key != M_ALT)
+      wolf_ui_combo_pressed++;
+
+    // CTRL + ALT + SHIFT + W
+    const bool wolf_ui_combo = (wolf_ui_combo_pressed == 3 && moonlight_key == 0x57);
+
+    if (wolf_ui_combo) {
+      // Ensure modifiers are released before we return to overlay
+      if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT)
+        std::visit([](auto &keyboard) { keyboard.release(M_SHIFT); }, session.keyboard->value());
+      if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL)
+        std::visit([](auto &keyboard) { keyboard.release(M_CTRL); }, session.keyboard->value());
+      if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT)
+        std::visit([](auto &keyboard) { keyboard.release(M_ALT); }, session.keyboard->value());
+
+      session.event_bus->fire_event(immer::box<events::ClientWolfUIComboEvent>{
+          events::ClientWolfUIComboEvent{.session_id = session.session_id}
+      });
+      return;
+    }
+
+    // Press the virtual modifiers
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && moonlight_key != M_SHIFT)
+      std::visit([](auto &keyboard) { keyboard.press(M_SHIFT); }, session.keyboard->value());
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && moonlight_key != M_CTRL)
+      std::visit([](auto &keyboard) { keyboard.press(M_CTRL); }, session.keyboard->value());
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && moonlight_key != M_ALT)
+      std::visit([](auto &keyboard) { keyboard.press(M_ALT); }, session.keyboard->value());
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::META && moonlight_key != M_META)
+      std::visit([](auto &keyboard) { keyboard.press(M_META); }, session.keyboard->value());
+
+    // Press the actual key
+    std::visit([moonlight_key](auto &keyboard) { keyboard.press(moonlight_key); }, session.keyboard->value());
+
+    // Release the virtual modifiers
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && moonlight_key != M_SHIFT)
+      std::visit([](auto &keyboard) { keyboard.release(M_SHIFT); }, session.keyboard->value());
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && moonlight_key != M_CTRL)
+      std::visit([](auto &keyboard) { keyboard.release(M_CTRL); }, session.keyboard->value());
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && moonlight_key != M_ALT)
+      std::visit([](auto &keyboard) { keyboard.release(M_ALT); }, session.keyboard->value());
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::META && moonlight_key != M_META)
+      std::visit([](auto &keyboard) { keyboard.release(M_META); }, session.keyboard->value());
+
+  } else {
+    std::visit([moonlight_key](auto &keyboard) { keyboard.release(moonlight_key); }, session.keyboard->value());
   }
 }
 

--- a/src/moonlight-server/control/input_handler.cpp
+++ b/src/moonlight-server/control/input_handler.cpp
@@ -362,19 +362,17 @@ void keyboard_key(const KEYBOARD_PACKET &pkt, events::StreamSession &session) {
 
     // CTRL + ALT + SHIFT + W
     const bool wolf_ui_combo = (wolf_ui_combo_pressed == 3 && moonlight_key == 0x57);
-
     if (wolf_ui_combo) {
       // Ensure modifiers are released before we return to overlay
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT)
-        std::visit([](auto &keyboard) { keyboard.release(M_SHIFT); }, session.keyboard->value());
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL)
-        std::visit([](auto &keyboard) { keyboard.release(M_CTRL); }, session.keyboard->value());
-      if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT)
-        std::visit([](auto &keyboard) { keyboard.release(M_ALT); }, session.keyboard->value());
-
-      session.event_bus->fire_event(immer::box<events::ClientWolfUIComboEvent>{
-          events::ClientWolfUIComboEvent{.session_id = session.session_id}
-      });
+      std::visit(
+          [](auto &keyboard) {
+            keyboard.release(M_SHIFT);
+            keyboard.release(M_CTRL);
+            keyboard.release(M_ALT);
+          },
+          session.keyboard->value());
+      session.event_bus->fire_event(
+          immer::box<events::ClientWolfUIComboEvent>{events::ClientWolfUIComboEvent{.session_id = session.session_id}});
       return;
     }
 


### PR DESCRIPTION
Triggering the Wolf UI overlay via the CTRL + ALT + SHIFT + W escape sequence causes the currently active application to get stuck modifier keys. This happens because the current escape sequence implementation disconnects from the lobby before the keys can be released.

This PR ensures the combo is never sent to the application and that modifier keys are properly released before handing the user session back to the Wolf UI overlay.