### PR TITLE
Pause/Resume containers

### DIFF
--- a/.devcontainer/dev-setup.sh
+++ b/.devcontainer/dev-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 export DEBIAN_FRONTEND=noninteractive
 

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+source_env .envrc.local
+
+use flake

--- a/.envrc.local.sample
+++ b/.envrc.local.sample
@@ -1,0 +1,1 @@
+export HOST_APPS_STATE_FOLDER=./state_folder

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# System
+.DS_Store
+
+# Editors
+.vscode
+.idea
+
+# direnv
+.direnv
+.envrc.local
+
+# CMake
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles
@@ -7,17 +19,20 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 compile_commands.json
-CTestTestfile.cmake
-_deps
 build
-.vscode
-.idea
 cmake-build-*
-DartConfiguration.tcl
-.DS_Store
 .run/
+build/
+_deps
+
+# Rust
 target
 Cargo.lock
-build/
+
+# CTest
+CTestTestfile.cmake
+DartConfiguration.tcl
+
+# Static Analysis
 .clj-kondo
 .lsp

--- a/docker/gpu-drivers.Dockerfile
+++ b/docker/gpu-drivers.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update -y && \
 
 # libmfx is not available in Ubuntu 25.04 so we are building from sources (see: https://github.com/games-on-whales/wolf/issues/221)
 RUN <<_BUILD_LIBMFX
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -e
 
     apt-get update -y
@@ -53,7 +53,7 @@ _BUILD_LIBMFX
 # Adding missing libnvrtc.so and libnvrtc-bulletins.so for Nvidia
 # https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/LICENSE.txt
 RUN <<_ADD_NVRTC
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -e
 
     #Extra deps

--- a/docker/gstreamer.Dockerfile
+++ b/docker/gstreamer.Dockerfile
@@ -27,7 +27,7 @@ Description: Manually built from git
 EOT
 
 RUN <<_GSTREAMER_INSTALL
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -e
 
     DEV_PACKAGES=" \

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Make sure configure folder exists

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -38,7 +38,7 @@ RUN rustup install $RUST_VERSION && rustup default $RUST_VERSION
 
 WORKDIR /tmp/
 RUN <<_GST_WAYLAND_DISPLAY
-    #!/bin/bash
+    #!/usr/bin/env bash
     set -e
 
     git clone https://github.com/games-on-whales/gst-wayland-display

--- a/docs/modules/dev/pages/manual_build.adoc
+++ b/docs/modules/dev/pages/manual_build.adoc
@@ -203,7 +203,7 @@ Since Wolf is configured via a swoth of environment variables, it may be a good 
 .runwolf.sh
 [source,bash]
 ....
-#!/bin/bash
+#!/usr/bin/env bash
 
 : ${WOLF_CFG_FOLDER:-"config"}
 

--- a/docs/modules/dev/partials/spec.json
+++ b/docs/modules/dev/partials/spec.json
@@ -461,84 +461,6 @@
         }
       }
     },
-    "/api/v1/lobbies/pause": {
-      "post": {
-        "summary": "Pause a lobby",
-        "description": "",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/wolf__core__events__PauseLobbyEvent"
-              }
-            }
-          },
-          "description": "",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/wolf__api__GenericSuccessResponse"
-                }
-              }
-            },
-            "description": ""
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/wolf__api__GenericErrorResponse"
-                }
-              }
-            },
-            "description": ""
-          }
-        }
-      }
-    },
-    "/api/v1/lobbies/resume": {
-      "post": {
-        "summary": "Resume a lobby",
-        "description": "",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/wolf__core__events__ResumeLobbyEvent"
-              }
-            }
-          },
-          "description": "",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/wolf__api__GenericSuccessResponse"
-                }
-              }
-            },
-            "description": ""
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/wolf__api__GenericErrorResponse"
-                }
-              }
-            },
-            "description": ""
-          }
-        }
-      }
-    },
     "/api/v1/lobbies/stop": {
       "post": {
         "summary": "Stop a lobby",
@@ -704,6 +626,84 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/wolf__api__RunnerStartRequest"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/wolf__api__GenericSuccessResponse"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/wolf__api__GenericErrorResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v1/runners/pause": {
+      "post": {
+        "summary": "Pause a runner",
+        "description": "",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/wolf__api__RunnerPauseRequest"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/wolf__api__GenericSuccessResponse"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/wolf__api__GenericErrorResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v1/runners/resume": {
+      "post": {
+        "summary": "Resume a runner",
+        "description": "",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/wolf__api__RunnerPauseRequest"
               }
             }
           },
@@ -1617,6 +1617,28 @@
           "session_id"
         ]
       },
