### PR TITLE
Fix podman command in quadlet quickstart guide

### DIFF
--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -533,7 +533,7 @@ Check volume exists with:
 
 [source,bash]
 ....
-sudo docker volume ls | grep nvidia-driver
+sudo podman volume ls | grep nvidia-driver
 
 local     nvidia-driver-vol
 ....


### PR DESCRIPTION
This fixes one of the commands in the podman quadlet quickstart guide which refers to docker instead of podman