+      "wolf__api__RunnerPauseRequest": {
+        "type": "object",
+        "properties": {
+          "runner": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/wolf__config__AppCMD__tagged"
+              },
+              {
+                "$ref": "#/components/schemas/wolf__config__AppDocker__tagged"
+              }
+            ]
+          },
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runner",
+          "session_id"
+        ]
+      },
       "wolf__api__StreamSessionCreated": {
         "type": "object",
         "properties": {
@@ -2026,54 +2048,6 @@
         "required": [
           "lobby_id",
           "moonlight_session_id"
-        ]
-      },
-      "wolf__core__events__PauseLobbyEvent": {
-        "type": "object",
-        "properties": {
-          "lobby_id": {
-            "type": "string"
-          },
-          "pin": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "required": [
-          "lobby_id"
-        ]
-      },
-      "wolf__core__events__ResumeLobbyEvent": {
-        "type": "object",
-        "properties": {
-          "lobby_id": {
-            "type": "string"
-          },
-          "pin": {
-            "anyOf": [
-              {
-                "type": "array",
-                "items": {
-                  "type": "integer"
-                }
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "required": [
-          "lobby_id"
         ]
       },
       "wolf__core__events__StopLobbyEvent": {

--- a/docs/modules/dev/partials/spec.json
+++ b/docs/modules/dev/partials/spec.json
@@ -461,6 +461,84 @@
         }
       }
     },
+    "/api/v1/lobbies/pause": {
+      "post": {
+        "summary": "Pause a lobby",
+        "description": "",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/wolf__core__events__PauseLobbyEvent"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/wolf__api__GenericSuccessResponse"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/wolf__api__GenericErrorResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
+    "/api/v1/lobbies/resume": {
+      "post": {
+        "summary": "Resume a lobby",
+        "description": "",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/wolf__core__events__ResumeLobbyEvent"
+              }
+            }
+          },
+          "description": "",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/wolf__api__GenericSuccessResponse"
+                }
+              }
+            },
+            "description": ""
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/wolf__api__GenericErrorResponse"
+                }
+              }
+            },
+            "description": ""
+          }
+        }
+      }
+    },
     "/api/v1/lobbies/stop": {
       "post": {
         "summary": "Stop a lobby",
@@ -1948,6 +2026,54 @@
         "required": [
           "lobby_id",
           "moonlight_session_id"
+        ]
+      },
+      "wolf__core__events__PauseLobbyEvent": {
+        "type": "object",
+        "properties": {
+          "lobby_id": {
+            "type": "string"
+          },
+          "pin": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "lobby_id"
+        ]
+      },
+      "wolf__core__events__ResumeLobbyEvent": {
+        "type": "object",
+        "properties": {
+          "lobby_id": {
+            "type": "string"
+          },
+          "pin": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "lobby_id"
         ]
       },
       "wolf__core__events__StopLobbyEvent": {

--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -292,7 +292,7 @@ sudo nvidia-container-cli --load-kmods info
 
 [source,bash]
 ....
-#!/bin/bash
+#!/usr/bin/env bash
 ## Script to initialize nvidia device nodes.
 ## https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#runfile-verifications
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764517877,
+        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Dev Environment flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    system = "x86_64-linux";
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
+    devShells.${system}.default = import ./shell.nix { inherit pkgs; };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{pkgs ? import <nixpkgs> {}}: 
+  pkgs.mkShell {
+    name = "Wolf";
+
+    nativeBuildInputs = with pkgs; [
+      docker
+      docker-compose
+    ];
+  }

--- a/src/core/src/core/docker.hpp
+++ b/src/core/src/core/docker.hpp
@@ -111,6 +111,20 @@ public:
   bool start_by_id(std::string_view id) const;
 
   /**
+   * Pauses the container
+   *
+   * https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Container/operation/ContainerPause
+   */
+  bool pause_by_id(std::string_view id) const;
+
+  /**
+   * Upauses the container
+   *
+   * https://docs.docker.com/reference/api/engine/version/v1.51/#tag/Container/operation/ContainerUnpause
+   */
+  bool unpause_by_id(std::string_view id) const;
+
+  /**
    * Stops the container
    *
    * https://docs.docker.com/engine/api/v1.30/#tag/Container/operation/ContainerStop

--- a/src/core/src/platforms/all/docker/docker/docker.cpp
+++ b/src/core/src/platforms/all/docker/docker/docker.cpp
@@ -219,6 +219,38 @@ bool DockerAPI::start_by_id(std::string_view id) const {
   return false;
 }
 
+bool DockerAPI::pause_by_id(std::string_view id) const {
+  if (auto conn = docker_connect(socket_path)) {
+    auto raw_msg = req(
+        conn.value().get(),
+        POST,
+        fmt::format("http://localhost/{}/containers/{}/pause", docker_api_version, id));
+    if (raw_msg && (raw_msg->first == 204 || raw_msg->first == 304)) {
+      return true;
+    } else if (raw_msg) {
+      logs::log(logs::warning, "[DOCKER] error {} - {}", raw_msg->first, raw_msg->second);
+    }
+  }
+
+  return false;
+}
+
+bool DockerAPI::unpause_by_id(std::string_view id) const {
+  if (auto conn = docker_connect(socket_path)) {
+    auto raw_msg = req(
+        conn.value().get(),
+        POST,
+        fmt::format("http://localhost/{}/containers/{}/unpause", docker_api_version, id));
+    if (raw_msg && (raw_msg->first == 204 || raw_msg->first == 304)) {
+      return true;
+    } else if (raw_msg) {
+      logs::log(logs::warning, "[DOCKER] error {} - {}", raw_msg->first, raw_msg->second);
+    }
+  }
+
+  return false;
+}
+
 bool DockerAPI::stop_by_id(std::string_view id, int timeout_seconds) const {
   if (auto conn = docker_connect(socket_path)) {
     auto raw_msg = req(

--- a/src/moonlight-server/api/api.hpp
+++ b/src/moonlight-server/api/api.hpp
@@ -157,6 +157,11 @@ struct RunnerStartRequest {
   std::string session_id;
 };
 
+struct RunnerPauseRequest {
+  events::RunnerTypes runner;
+  std::string session_id;
+};
+
 struct GetIconRequest {
   std::string icon_png_path;
 };
@@ -216,11 +221,11 @@ private:
   void endpoint_LobbyCreate(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_LobbyJoin(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_LobbyLeave(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
-  void endpoint_LobbyPause(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
-  void endpoint_LobbyResume(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_LobbyStop(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
 
   void endpoint_RunnerStart(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
+  void endpoint_RunnerPause(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
+  void endpoint_RunnerResume(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
 
   void endpoint_UpdateClientSettings(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_GetIcon(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);

--- a/src/moonlight-server/api/api.hpp
+++ b/src/moonlight-server/api/api.hpp
@@ -216,6 +216,8 @@ private:
   void endpoint_LobbyCreate(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_LobbyJoin(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_LobbyLeave(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
+  void endpoint_LobbyPause(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
+  void endpoint_LobbyResume(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_LobbyStop(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
 
   void endpoint_RunnerStart(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -505,6 +505,38 @@ void UnixSocketServer::endpoint_LobbyLeave(const wolf::api::HTTPRequest &req, st
   }
 }
 
+void UnixSocketServer::endpoint_LobbyPause(const wolf::api::HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
+  auto event = rfl::json::read<events::PauseLobbyEvent>(req.body);
+  if (event) {
+    auto lobbies = this->state_->app_state->lobbies->load();
+    if (auto err = check_lobby_pin(lobbies.get(), event->lobby_id, event->pin)) {
+      send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = err.value()}));
+      return;
+    }
+    state_->app_state->event_bus->fire_event(immer::box<events::PauseLobbyEvent>(event.value()));
+    send_http(socket, 200, rfl::json::write(GenericSuccessResponse{}));
+  } else {
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());
+    send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = event.error().what()}));
+  }
+}
+
+void UnixSocketServer::endpoint_LobbyResume(const wolf::api::HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
+  auto event = rfl::json::read<events::ResumeLobbyEvent>(req.body);
+  if (event) {
+    auto lobbies = this->state_->app_state->lobbies->load();
+    if (auto err = check_lobby_pin(lobbies.get(), event->lobby_id, event->pin)) {
+      send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = err.value()}));
+      return;
+    }
+    state_->app_state->event_bus->fire_event(immer::box<events::ResumeLobbyEvent>(event.value()));
+    send_http(socket, 200, rfl::json::write(GenericSuccessResponse{}));
+  } else {
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());
+    send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = event.error().what()}));
+  }
+}
+
 void UnixSocketServer::endpoint_LobbyStop(const wolf::api::HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
   auto event = rfl::json::read<events::StopLobbyEvent>(req.body);
   if (event) {

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -505,38 +505,6 @@ void UnixSocketServer::endpoint_LobbyLeave(const wolf::api::HTTPRequest &req, st
   }
 }
 
-void UnixSocketServer::endpoint_LobbyPause(const wolf::api::HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
-  auto event = rfl::json::read<events::PauseLobbyEvent>(req.body);
-  if (event) {
-    auto lobbies = this->state_->app_state->lobbies->load();
-    if (auto err = check_lobby_pin(lobbies.get(), event->lobby_id, event->pin)) {
-      send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = err.value()}));
-      return;
-    }
-    state_->app_state->event_bus->fire_event(immer::box<events::PauseLobbyEvent>(event.value()));
-    send_http(socket, 200, rfl::json::write(GenericSuccessResponse{}));
-  } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());
-    send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = event.error().what()}));
-  }
-}
-
-void UnixSocketServer::endpoint_LobbyResume(const wolf::api::HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
-  auto event = rfl::json::read<events::ResumeLobbyEvent>(req.body);
-  if (event) {
-    auto lobbies = this->state_->app_state->lobbies->load();
-    if (auto err = check_lobby_pin(lobbies.get(), event->lobby_id, event->pin)) {
-      send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = err.value()}));
-      return;
-    }
-    state_->app_state->event_bus->fire_event(immer::box<events::ResumeLobbyEvent>(event.value()));
-    send_http(socket, 200, rfl::json::write(GenericSuccessResponse{}));
-  } else {
-    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());
-    send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = event.error().what()}));
-  }
-}
-
 void UnixSocketServer::endpoint_LobbyStop(const wolf::api::HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
   auto event = rfl::json::read<events::StopLobbyEvent>(req.body);
   if (event) {
@@ -566,9 +534,55 @@ void UnixSocketServer::endpoint_RunnerStart(const wolf::api::HTTPRequest &req, s
     }
 
     auto runner = state::get_runner(event.value().runner, this->state_->app_state->event_bus);
-    state_->app_state->event_bus->fire_event(immer::box<events::StartRunner>(
-        events::StartRunner{.stop_stream_when_over = event.value().stop_stream_when_over,
+    state_->app_state->event_bus->fire_event(immer::box<events::StartRunnerEvent>(
+        events::StartRunnerEvent{.stop_stream_when_over = event.value().stop_stream_when_over,
                             .runner = runner,
+                            .stream_session = std::make_shared<events::StreamSession>(*session)}));
+  } else {
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());
+    auto res = GenericErrorResponse{.error = event.error().what()};
+    send_http(socket, 500, rfl::json::write(res));
+  }
+}
+
+void UnixSocketServer::endpoint_RunnerPause(const wolf::api::HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
+  auto event = rfl::json::read<RunnerPauseRequest>(req.body);
+  if (event) {
+    auto session = state::get_session_by_id(this->state_->app_state->running_sessions->load(),
+                                            std::stoul(event.value().session_id));
+    if (!session) {
+      logs::log(logs::warning, "[API] Invalid session_id: {}", event.value().session_id);
+      auto res = GenericErrorResponse{.error = "Invalid session_id"};
+      send_http(socket, 500, rfl::json::write(res));
+      return;
+    }
+
+    auto runner = state::get_runner(event.value().runner, this->state_->app_state->event_bus);
+    state_->app_state->event_bus->fire_event(immer::box<events::PauseRunnerEvent>(
+        events::PauseRunnerEvent{.runner = runner,
+                            .stream_session = std::make_shared<events::StreamSession>(*session)}));
+  } else {
+    logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());
+    auto res = GenericErrorResponse{.error = event.error().what()};
+    send_http(socket, 500, rfl::json::write(res));
+  }
+}
+
+void UnixSocketServer::endpoint_RunnerResume(const wolf::api::HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
+  auto event = rfl::json::read<RunnerPauseRequest>(req.body);
+  if (event) {
+    auto session = state::get_session_by_id(this->state_->app_state->running_sessions->load(),
+                                            std::stoul(event.value().session_id));
+    if (!session) {
+      logs::log(logs::warning, "[API] Invalid session_id: {}", event.value().session_id);
+      auto res = GenericErrorResponse{.error = "Invalid session_id"};
+      send_http(socket, 500, rfl::json::write(res));
+      return;
+    }
+
+    auto runner = state::get_runner(event.value().runner, this->state_->app_state->event_bus);
+    state_->app_state->event_bus->fire_event(immer::box<events::ResumeRunnerEvent>(
+        events::ResumeRunnerEvent{.runner = runner,
                             .stream_session = std::make_shared<events::StreamSession>(*session)}));
   } else {
     logs::log(logs::warning, "[API] Invalid event: {} - {}", req.body, event.error().what());

--- a/src/moonlight-server/api/unix_socket_server.cpp
+++ b/src/moonlight-server/api/unix_socket_server.cpp
@@ -282,6 +282,28 @@ UnixSocketServer::UnixSocketServer(boost::asio::io_context &io_context,
 
   state_->http.add(
       HTTPMethod::POST,
+      "/api/v1/lobbies/pause",
+      {
+          .summary = "Pause a lobby",
+          .request_description = APIDescription{.json_schema = rfl::json::to_schema<events::PauseLobbyEvent>()},
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                   {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_LobbyPause(req, socket); },
+      });
+
+  state_->http.add(
+      HTTPMethod::POST,
+      "/api/v1/lobbies/resume",
+      {
+          .summary = "Resume a lobby",
+          .request_description = APIDescription{.json_schema = rfl::json::to_schema<events::ResumeLobbyEvent>()},
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                   {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_LobbyResume(req, socket); },
+      });
+
+  state_->http.add(
+      HTTPMethod::POST,
       "/api/v1/lobbies/stop",
       {
           .summary = "Stop a lobby",

--- a/src/moonlight-server/api/unix_socket_server.cpp
+++ b/src/moonlight-server/api/unix_socket_server.cpp
@@ -101,36 +101,38 @@ UnixSocketServer::UnixSocketServer(boost::asio::io_context &io_context,
       });
 
   state_->http.add(HTTPMethod::POST,
-                   "/api/v1/apps/add",
-                   {
-                       .summary = "Add a Moonlight app",
-                       .request_description =
-                           APIDescription{.json_schema = rfl::json::to_schema<rfl::Reflector<events::App>::ReflType>()},
-                       .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
-                                                {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
-                       .handler = [this](auto req, auto socket) { endpoint_AddApp(req, socket); },
-                   });
+      "/api/v1/apps/add",
+      {
+          .summary = "Add a Moonlight app",
+          .request_description =
+              APIDescription{.json_schema = rfl::json::to_schema<rfl::Reflector<events::App>::ReflType>()},
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                  {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_AddApp(req, socket); },
+      });
 
   state_->http.add(HTTPMethod::POST,
-                   "/api/v1/apps/delete",
-                   {.summary = "Remove a Moonlight app",
-                    .request_description = APIDescription{.json_schema = rfl::json::to_schema<AppDeleteRequest>()},
-                    .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
-                                             {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
-                    .handler = [this](auto req, auto socket) { endpoint_RemoveApp(req, socket); }});
+      "/api/v1/apps/delete",
+      {
+          .summary = "Remove a Moonlight app",
+          .request_description = APIDescription{.json_schema = rfl::json::to_schema<AppDeleteRequest>()},
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                    {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_RemoveApp(req, socket); },
+      });
 
   /**
    * Profiles API
    */
 
   state_->http.add(HTTPMethod::GET,
-                   "/api/v1/profiles",
-                   {
-                       .summary = "Get all profiles",
-                       .description = "This endpoint returns a list of all profiles.",
-                       .response_description = {{200, {.json_schema = rfl::json::to_schema<ProfileListResponse>()}}},
-                       .handler = [this](auto req, auto socket) { endpoint_Profiles(req, socket); },
-                   });
+      "/api/v1/profiles",
+      {
+          .summary = "Get all profiles",
+          .description = "This endpoint returns a list of all profiles.",
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<ProfileListResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_Profiles(req, socket); },
+      });
 
   state_->http.add(
       HTTPMethod::POST,
@@ -225,38 +227,61 @@ UnixSocketServer::UnixSocketServer(boost::asio::io_context &io_context,
           .handler = [this](auto req, auto socket) { endpoint_StreamSessionHandleInput(req, socket); },
       });
 
-  state_->http.add(HTTPMethod::POST,
-                   "/api/v1/runners/start",
-                   {
-                       .summary = "Start a runner in a given session",
-                       .request_description = APIDescription{.json_schema = rfl::json::to_schema<RunnerStartRequest>()},
-                       .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
-                                                {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
-                       .handler = [this](auto req, auto socket) { endpoint_RunnerStart(req, socket); },
-                   });
+  state_->http.add(
+      HTTPMethod::POST,
+      "/api/v1/runners/start",
+      {
+          .summary = "Start a runner in a given session",
+          .request_description = APIDescription{.json_schema = rfl::json::to_schema<RunnerStartRequest>()},
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                  {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_RunnerStart(req, socket); },
+      });
+
+  state_->http.add(
+      HTTPMethod::POST,
+      "/api/v1/runners/pause",
+      {
+          .summary = "Pause a runner",
+          .request_description = APIDescription{.json_schema = rfl::json::to_schema<RunnerPauseRequest>()},
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                   {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_RunnerPause(req, socket); },
+      });
+
+  state_->http.add(
+      HTTPMethod::POST,
+      "/api/v1/runners/resume",
+      {
+          .summary = "Resume a runner",
+          .request_description = APIDescription{.json_schema = rfl::json::to_schema<RunnerPauseRequest>()},
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                   {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_RunnerResume(req, socket); },
+      });
 
   /**
    * Lobbies API
    */
 
   state_->http.add(HTTPMethod::GET,
-                   "/api/v1/lobbies",
-                   {
-                       .summary = "List all lobbies",
-                       .response_description = {{200, {.json_schema = rfl::json::to_schema<LobbiesResponse>()}},
-                                                {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
-                       .handler = [this](auto req, auto socket) { endpoint_Lobbies(req, socket); },
-                   });
+      "/api/v1/lobbies",
+      {
+          .summary = "List all lobbies",
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<LobbiesResponse>()}},
+                                  {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_Lobbies(req, socket); },
+      });
 
   state_->http.add(HTTPMethod::POST,
-                   "/api/v1/lobbies/create",
-                   {
-                       .summary = "Create a new lobby",
-                       .request_description = APIDescription{.json_schema = rfl::json::to_schema<CreateLobbyRequest>()},
-                       .response_description = {{200, {.json_schema = rfl::json::to_schema<LobbyCreateResponse>()}},
-                                                {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
-                       .handler = [this](auto req, auto socket) { endpoint_LobbyCreate(req, socket); },
-                   });
+      "/api/v1/lobbies/create",
+      {
+          .summary = "Create a new lobby",
+          .request_description = APIDescription{.json_schema = rfl::json::to_schema<CreateLobbyRequest>()},
+          .response_description = {{200, {.json_schema = rfl::json::to_schema<LobbyCreateResponse>()}},
+                                  {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+          .handler = [this](auto req, auto socket) { endpoint_LobbyCreate(req, socket); },
+      });
 
   state_->http.add(
       HTTPMethod::POST,
@@ -278,28 +303,6 @@ UnixSocketServer::UnixSocketServer(boost::asio::io_context &io_context,
           .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
                                    {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
           .handler = [this](auto req, auto socket) { endpoint_LobbyLeave(req, socket); },
-      });
-
-  state_->http.add(
-      HTTPMethod::POST,
-      "/api/v1/lobbies/pause",
-      {
-          .summary = "Pause a lobby",
-          .request_description = APIDescription{.json_schema = rfl::json::to_schema<events::PauseLobbyEvent>()},
-          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
-                                   {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
-          .handler = [this](auto req, auto socket) { endpoint_LobbyPause(req, socket); },
-      });
-
-  state_->http.add(
-      HTTPMethod::POST,
-      "/api/v1/lobbies/resume",
-      {
-          .summary = "Resume a lobby",
-          .request_description = APIDescription{.json_schema = rfl::json::to_schema<events::ResumeLobbyEvent>()},
-          .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
-                                   {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
-          .handler = [this](auto req, auto socket) { endpoint_LobbyResume(req, socket); },
       });
 
   state_->http.add(

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -192,16 +192,6 @@ struct LeaveLobbyEvent {
   const std::size_t moonlight_session_id;
 };
 
-struct PauseLobbyEvent {
-  const std::string lobby_id;
-  std::optional<std::vector<short>> pin = std::nullopt;
-};
-
-struct ResumeLobbyEvent {
-  const std::string lobby_id;
-  std::optional<std::vector<short>> pin = std::nullopt;
-};
-
 struct StopLobbyEvent {
   const std::string lobby_id;
   std::optional<std::vector<short>> pin = std::nullopt;
@@ -326,8 +316,18 @@ struct RTPAudioPingEvent {
 
 struct StreamSession;
 
-struct StartRunner {
+struct StartRunnerEvent {
   bool stop_stream_when_over = false;
+  std::shared_ptr<Runner> runner;
+  std::shared_ptr<StreamSession> stream_session;
+};
+
+struct PauseRunnerEvent {
+  std::shared_ptr<Runner> runner;
+  std::shared_ptr<StreamSession> stream_session;
+};
+
+struct ResumeRunnerEvent {
   std::shared_ptr<Runner> runner;
   std::shared_ptr<StreamSession> stream_session;
 };
@@ -345,12 +345,12 @@ using EventBusHandlers = dp::handler_registration<immer::box<PlugDeviceEvent>,
                                                   immer::box<ClientWolfUIComboEvent>,
                                                   immer::box<RTPVideoPingEvent>,
                                                   immer::box<RTPAudioPingEvent>,
-                                                  immer::box<StartRunner>,
+                                                  immer::box<StartRunnerEvent>,
+                                                  immer::box<PauseRunnerEvent>,
+                                                  immer::box<ResumeRunnerEvent>,
                                                   immer::box<JoinLobbyEvent>,
                                                   immer::box<LeaveLobbyEvent>,
                                                   immer::box<CreateLobbyEvent>,
-                                                  immer::box<PauseLobbyEvent>,
-                                                  immer::box<ResumeLobbyEvent>,
                                                   immer::box<StopLobbyEvent>,
                                                   immer::box<SwitchStreamProducerEvents>>;
 using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
@@ -366,12 +366,12 @@ using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<ClientWolfUIComboEvent>,
                                    immer::box<RTPVideoPingEvent>,
                                    immer::box<RTPAudioPingEvent>,
-                                   immer::box<StartRunner>,
+                                   immer::box<StartRunnerEvent>,
+                                   immer::box<PauseRunnerEvent>,
+                                   immer::box<ResumeRunnerEvent>,
                                    immer::box<JoinLobbyEvent>,
                                    immer::box<LeaveLobbyEvent>,
                                    immer::box<CreateLobbyEvent>,
-                                   immer::box<PauseLobbyEvent>,
-                                   immer::box<ResumeLobbyEvent>,
                                    immer::box<StopLobbyEvent>,
                                    immer::box<SwitchStreamProducerEvents>>;
 using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
@@ -387,12 +387,12 @@ using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<ClientWolfUIComboEvent>,
                                    immer::box<RTPVideoPingEvent>,
                                    immer::box<RTPAudioPingEvent>,
-                                   immer::box<StartRunner>,
+                                   immer::box<StartRunnerEvent>,
+                                   immer::box<PauseRunnerEvent>,
+                                   immer::box<ResumeRunnerEvent>,
                                    immer::box<JoinLobbyEvent>,
                                    immer::box<LeaveLobbyEvent>,
                                    immer::box<CreateLobbyEvent>,
-                                   immer::box<PauseLobbyEvent>,
-                                   immer::box<ResumeLobbyEvent>,
                                    immer::box<StopLobbyEvent>,
                                    immer::box<SwitchStreamProducerEvents>>;
 

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -192,6 +192,16 @@ struct LeaveLobbyEvent {
   const std::size_t moonlight_session_id;
 };
 
+struct PauseLobbyEvent {
+  const std::string lobby_id;
+  std::optional<std::vector<short>> pin = std::nullopt;
+};
+
+struct ResumeLobbyEvent {
+  const std::string lobby_id;
+  std::optional<std::vector<short>> pin = std::nullopt;
+};
+
 struct StopLobbyEvent {
   const std::string lobby_id;
   std::optional<std::vector<short>> pin = std::nullopt;
@@ -339,6 +349,8 @@ using EventBusHandlers = dp::handler_registration<immer::box<PlugDeviceEvent>,
                                                   immer::box<JoinLobbyEvent>,
                                                   immer::box<LeaveLobbyEvent>,
                                                   immer::box<CreateLobbyEvent>,
+                                                  immer::box<PauseLobbyEvent>,
+                                                  immer::box<ResumeLobbyEvent>,
                                                   immer::box<StopLobbyEvent>,
                                                   immer::box<SwitchStreamProducerEvents>>;
 using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
@@ -358,6 +370,8 @@ using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<JoinLobbyEvent>,
                                    immer::box<LeaveLobbyEvent>,
                                    immer::box<CreateLobbyEvent>,
+                                   immer::box<PauseLobbyEvent>,
+                                   immer::box<ResumeLobbyEvent>,
                                    immer::box<StopLobbyEvent>,
                                    immer::box<SwitchStreamProducerEvents>>;
 using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
@@ -377,6 +391,8 @@ using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<JoinLobbyEvent>,
                                    immer::box<LeaveLobbyEvent>,
                                    immer::box<CreateLobbyEvent>,
+                                   immer::box<PauseLobbyEvent>,
+                                   immer::box<ResumeLobbyEvent>,
                                    immer::box<StopLobbyEvent>,
                                    immer::box<SwitchStreamProducerEvents>>;
 

--- a/src/moonlight-server/events/reflectors.hpp
+++ b/src/moonlight-server/events/reflectors.hpp
@@ -122,14 +122,14 @@ template <> struct Reflector<events::Profile> {
   }
 };
 
-template <> struct Reflector<events::StartRunner> {
+template <> struct Reflector<events::StartRunnerEvent> {
   struct ReflType {
     bool stop_stream_when_over;
     events::RunnerTypes runner;
     std::string session_id;
   };
 
-  static ReflType from(const events::StartRunner &v) {
+  static ReflType from(const events::StartRunnerEvent &v) {
     return {.stop_stream_when_over = v.stop_stream_when_over,
             .runner = v.runner->serialize(),
             .session_id = std::to_string(v.stream_session->session_id)};

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -196,6 +196,34 @@ void RunDocker::run(std::string_view session_id,
     logs::log(logs::info, "[DOCKER] Starting container: {}", docker_container->name);
     logs::log(logs::debug, "[DOCKER] Starting container: {}", *docker_container);
 
+    auto pause_handler = this->ev_bus->register_handler<immer::box<events::PauseStreamEvent>>(
+        [session_id, container_id, this](const immer::box<events::PauseStreamEvent> &pause_ev) {
+          if (std::to_string(pause_ev->session_id) == session_id) {
+            docker_api.pause_by_id(container_id);
+          }
+        });
+
+    auto pause_lobby_handler = this->ev_bus->register_handler<immer::box<events::PauseLobbyEvent>>(
+        [session_id, container_id, this](const immer::box<events::PauseLobbyEvent> &pause_ev) {
+          if (pause_ev->lobby_id == session_id) {
+            docker_api.pause_by_id(container_id);
+          }
+        });
+
+    auto unpause_handler = this->ev_bus->register_handler<immer::box<events::ResumeStreamEvent>>(
+        [session_id, container_id, this](const immer::box<events::ResumeStreamEvent> &resume_ev) {
+          if (std::to_string(resume_ev->session_id) == session_id) {
+            docker_api.unpause_by_id(container_id);
+          }
+        });
+
+    auto unpause_lobby_handler = this->ev_bus->register_handler<immer::box<events::ResumeLobbyEvent>>(
+        [session_id, container_id, this](const immer::box<events::ResumeLobbyEvent> &resume_ev) {
+          if (resume_ev->lobby_id == session_id) {
+            docker_api.unpause_by_id(container_id);
+          }
+        });
+
     auto terminate_handler = this->ev_bus->register_handler<immer::box<events::StopStreamEvent>>(
         [session_id, container_id, this](const immer::box<events::StopStreamEvent> &terminate_ev) {
           if (std::to_string(terminate_ev->session_id) == session_id) {

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -196,30 +196,16 @@ void RunDocker::run(std::string_view session_id,
     logs::log(logs::info, "[DOCKER] Starting container: {}", docker_container->name);
     logs::log(logs::debug, "[DOCKER] Starting container: {}", *docker_container);
 
-    auto pause_handler = this->ev_bus->register_handler<immer::box<events::PauseStreamEvent>>(
-        [session_id, container_id, this](const immer::box<events::PauseStreamEvent> &pause_ev) {
-          if (std::to_string(pause_ev->session_id) == session_id) {
+    auto pause_runner_handler = this->ev_bus->register_handler<immer::box<events::PauseRunnerEvent>>(
+        [session_id, container_id, this](const immer::box<events::PauseRunnerEvent> &pause_ev) {
+          if (std::to_string(pause_ev->stream_session->session_id) == session_id) {
             docker_api.pause_by_id(container_id);
           }
         });
 
-    auto pause_lobby_handler = this->ev_bus->register_handler<immer::box<events::PauseLobbyEvent>>(
-        [session_id, container_id, this](const immer::box<events::PauseLobbyEvent> &pause_ev) {
-          if (pause_ev->lobby_id == session_id) {
-            docker_api.pause_by_id(container_id);
-          }
-        });
-
-    auto unpause_handler = this->ev_bus->register_handler<immer::box<events::ResumeStreamEvent>>(
-        [session_id, container_id, this](const immer::box<events::ResumeStreamEvent> &resume_ev) {
-          if (std::to_string(resume_ev->session_id) == session_id) {
-            docker_api.unpause_by_id(container_id);
-          }
-        });
-
-    auto unpause_lobby_handler = this->ev_bus->register_handler<immer::box<events::ResumeLobbyEvent>>(
-        [session_id, container_id, this](const immer::box<events::ResumeLobbyEvent> &resume_ev) {
-          if (resume_ev->lobby_id == session_id) {
+    auto unpause_runner_handler = this->ev_bus->register_handler<immer::box<events::ResumeRunnerEvent>>(
+        [session_id, container_id, this](const immer::box<events::ResumeRunnerEvent> &resume_ev) {
+          if (std::to_string(resume_ev->stream_session->session_id) == session_id) {
             docker_api.unpause_by_id(container_id);
           }
         });

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -253,6 +253,39 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
         }
       }));
 
+  // Pausing a lobby will trigger leave for all the connected sessions
+  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::PauseLobbyEvent>>(
+      [=](const immer::box<events::PauseLobbyEvent> &stop_lobby_event) {
+        auto lobbies = app_state->lobbies->load();
+        auto lobby = state::get_lobby_by_id(lobbies.get(), stop_lobby_event->lobby_id);
+
+        if (!lobby) {
+          logs::log(logs::warning, "[LOBBY] lobby {} not found", stop_lobby_event->lobby_id);
+          return;
+        }
+        logs::log(logs::info, "[LOBBY] pausing lobby {}", stop_lobby_event->lobby_id);
+
+        immer::vector<immer::box<std::string>> sessions = lobby->connected_sessions->load();
+        for (auto &session_id : sessions) {
+          app_state->event_bus->fire_event(immer::box<events::LeaveLobbyEvent>{
+              events::LeaveLobbyEvent{.lobby_id = lobby->id, .moonlight_session_id = std::stoul(*session_id)}});
+        }
+      }));
+
+  // When a Moonlight client resume a lobby
+  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::ResumeLobbyEvent>>(
+      [=](const immer::box<events::ResumeLobbyEvent> &resume_lobby_event) {
+        auto lobbies = app_state->lobbies->load();
+        auto lobby = state::get_lobby_by_id(lobbies.get(), resume_lobby_event->lobby_id);
+
+        if (!lobby) {
+          logs::log(logs::error,
+                    "[LOBBY] Failed to resume lobby: lobby {} not found",
+                    resume_lobby_event->lobby_id);
+          return;
+        }
+      }));
+
   // Stopping a lobby will trigger leave for all the connected sessions
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::StopLobbyEvent>>(
       [=](const immer::box<events::StopLobbyEvent> &stop_lobby_event) {

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -253,39 +253,6 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
         }
       }));
 
-  // Pausing a lobby will trigger leave for all the connected sessions
-  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::PauseLobbyEvent>>(
-      [=](const immer::box<events::PauseLobbyEvent> &stop_lobby_event) {
-        auto lobbies = app_state->lobbies->load();
-        auto lobby = state::get_lobby_by_id(lobbies.get(), stop_lobby_event->lobby_id);
-
-        if (!lobby) {
-          logs::log(logs::warning, "[LOBBY] lobby {} not found", stop_lobby_event->lobby_id);
-          return;
-        }
-        logs::log(logs::info, "[LOBBY] pausing lobby {}", stop_lobby_event->lobby_id);
-
-        immer::vector<immer::box<std::string>> sessions = lobby->connected_sessions->load();
-        for (auto &session_id : sessions) {
-          app_state->event_bus->fire_event(immer::box<events::LeaveLobbyEvent>{
-              events::LeaveLobbyEvent{.lobby_id = lobby->id, .moonlight_session_id = std::stoul(*session_id)}});
-        }
-      }));
-
-  // When a Moonlight client resume a lobby
-  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::ResumeLobbyEvent>>(
-      [=](const immer::box<events::ResumeLobbyEvent> &resume_lobby_event) {
-        auto lobbies = app_state->lobbies->load();
-        auto lobby = state::get_lobby_by_id(lobbies.get(), resume_lobby_event->lobby_id);
-
-        if (!lobby) {
-          logs::log(logs::error,
-                    "[LOBBY] Failed to resume lobby: lobby {} not found",
-                    resume_lobby_event->lobby_id);
-          return;
-        }
-      }));
-
   // Stopping a lobby will trigger leave for all the connected sessions
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::StopLobbyEvent>>(
       [=](const immer::box<events::StopLobbyEvent> &stop_lobby_event) {

--- a/src/moonlight-server/sessions/moonlight.cpp
+++ b/src/moonlight-server/sessions/moonlight.cpp
@@ -168,16 +168,16 @@ setup_moonlight_handlers(const immer::box<state::AppState> &app_state,
           session->touch_screen->emplace(virtual_display::WaylandTouchScreen(wl_state));
 
           logs::log(logs::debug, "[STREAM_SESSION] Start runner");
-          session->event_bus->fire_event(immer::box<events::StartRunner>(
-              events::StartRunner{.stop_stream_when_over = true,
+          session->event_bus->fire_event(immer::box<events::StartRunnerEvent>(
+              events::StartRunnerEvent{.stop_stream_when_over = true,
                                   .runner = session->app->runner,
                                   .stream_session = std::make_shared<events::StreamSession>(*session)}));
         });
       }));
 
   /* Start runner */
-  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::StartRunner>>(
-      [=](const immer::box<events::StartRunner> &run_session) {
+  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::StartRunnerEvent>>(
+      [=](const immer::box<events::StartRunnerEvent> &run_session) {
         auto session_id = std::to_string(run_session->stream_session->session_id);
         auto devices_q = plugged_devices_queue->load()->find(session_id);
         if (!devices_q) {

--- a/tests/docker/testDocker.cpp
+++ b/tests/docker/testDocker.cpp
@@ -33,6 +33,8 @@ TEST_CASE("Docker API", "[DOCKER]") {
   auto first_container = docker_api.create(container);
   REQUIRE(first_container.has_value());
   REQUIRE(docker_api.start_by_id(first_container.value().id));
+  REQUIRE(docker_api.pause_by_id(first_container.value().id));
+  REQUIRE(docker_api.unpause_by_id(first_container.value().id));
   REQUIRE(docker_api.stop_by_id(first_container.value().id));
 
   // This should remove the first container and create a new one with the same name


### PR DESCRIPTION
Attempt at enabling pause/resume scheme from Wolf to Wolf UI.

As discussed on Discord, this might not work perfectly has pausing containers doesn't free GPU VRAM, since there's no cgroup freeze method available to do so by default. There is hope that we could do it with some research, and it might come to the kernel in the next years, but for now we have to try without. This might end up creating crashes though.

I'm still not sure of the return values that `Resume` should give. I kept it as a separated action from `Join` for now, but maybe the scheme would be better if we could directly join ?

I also might have connected pause and resume stream events to pause/resume container, which depending on how this works might not be a good idea.

Linked to https://github.com/games-on-whales/wolf-ui/pull/10