### PR TITLE
Add Pulse Audio Router to ensure correct sink is selected

### DIFF
--- a/src/core/src/core/audio.hpp
+++ b/src/core/src/core/audio.hpp
@@ -13,6 +13,9 @@
 namespace wolf::core::audio {
 
 typedef struct Server Server;
+struct pa_context; 
+
+pa_context* context(const std::shared_ptr<Server>& server);
 
 std::shared_ptr<Server> connect(std::string_view server = {});
 

--- a/src/core/src/core/audio.hpp
+++ b/src/core/src/core/audio.hpp
@@ -10,10 +10,11 @@
 #include <string>
 #include <vector>
 
+struct pa_context; 
+
 namespace wolf::core::audio {
 
 typedef struct Server Server;
-struct pa_context; 
 
 pa_context* context(const std::shared_ptr<Server>& server);
 

--- a/src/core/src/core/audio.hpp
+++ b/src/core/src/core/audio.hpp
@@ -55,6 +55,8 @@ struct VSink {
  */
 bool connected(const std::shared_ptr<Server> &server);
 
+void queue_op(const std::shared_ptr<Server>& server, const std::function<void()>& op);
+
 std::shared_ptr<VSink> create_virtual_sink(const std::shared_ptr<Server> &server, const AudioDevice &device);
 
 void delete_virtual_sink(const std::shared_ptr<Server> &server, const std::shared_ptr<VSink> &vsink);

--- a/src/core/src/core/docker.hpp
+++ b/src/core/src/core/docker.hpp
@@ -44,6 +44,7 @@ struct Device {
 struct Container {
   std::string id;
   std::string name;
+  std::string hostname;
 
   std::string image;
 

--- a/src/core/src/platforms/all/docker/docker/json_formatters.hpp
+++ b/src/core/src/platforms/all/docker/docker/json_formatters.hpp
@@ -140,8 +140,14 @@ docker::Container tag_invoke(value_to_tag<docker::Container>, value const &jv) {
     env = json::value_to<std::vector<std::string>>(obj.at("Config").at("Env"));
   }
 
+  std::string hostname;
+  if (!obj.at("Config").at("Hostname").is_null()) { // usually present; kept consistent with above null checks
+    hostname = json::value_to<std::string>(obj.at("Config").at("Hostname"));
+  }
+
   return docker::Container{.id = json::value_to<std::string>(obj.at("Id")),
                            .name = json::value_to<std::string>(obj.at("Name")),
+                           .hostname = hostname,
                            .image = json::value_to<std::string>(obj.at("Config").at("Image")),
                            .status = status,
                            .ports = ports,

--- a/src/core/src/platforms/linux/pulseaudio/pulse.cpp
+++ b/src/core/src/platforms/linux/pulseaudio/pulse.cpp
@@ -57,6 +57,10 @@ struct Server {
   boost::future<bool> on_ready_fut;
 };
 
+pa_context* context(const std::shared_ptr<Server>& server) {
+  return server ? server->ctx : nullptr;
+}
+
 std::shared_ptr<Server> connect(std::string_view server) {
   {
     auto loop = pa_mainloop_new();

--- a/src/moonlight-server/CMakeLists.txt
+++ b/src/moonlight-server/CMakeLists.txt
@@ -133,6 +133,7 @@ target_include_directories(wolf_runner PUBLIC .)
 file(GLOB HEADER_LIST CONFIGURE_DEPENDS */*.hpp)
 file(GLOB SRC_LIST SRCS
         api/*.cpp
+        audio/*.cpp
         control/*.cpp
         gst-plugin/*.cpp
         rest/*.cpp

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -43,6 +43,11 @@ setup_pulseaudio_router_handlers(const immer::box<state::AppState>& app_state,
         if (state) state->on_container_stopped(*ev);
       }));
 
+  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::VirtualAudioSinkCreated>>(
+      [state](const immer::box<events::VirtualAudioSinkCreated>& ev) {
+        state->on_virtual_sink_created(*ev);
+      }));
+
   // Subscribe to sink-input events and do an initial scan
   state->enable_pulse_subscribe();
 
@@ -83,15 +88,45 @@ void PulseAudioRouterState::on_container_created(const events::DockerContainerCr
 void PulseAudioRouterState::on_container_stopped(const events::DockerContainerStopped& ev) {
   if (ev.hostname.empty()) return;
 
+  std::optional<std::string> removed_session;
+
   host_to_session.update([&](auto m) {
-    return m.erase(ev.hostname);
+    if (auto v = m.find(ev.hostname)) {         // hostname -> session_id
+      // optionally guard against hostname reuse:
+      if (ev.session_id.empty() || *v == ev.session_id) {
+        removed_session = *v;
+        return m.erase(ev.hostname);
+      }
+    }
+    return m;
+  });
+
+  if (removed_session && !removed_session->empty()) {
+    session_to_sink_idx.update([&](auto m) { return m.erase(*removed_session); });
+
+    logs::log(logs::debug,
+              "[PULSE_ROUTER] Removed mappings host='{}' session='{}'",
+              ev.hostname,
+              *removed_session);
+  }
+
+}
+
+void PulseAudioRouterState::on_virtual_sink_created(const events::VirtualAudioSinkCreated& ev) {
+  if (ev.session_id.empty()) return;
+
+  session_to_sink_idx.update([&](auto m) {
+    return m.set(ev.session_id, ev.sink_index);
   });
 
   logs::log(logs::debug,
-            "[PULSE_ROUTER] Map del host='{}' session='{}' (container_id='{}')",
-            ev.hostname,
+            "[PULSE_ROUTER] Sink ready session='{}' sink='{}' idx={}",
             ev.session_id,
-            ev.container_id);
+            ev.sink_name,
+            ev.sink_index);
+
+  // Fix races: sink-input may already exist, or docker mapping may already exist
+  rescan();
 }
 
 void PulseAudioRouterState::enable_pulse_subscribe() {
@@ -145,25 +180,41 @@ void PulseAudioRouterState::route_sink_input_(pa_context* c, const pa_sink_input
   const char* host = pa_proplist_gets(info->proplist, "application.process.host");
   if (!host || host[0] == '\0') return;
 
-  auto target = target_sink_for_host_(host);
-  if (!target.has_value()) return;
+  // host -> session_id
+  std::optional<std::string> session_id;
+  {
+    auto box = host_to_session.load();
+    const auto& m = *box;
+    if (auto v = m.find(std::string(host))) {
+      session_id = *v; // immer::map find returns value ptr
+    }
+  }
+  if (!session_id || session_id->empty()) return;
 
-  auto op = pa_context_move_sink_input_by_name(c, info->index, target->c_str(), nullptr, nullptr);
+  // session_id -> sink index
+  std::optional<uint32_t> target_sink_idx;
+  {
+    auto box = session_to_sink_idx.load();
+    const auto& m = *box;
+    if (auto v = m.find(*session_id)) {
+      target_sink_idx = *v;
+    }
+  }
+  if (!target_sink_idx) return;
+
+  // Already routed?
+  if (info->sink == *target_sink_idx) return;
+
+  // Move by index (robust)
+  auto op = pa_context_move_sink_input_by_index(c, info->index, *target_sink_idx, nullptr, nullptr);
   if (op) pa_operation_unref(op);
 
-  logs::log(logs::info,
-            "[PULSE_ROUTER] Move sink-input={} host='{}' -> '{}'",
+  logs::log(logs::debug,
+            "[PULSE_ROUTER] Move sink-input={} host='{}' -> session='{}' sink_idx={}",
             info->index,
             host,
-            *target);
-}
-
-std::optional<std::string> PulseAudioRouterState::target_sink_for_host_(std::string_view host) const {
-  auto m = host_to_session.load();
-  if (auto session = m->find(std::string(host))) {
-    return std::string(VIRTUAL_SINK_PREFIX) + *session;
-  }
-  return std::nullopt;
+            *session_id,
+            *target_sink_idx);
 }
 
 } // namespace wolf::core::audio

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -1,0 +1,223 @@
+#include "pulse_router.hpp"
+
+#include <core/audio.hpp>
+#include <helpers/logger.hpp>
+
+#include <pulse/pulseaudio.h>
+
+#include <utility>
+
+namespace wolf::core::audio {
+
+PulseAudioRouter::PulseAudioRouter(std::shared_ptr<events::EventBusType> ev_bus,
+                                   std::shared_ptr<audio::Server> pulse_server,
+                                   std::string sink_prefix)
+    : ev_bus_(std::move(ev_bus)), pulse_server_(std::move(pulse_server)), sink_prefix_(std::move(sink_prefix)) {}
+
+PulseAudioRouter::~PulseAudioRouter() { stop(); }
+
+void PulseAudioRouter::start() {
+  bool expected = false;
+  if (!started_.compare_exchange_strong(expected, true)) {
+    return; // already started
+  }
+
+  if (!ev_bus_) {
+    logs::log(logs::warning, "[PULSE_ROUTER] No event bus provided, cannot start");
+    return;
+  }
+  if (!pulse_server_ || !pulse_server_->ctx) {
+    logs::log(logs::warning, "[PULSE_ROUTER] No Pulse server/context provided, cannot start");
+    return;
+  }
+
+  // Keep handler registrations alive by storing them as members.
+  created_handler_ = ev_bus_->register_handler<immer::box<events::DockerContainerCreated>>(
+      [this](const immer::box<events::DockerContainerCreated> &ev) { on_container_created(*ev); });
+
+  stopped_handler_ = ev_bus_->register_handler<immer::box<events::DockerContainerStopped>>(
+      [this](const immer::box<events::DockerContainerStopped> &ev) { on_container_stopped(*ev); });
+
+  // Enable PA subscribe on the PA thread (or queued until connected).
+  enable_pulse_subscribe();
+
+  logs::log(logs::info, "[PULSE_ROUTER] Started");
+}
+
+void PulseAudioRouter::stop() {
+  bool expected = true;
+  if (!started_.compare_exchange_strong(expected, false)) {
+    return; // not started
+  }
+
+  // Best-effort: unregister event handlers
+  try {
+    if (created_handler_) {
+      created_handler_->unregister();
+    }
+  } catch (...) {
+    // ignore
+  }
+  try {
+    if (stopped_handler_) {
+      stopped_handler_->unregister();
+    }
+  } catch (...) {
+    // ignore
+  }
+
+  disable_pulse_subscribe();
+
+  // Clear map
+  {
+    std::lock_guard<std::mutex> lk(map_mu_);
+    host_to_session_.clear();
+  }
+
+  logs::log(logs::info, "[PULSE_ROUTER] Stopped");
+}
+
+void PulseAudioRouter::rescan() {
+  if (!started_.load() || !pulse_server_ || !pulse_server_->ctx) return;
+
+  audio::queue_op(pulse_server_, [this]() {
+    if (!pulse_server_ || !pulse_server_->ctx) return;
+    auto *c = pulse_server_->ctx;
+    auto op = pa_context_get_sink_input_info_list(c, &PulseAudioRouter::pa_sink_input_info_cb, this);
+    if (op) pa_operation_unref(op);
+  });
+}
+
+void PulseAudioRouter::on_container_created(const events::DockerContainerCreated &ev) {
+  if (ev.hostname.empty() || ev.session_id.empty()) return;
+
+  {
+    std::lock_guard<std::mutex> lk(map_mu_);
+    host_to_session_[ev.hostname] = ev.session_id;
+  }
+
+  logs::log(logs::debug,
+            "[PULSE_ROUTER] Map add host='{}' -> session='{}' (container_id='{}')",
+            ev.hostname,
+            ev.session_id,
+            ev.container_id);
+
+  // Fix race: if sink-input already exists, route it now.
+  rescan();
+}
+
+void PulseAudioRouter::on_container_stopped(const events::DockerContainerStopped &ev) {
+  if (ev.hostname.empty()) return;
+
+  {
+    std::lock_guard<std::mutex> lk(map_mu_);
+    auto it = host_to_session_.find(ev.hostname);
+    if (it != host_to_session_.end()) {
+      // Optional: only erase if session matches (guards against hostname reuse)
+      if (ev.session_id.empty() || it->second == ev.session_id) {
+        host_to_session_.erase(it);
+      }
+    }
+  }
+
+  logs::log(logs::debug,
+            "[PULSE_ROUTER] Map del host='{}' session='{}' (container_id='{}')",
+            ev.hostname,
+            ev.session_id,
+            ev.container_id);
+}
+
+void PulseAudioRouter::enable_pulse_subscribe() {
+  if (!pulse_server_ || !pulse_server_->ctx) return;
+
+  audio::queue_op(pulse_server_, [this]() {
+    if (!pulse_server_ || !pulse_server_->ctx) return;
+    auto *c = pulse_server_->ctx;
+
+    pa_context_set_subscribe_callback(c, &PulseAudioRouter::pa_subscribe_cb, this);
+
+    auto op = pa_context_subscribe(c, PA_SUBSCRIPTION_MASK_SINK_INPUT, nullptr, nullptr);
+    if (op) pa_operation_unref(op);
+
+    // Also do an initial scan
+    auto op2 = pa_context_get_sink_input_info_list(c, &PulseAudioRouter::pa_sink_input_info_cb, this);
+    if (op2) pa_operation_unref(op2);
+
+    logs::log(logs::debug, "[PULSE_ROUTER] Enabled PulseAudio sink-input subscription");
+  });
+}
+
+void PulseAudioRouter::disable_pulse_subscribe() {
+  if (!pulse_server_ || !pulse_server_->ctx) return;
+
+  audio::queue_op(pulse_server_, [this]() {
+    if (!pulse_server_ || !pulse_server_->ctx) return;
+    auto *c = pulse_server_->ctx;
+
+    // Unsubscribe: set callback null and subscribe mask 0 (best-effort)
+    pa_context_set_subscribe_callback(c, nullptr, nullptr);
+    auto op = pa_context_subscribe(c, static_cast<pa_subscription_mask_t>(0), nullptr, nullptr);
+    if (op) pa_operation_unref(op);
+
+    logs::log(logs::debug, "[PULSE_ROUTER] Disabled PulseAudio sink-input subscription");
+  });
+}
+
+void PulseAudioRouter::pa_subscribe_cb(pa_context *c, unsigned int t, unsigned int idx, void *userdata) {
+  auto *self = static_cast<PulseAudioRouter *>(userdata);
+  if (!self || !self->started_.load()) return;
+
+  const auto ev = static_cast<pa_subscription_event_type_t>(t);
+  const auto facility = ev & PA_SUBSCRIPTION_EVENT_FACILITY_MASK;
+  const auto type = ev & PA_SUBSCRIPTION_EVENT_TYPE_MASK;
+
+  if (facility != PA_SUBSCRIPTION_EVENT_SINK_INPUT) return;
+  if (type != PA_SUBSCRIPTION_EVENT_NEW && type != PA_SUBSCRIPTION_EVENT_CHANGE) return;
+
+  // Query full info for this sink-input index
+  auto op = pa_context_get_sink_input_info(c, idx, &PulseAudioRouter::pa_sink_input_info_cb, userdata);
+  if (op) pa_operation_unref(op);
+}
+
+void PulseAudioRouter::pa_sink_input_info_cb(pa_context *c,
+                                            const pa_sink_input_info *info,
+                                            int eol,
+                                            void *userdata) {
+  if (eol || !info) return;
+  auto *self = static_cast<PulseAudioRouter *>(userdata);
+  if (!self || !self->started_.load()) return;
+
+  self->route_sink_input_(c, info);
+}
+
+void PulseAudioRouter::route_sink_input_(pa_context *c, const pa_sink_input_info *info) {
+  if (!info || !info->proplist) return;
+
+  const char *host = pa_proplist_gets(info->proplist, "application.process.host");
+  if (!host || host[0] == '\0') return;
+
+  auto target = target_sink_for_host_(host);
+  if (!target.has_value()) return;
+
+  // Move the sink-input to the session's virtual sink.
+  auto op = pa_context_move_sink_input_by_name(c, info->index, target->c_str(), nullptr, nullptr);
+  if (op) pa_operation_unref(op);
+
+  logs::log(logs::debug,
+            "[PULSE_ROUTER] Move sink-input={} host='{}' -> '{}'",
+            info->index,
+            host,
+            *target);
+}
+
+std::optional<std::string> PulseAudioRouter::target_sink_for_host_(std::string_view host) const {
+  std::lock_guard<std::mutex> lk(map_mu_);
+  auto it = host_to_session_.find(std::string(host));
+  if (it == host_to_session_.end()) return std::nullopt;
+  if (it->second.empty()) return std::nullopt;
+
+  return sink_prefix_ + it->second;
+}
+
+} // namespace wolf::core::audio
+```0

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -1,4 +1,5 @@
 #include "pulse_router.hpp"
+#include <immer/vector_transient.hpp>
 
 #include <core/audio.hpp>
 #include <helpers/logger.hpp>

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -220,4 +220,3 @@ std::optional<std::string> PulseAudioRouter::target_sink_for_host_(std::string_v
 }
 
 } // namespace wolf::core::audio
-```0

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -6,8 +6,11 @@
 
 #include <pulse/pulseaudio.h>
 #include <state/sessions.hpp>
+#include <sessions/common.hpp>
 
 #include <utility>
+
+using wolf::core::sessions::VIRTUAL_SINK_PREFIX;
 
 namespace wolf::core::audio {
 
@@ -148,7 +151,7 @@ void PulseAudioRouterState::route_sink_input_(pa_context* c, const pa_sink_input
   auto op = pa_context_move_sink_input_by_name(c, info->index, target->c_str(), nullptr, nullptr);
   if (op) pa_operation_unref(op);
 
-  logs::log(logs::debug,
+  logs::log(logs::info,
             "[PULSE_ROUTER] Move sink-input={} host='{}' -> '{}'",
             info->index,
             host,
@@ -158,7 +161,7 @@ void PulseAudioRouterState::route_sink_input_(pa_context* c, const pa_sink_input
 std::optional<std::string> PulseAudioRouterState::target_sink_for_host_(std::string_view host) const {
   auto m = host_to_session.load();
   if (auto session = m->find(std::string(host))) {
-    return sink_prefix + *session;
+    return std::string(VIRTUAL_SINK_PREFIX) + *session;
   }
   return std::nullopt;
 }

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -20,7 +20,7 @@ setup_pulseaudio_router_handlers(const immer::box<state::AppState>& app_state,
     logs::log(logs::warning, "[PULSE_ROUTER] No router state provided, cannot setup handlers");
     return handlers.persistent();
   }
-  if (!app_state || !app_state->event_bus) {
+  if (!app_state->event_bus) {
     logs::log(logs::warning, "[PULSE_ROUTER] No event bus provided, cannot setup handlers");
     return handlers.persistent();
   }

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -24,8 +24,8 @@ setup_pulseaudio_router_handlers(const immer::box<state::AppState>& app_state,
     logs::log(logs::warning, "[PULSE_ROUTER] No event bus provided, cannot setup handlers");
     return handlers.persistent();
   }
-  if (!state->pulse_server || !state->pulse_server->ctx) {
-    logs::log(logs::warning, "[PULSE_ROUTER] No Pulse server/context provided, cannot setup handlers");
+  if (!state->pulse_server) {
+    logs::log(logs::warning, "[PULSE_ROUTER] No Pulse server provided, cannot setup handlers");
     return handlers.persistent();
   }
 
@@ -50,11 +50,11 @@ setup_pulseaudio_router_handlers(const immer::box<state::AppState>& app_state,
 // --- PulseAudioRouterState implementation ------------------------------------
 
 void PulseAudioRouterState::rescan() {
-  if (!pulse_server || !pulse_server->ctx) return;
+  if (!pulse_server) return;
 
   audio::queue_op(pulse_server, [this]() {
-    if (!pulse_server || !pulse_server->ctx) return;
-    auto* c = pulse_server->ctx;
+    if (!pulse_server) return;
+    auto* c = audio::context(pulse_server);
     auto op = pa_context_get_sink_input_info_list(c, &PulseAudioRouterState::pa_sink_input_info_cb, this);
     if (op) pa_operation_unref(op);
   });
@@ -100,11 +100,11 @@ void PulseAudioRouterState::on_container_stopped(const events::DockerContainerSt
 }
 
 void PulseAudioRouterState::enable_pulse_subscribe() {
-  if (!pulse_server || !pulse_server->ctx) return;
+  if (!pulse_server) return;
 
   audio::queue_op(pulse_server, [this]() {
-    if (!pulse_server || !pulse_server->ctx) return;
-    auto* c = pulse_server->ctx;
+    if (!pulse_server) return;
+    auto* c = audio::context(pulse_server);
 
     pa_context_set_subscribe_callback(c, &PulseAudioRouterState::pa_subscribe_cb, this);
 

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -4,6 +4,7 @@
 #include <helpers/logger.hpp>
 
 #include <pulse/pulseaudio.h>
+#include <state/sessions.hpp>
 
 #include <utility>
 

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -153,7 +153,10 @@ void PulseAudioRouterState::enable_pulse_subscribe() {
     auto op2 = pa_context_get_sink_input_info_list(c, &PulseAudioRouterState::pa_sink_input_info_cb, this);
     if (op2) pa_operation_unref(op2);
 
-    logs::log(logs::debug, "[PULSE_ROUTER] Enabled PulseAudio sink-input subscription");
+    auto op3 = pa_context_get_sink_info_list(c, &PulseAudioRouterState::pa_sink_info_cb, this);
+    if (op3) pa_operation_unref(op3);
+
+    logs::log(logs::debug, "[PULSE_ROUTER] Enabled PulseAudio subscription (sink-input + sink)");
   });
 }
 

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -9,91 +9,61 @@
 
 namespace wolf::core::audio {
 
-PulseAudioRouter::PulseAudioRouter(std::shared_ptr<events::EventBusType> ev_bus,
-                                   std::shared_ptr<audio::Server> pulse_server,
-                                   std::string sink_prefix)
-    : ev_bus_(std::move(ev_bus)), pulse_server_(std::move(pulse_server)), sink_prefix_(std::move(sink_prefix)) {}
+immer::vector<immer::box<events::EventBusHandlers>>
+setup_pulseaudio_router_handlers(const immer::box<state::AppState>& app_state,
+                                 std::shared_ptr<PulseAudioRouterState> state) {
+  immer::vector_transient<immer::box<events::EventBusHandlers>> handlers;
 
-PulseAudioRouter::~PulseAudioRouter() { stop(); }
-
-void PulseAudioRouter::start() {
-  bool expected = false;
-  if (!started_.compare_exchange_strong(expected, true)) {
-    return; // already started
+  if (!state) {
+    logs::log(logs::warning, "[PULSE_ROUTER] No router state provided, cannot setup handlers");
+    return handlers.persistent();
+  }
+  if (!app_state || !app_state->event_bus) {
+    logs::log(logs::warning, "[PULSE_ROUTER] No event bus provided, cannot setup handlers");
+    return handlers.persistent();
+  }
+  if (!state->pulse_server || !state->pulse_server->ctx) {
+    logs::log(logs::warning, "[PULSE_ROUTER] No Pulse server/context provided, cannot setup handlers");
+    return handlers.persistent();
   }
 
-  if (!ev_bus_) {
-    logs::log(logs::warning, "[PULSE_ROUTER] No event bus provided, cannot start");
-    return;
-  }
-  if (!pulse_server_ || !pulse_server_->ctx) {
-    logs::log(logs::warning, "[PULSE_ROUTER] No Pulse server/context provided, cannot start");
-    return;
-  }
+  // Register handlers (Wolf pattern: store registrations in `handlers`)
+  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::DockerContainerCreated>>(
+      [state](const immer::box<events::DockerContainerCreated>& ev) {
+        if (state) state->on_container_created(*ev);
+      }));
 
-  // Keep handler registrations alive by storing them as members.
-  created_handler_ = ev_bus_->register_handler<immer::box<events::DockerContainerCreated>>(
-      [this](const immer::box<events::DockerContainerCreated> &ev) { on_container_created(*ev); });
+  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::DockerContainerStopped>>(
+      [state](const immer::box<events::DockerContainerStopped>& ev) {
+        if (state) state->on_container_stopped(*ev);
+      }));
 
-  stopped_handler_ = ev_bus_->register_handler<immer::box<events::DockerContainerStopped>>(
-      [this](const immer::box<events::DockerContainerStopped> &ev) { on_container_stopped(*ev); });
+  // Subscribe to sink-input events and do an initial scan
+  state->enable_pulse_subscribe();
 
-  // Enable PA subscribe on the PA thread (or queued until connected).
-  enable_pulse_subscribe();
-
-  logs::log(logs::info, "[PULSE_ROUTER] Started");
+  logs::log(logs::info, "[PULSE_ROUTER] Setup complete (handlers registered, PA subscribed)");
+  return handlers.persistent();
 }
 
-void PulseAudioRouter::stop() {
-  bool expected = true;
-  if (!started_.compare_exchange_strong(expected, false)) {
-    return; // not started
-  }
+// --- PulseAudioRouterState implementation ------------------------------------
 
-  // Best-effort: unregister event handlers
-  try {
-    if (created_handler_) {
-      created_handler_->unregister();
-    }
-  } catch (...) {
-    // ignore
-  }
-  try {
-    if (stopped_handler_) {
-      stopped_handler_->unregister();
-    }
-  } catch (...) {
-    // ignore
-  }
+void PulseAudioRouterState::rescan() {
+  if (!pulse_server || !pulse_server->ctx) return;
 
-  disable_pulse_subscribe();
-
-  // Clear map
-  {
-    std::lock_guard<std::mutex> lk(map_mu_);
-    host_to_session_.clear();
-  }
-
-  logs::log(logs::info, "[PULSE_ROUTER] Stopped");
-}
-
-void PulseAudioRouter::rescan() {
-  if (!started_.load() || !pulse_server_ || !pulse_server_->ctx) return;
-
-  audio::queue_op(pulse_server_, [this]() {
-    if (!pulse_server_ || !pulse_server_->ctx) return;
-    auto *c = pulse_server_->ctx;
-    auto op = pa_context_get_sink_input_info_list(c, &PulseAudioRouter::pa_sink_input_info_cb, this);
+  audio::queue_op(pulse_server, [this]() {
+    if (!pulse_server || !pulse_server->ctx) return;
+    auto* c = pulse_server->ctx;
+    auto op = pa_context_get_sink_input_info_list(c, &PulseAudioRouterState::pa_sink_input_info_cb, this);
     if (op) pa_operation_unref(op);
   });
 }
 
-void PulseAudioRouter::on_container_created(const events::DockerContainerCreated &ev) {
+void PulseAudioRouterState::on_container_created(const events::DockerContainerCreated& ev) {
   if (ev.hostname.empty() || ev.session_id.empty()) return;
 
   {
-    std::lock_guard<std::mutex> lk(map_mu_);
-    host_to_session_[ev.hostname] = ev.session_id;
+    std::lock_guard<std::mutex> lk(map_mu);
+    host_to_session[ev.hostname] = ev.session_id;
   }
 
   logs::log(logs::debug,
@@ -102,20 +72,20 @@ void PulseAudioRouter::on_container_created(const events::DockerContainerCreated
             ev.session_id,
             ev.container_id);
 
-  // Fix race: if sink-input already exists, route it now.
+  // If sink-input already exists, route it now.
   rescan();
 }
 
-void PulseAudioRouter::on_container_stopped(const events::DockerContainerStopped &ev) {
+void PulseAudioRouterState::on_container_stopped(const events::DockerContainerStopped& ev) {
   if (ev.hostname.empty()) return;
 
   {
-    std::lock_guard<std::mutex> lk(map_mu_);
-    auto it = host_to_session_.find(ev.hostname);
-    if (it != host_to_session_.end()) {
+    std::lock_guard<std::mutex> lk(map_mu);
+    auto it = host_to_session.find(ev.hostname);
+    if (it != host_to_session.end()) {
       // Optional: only erase if session matches (guards against hostname reuse)
       if (ev.session_id.empty() || it->second == ev.session_id) {
-        host_to_session_.erase(it);
+        host_to_session.erase(it);
       }
     }
   }
@@ -127,45 +97,29 @@ void PulseAudioRouter::on_container_stopped(const events::DockerContainerStopped
             ev.container_id);
 }
 
-void PulseAudioRouter::enable_pulse_subscribe() {
-  if (!pulse_server_ || !pulse_server_->ctx) return;
+void PulseAudioRouterState::enable_pulse_subscribe() {
+  if (!pulse_server || !pulse_server->ctx) return;
 
-  audio::queue_op(pulse_server_, [this]() {
-    if (!pulse_server_ || !pulse_server_->ctx) return;
-    auto *c = pulse_server_->ctx;
+  audio::queue_op(pulse_server, [this]() {
+    if (!pulse_server || !pulse_server->ctx) return;
+    auto* c = pulse_server->ctx;
 
-    pa_context_set_subscribe_callback(c, &PulseAudioRouter::pa_subscribe_cb, this);
+    pa_context_set_subscribe_callback(c, &PulseAudioRouterState::pa_subscribe_cb, this);
 
     auto op = pa_context_subscribe(c, PA_SUBSCRIPTION_MASK_SINK_INPUT, nullptr, nullptr);
     if (op) pa_operation_unref(op);
 
-    // Also do an initial scan
-    auto op2 = pa_context_get_sink_input_info_list(c, &PulseAudioRouter::pa_sink_input_info_cb, this);
+    // Initial scan
+    auto op2 = pa_context_get_sink_input_info_list(c, &PulseAudioRouterState::pa_sink_input_info_cb, this);
     if (op2) pa_operation_unref(op2);
 
     logs::log(logs::debug, "[PULSE_ROUTER] Enabled PulseAudio sink-input subscription");
   });
 }
 
-void PulseAudioRouter::disable_pulse_subscribe() {
-  if (!pulse_server_ || !pulse_server_->ctx) return;
-
-  audio::queue_op(pulse_server_, [this]() {
-    if (!pulse_server_ || !pulse_server_->ctx) return;
-    auto *c = pulse_server_->ctx;
-
-    // Unsubscribe: set callback null and subscribe mask 0 (best-effort)
-    pa_context_set_subscribe_callback(c, nullptr, nullptr);
-    auto op = pa_context_subscribe(c, static_cast<pa_subscription_mask_t>(0), nullptr, nullptr);
-    if (op) pa_operation_unref(op);
-
-    logs::log(logs::debug, "[PULSE_ROUTER] Disabled PulseAudio sink-input subscription");
-  });
-}
-
-void PulseAudioRouter::pa_subscribe_cb(pa_context *c, unsigned int t, unsigned int idx, void *userdata) {
-  auto *self = static_cast<PulseAudioRouter *>(userdata);
-  if (!self || !self->started_.load()) return;
+void PulseAudioRouterState::pa_subscribe_cb(pa_context* c, unsigned int t, unsigned int idx, void* userdata) {
+  auto* self = static_cast<PulseAudioRouterState*>(userdata);
+  if (!self) return;
 
   const auto ev = static_cast<pa_subscription_event_type_t>(t);
   const auto facility = ev & PA_SUBSCRIPTION_EVENT_FACILITY_MASK;
@@ -175,31 +129,30 @@ void PulseAudioRouter::pa_subscribe_cb(pa_context *c, unsigned int t, unsigned i
   if (type != PA_SUBSCRIPTION_EVENT_NEW && type != PA_SUBSCRIPTION_EVENT_CHANGE) return;
 
   // Query full info for this sink-input index
-  auto op = pa_context_get_sink_input_info(c, idx, &PulseAudioRouter::pa_sink_input_info_cb, userdata);
+  auto op = pa_context_get_sink_input_info(c, idx, &PulseAudioRouterState::pa_sink_input_info_cb, userdata);
   if (op) pa_operation_unref(op);
 }
 
-void PulseAudioRouter::pa_sink_input_info_cb(pa_context *c,
-                                            const pa_sink_input_info *info,
-                                            int eol,
-                                            void *userdata) {
+void PulseAudioRouterState::pa_sink_input_info_cb(pa_context* c,
+                                                 const pa_sink_input_info* info,
+                                                 int eol,
+                                                 void* userdata) {
   if (eol || !info) return;
-  auto *self = static_cast<PulseAudioRouter *>(userdata);
-  if (!self || !self->started_.load()) return;
+  auto* self = static_cast<PulseAudioRouterState*>(userdata);
+  if (!self) return;
 
   self->route_sink_input_(c, info);
 }
 
-void PulseAudioRouter::route_sink_input_(pa_context *c, const pa_sink_input_info *info) {
+void PulseAudioRouterState::route_sink_input_(pa_context* c, const pa_sink_input_info* info) {
   if (!info || !info->proplist) return;
 
-  const char *host = pa_proplist_gets(info->proplist, "application.process.host");
+  const char* host = pa_proplist_gets(info->proplist, "application.process.host");
   if (!host || host[0] == '\0') return;
 
   auto target = target_sink_for_host_(host);
   if (!target.has_value()) return;
 
-  // Move the sink-input to the session's virtual sink.
   auto op = pa_context_move_sink_input_by_name(c, info->index, target->c_str(), nullptr, nullptr);
   if (op) pa_operation_unref(op);
 
@@ -210,13 +163,13 @@ void PulseAudioRouter::route_sink_input_(pa_context *c, const pa_sink_input_info
             *target);
 }
 
-std::optional<std::string> PulseAudioRouter::target_sink_for_host_(std::string_view host) const {
-  std::lock_guard<std::mutex> lk(map_mu_);
-  auto it = host_to_session_.find(std::string(host));
-  if (it == host_to_session_.end()) return std::nullopt;
+std::optional<std::string> PulseAudioRouterState::target_sink_for_host_(std::string_view host) const {
+  std::lock_guard<std::mutex> lk(map_mu);
+  auto it = host_to_session.find(std::string(host));
+  if (it == host_to_session.end()) return std::nullopt;
   if (it->second.empty()) return std::nullopt;
 
-  return sink_prefix_ + it->second;
+  return sink_prefix + it->second;
 }
 
 } // namespace wolf::core::audio

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -43,11 +43,6 @@ setup_pulseaudio_router_handlers(const immer::box<state::AppState>& app_state,
         if (state) state->on_container_stopped(*ev);
       }));
 
-  handlers.push_back(app_state->event_bus->register_handler<immer::box<events::VirtualAudioSinkCreated>>(
-      [state](const immer::box<events::VirtualAudioSinkCreated>& ev) {
-        state->on_virtual_sink_created(*ev, state);
-      }));
-
   // Subscribe to sink-input events and do an initial scan
   state->enable_pulse_subscribe();
 
@@ -112,82 +107,34 @@ void PulseAudioRouterState::on_container_stopped(const events::DockerContainerSt
 
 }
 
-namespace {
-struct SinkResolveCtx {
-  std::shared_ptr<wolf::core::audio::PulseAudioRouterState> state;
-  std::string session_id;
-  std::string sink_name;
-};
-} // namespace
-
-void PulseAudioRouterState::on_virtual_sink_created(const events::VirtualAudioSinkCreated& ev, std::shared_ptr<PulseAudioRouterState> state_sp) {
-  if (ev.session_id.empty()) return;
-
-  // the sink index turns out to be the owner module index, which cannot be used to route sink
-  /*
-  session_to_sink_idx.update([&](auto m) {
-    return m.set(ev.session_id, ev.sink_index);
-  });
-  
-  logs::log(logs::debug,
-            "[PULSE_ROUTER] Sink ready session='{}' sink='{}' idx={}",
-            ev.session_id,
-            ev.sink_name,
-            ev.sink_index);
-
-  // Fix races: sink-input may already exist, or docker mapping may already exist
-  rescan();
-  */
-  if (!state_sp) return;
-
-  audio::queue_op(pulse_server, [state_sp,
-                                 session_id = ev.session_id,
-                                 sink_name = ev.sink_name]() {
-    if (!state_sp->pulse_server || !audio::context(state_sp->pulse_server)) return;
-
-    auto* ctx = new SinkResolveCtx{
-        .state = state_sp,
-        .session_id = session_id,
-        .sink_name = sink_name,
-    };
-
-    auto* c = audio::context(state_sp->pulse_server);
-    auto op = pa_context_get_sink_info_by_name(
-        c,
-        ctx->sink_name.c_str(),
-        &PulseAudioRouterState::pa_sink_info_by_name_cb,
-        ctx);
-    if (op) pa_operation_unref(op);
-  });
-}
-
-// function necessary to resolve the real sink index
-void PulseAudioRouterState::pa_sink_info_by_name_cb(pa_context* /*c*/,
+// resolve sink name to sink index
+void PulseAudioRouterState::pa_sink_info_cb(pa_context* /*c*/,
                                                     const pa_sink_info* info,
                                                     int eol,
                                                     void* userdata) {
-  auto* ctx = static_cast<SinkResolveCtx*>(userdata);
-  if (!ctx) return;
+  if (eol != 0 || !info) return;
+  auto* self = static_cast<PulseAudioRouterState*>(userdata);
+  if (!self) return;
 
-  if (eol) { // end of list / failure path
-    delete ctx;
-    return;
-  }
-  if (!info) return;
+  if (!info->name) return;
+  std::string_view name{info->name};
 
-  const uint32_t sink_idx = info->index;
+  // Prefix match
+  if (!name.starts_with(VIRTUAL_SINK_PREFIX)) return;
 
-  ctx->state->session_to_sink_idx.update([&](auto m) {
-    return m.set(ctx->session_id, sink_idx);
-  });
+  // session_id is suffix after prefix
+  std::string session_id{name.substr(VIRTUAL_SINK_PREFIX.size())};
+
+  self->session_to_sink_idx.update([&](auto m) { return m.set(session_id, info->index); });
 
   logs::log(logs::debug,
-            "[PULSE_ROUTER] Resolved sink '{}' -> idx={} for session '{}'",
-            ctx->sink_name,
-            sink_idx,
-            ctx->session_id);
+            "[PULSE_ROUTER] Sink appeared name='{}' idx={} -> session='{}'",
+            info->name,
+            info->index,
+            session_id);
 
-  ctx->state->rescan();
+  // route anything pending
+  self->rescan();
 }
 
 void PulseAudioRouterState::enable_pulse_subscribe() {
@@ -199,7 +146,7 @@ void PulseAudioRouterState::enable_pulse_subscribe() {
 
     pa_context_set_subscribe_callback(c, &PulseAudioRouterState::pa_subscribe_cb, this);
 
-    auto op = pa_context_subscribe(c, PA_SUBSCRIPTION_MASK_SINK_INPUT, nullptr, nullptr);
+    auto op = pa_context_subscribe(c, static_cast<pa_subscription_mask_t>(PA_SUBSCRIPTION_MASK_SINK_INPUT | PA_SUBSCRIPTION_MASK_SINK), nullptr, nullptr);
     if (op) pa_operation_unref(op);
 
     // Initial scan
@@ -217,11 +164,21 @@ void PulseAudioRouterState::pa_subscribe_cb(pa_context* c, pa_subscription_event
   const auto facility = t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK;
   const auto type     = t & PA_SUBSCRIPTION_EVENT_TYPE_MASK;
 
-  if (facility != PA_SUBSCRIPTION_EVENT_SINK_INPUT) return;
-  if (type != PA_SUBSCRIPTION_EVENT_NEW && type != PA_SUBSCRIPTION_EVENT_CHANGE) return;
+  if (facility == PA_SUBSCRIPTION_EVENT_SINK_INPUT) {
+    if (type == PA_SUBSCRIPTION_EVENT_NEW || type == PA_SUBSCRIPTION_EVENT_CHANGE) {
+      auto op = pa_context_get_sink_input_info(c, idx, &PulseAudioRouterState::pa_sink_input_info_cb, userdata);
+      if (op) pa_operation_unref(op);
+    }
+    return;
+  }
 
-  auto op = pa_context_get_sink_input_info(c, idx, &PulseAudioRouterState::pa_sink_input_info_cb, userdata);
-  if (op) pa_operation_unref(op);
+  if (facility == PA_SUBSCRIPTION_EVENT_SINK) {
+    if (type == PA_SUBSCRIPTION_EVENT_NEW || type == PA_SUBSCRIPTION_EVENT_CHANGE) {
+      auto op = pa_context_get_sink_info_by_index(c, idx, &PulseAudioRouterState::pa_sink_info_cb, userdata);
+      if (op) pa_operation_unref(op);
+    }
+    return;
+  }
 }
 
 void PulseAudioRouterState::pa_sink_input_info_cb(pa_context* c,

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -45,7 +45,7 @@ setup_pulseaudio_router_handlers(const immer::box<state::AppState>& app_state,
 
   handlers.push_back(app_state->event_bus->register_handler<immer::box<events::VirtualAudioSinkCreated>>(
       [state](const immer::box<events::VirtualAudioSinkCreated>& ev) {
-        state->on_virtual_sink_created(*ev);
+        state->on_virtual_sink_created(*ev, state);
       }));
 
   // Subscribe to sink-input events and do an initial scan
@@ -112,13 +112,23 @@ void PulseAudioRouterState::on_container_stopped(const events::DockerContainerSt
 
 }
 
-void PulseAudioRouterState::on_virtual_sink_created(const events::VirtualAudioSinkCreated& ev) {
+namespace {
+struct SinkResolveCtx {
+  std::shared_ptr<wolf::core::audio::PulseAudioRouterState> state;
+  std::string session_id;
+  std::string sink_name;
+};
+} // namespace
+
+void PulseAudioRouterState::on_virtual_sink_created(const events::VirtualAudioSinkCreated& ev, std::shared_ptr<PulseAudioRouterState> state_sp) {
   if (ev.session_id.empty()) return;
 
+  // the sink index turns out to be the owner module index, which cannot be used to route sink
+  /*
   session_to_sink_idx.update([&](auto m) {
     return m.set(ev.session_id, ev.sink_index);
   });
-
+  
   logs::log(logs::debug,
             "[PULSE_ROUTER] Sink ready session='{}' sink='{}' idx={}",
             ev.session_id,
@@ -127,6 +137,57 @@ void PulseAudioRouterState::on_virtual_sink_created(const events::VirtualAudioSi
 
   // Fix races: sink-input may already exist, or docker mapping may already exist
   rescan();
+  */
+  if (!state_sp) return;
+
+  audio::queue_op(pulse_server, [state_sp,
+                                 session_id = ev.session_id,
+                                 sink_name = ev.sink_name]() {
+    if (!state_sp->pulse_server || !audio::context(state_sp->pulse_server)) return;
+
+    auto* ctx = new SinkResolveCtx{
+        .state = state_sp,
+        .session_id = session_id,
+        .sink_name = sink_name,
+    };
+
+    auto* c = audio::context(state_sp->pulse_server);
+    auto op = pa_context_get_sink_info_by_name(
+        c,
+        ctx->sink_name.c_str(),
+        &PulseAudioRouterState::pa_sink_info_by_name_cb,
+        ctx);
+    if (op) pa_operation_unref(op);
+  });
+}
+
+// function necessary to resolve the real sink index
+void PulseAudioRouterState::pa_sink_info_by_name_cb(pa_context* /*c*/,
+                                                    const pa_sink_info* info,
+                                                    int eol,
+                                                    void* userdata) {
+  auto* ctx = static_cast<SinkResolveCtx*>(userdata);
+  if (!ctx) return;
+
+  if (eol) { // end of list / failure path
+    delete ctx;
+    return;
+  }
+  if (!info) return;
+
+  const uint32_t sink_idx = info->index;
+
+  ctx->state->session_to_sink_idx.update([&](auto m) {
+    return m.set(ctx->session_id, sink_idx);
+  });
+
+  logs::log(logs::debug,
+            "[PULSE_ROUTER] Resolved sink '{}' -> idx={} for session '{}'",
+            ctx->sink_name,
+            sink_idx,
+            ctx->session_id);
+
+  ctx->state->rescan();
 }
 
 void PulseAudioRouterState::enable_pulse_subscribe() {

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -119,18 +119,16 @@ void PulseAudioRouterState::enable_pulse_subscribe() {
   });
 }
 
-void PulseAudioRouterState::pa_subscribe_cb(pa_context* c, unsigned int t, unsigned int idx, void* userdata) {
+void PulseAudioRouterState::pa_subscribe_cb(pa_context* c, pa_subscription_event_type_t t, uint32_t idx, void* userdata) {
   auto* self = static_cast<PulseAudioRouterState*>(userdata);
   if (!self) return;
 
-  const auto ev = static_cast<pa_subscription_event_type_t>(t);
-  const auto facility = ev & PA_SUBSCRIPTION_EVENT_FACILITY_MASK;
-  const auto type = ev & PA_SUBSCRIPTION_EVENT_TYPE_MASK;
+  const auto facility = t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK;
+  const auto type     = t & PA_SUBSCRIPTION_EVENT_TYPE_MASK;
 
   if (facility != PA_SUBSCRIPTION_EVENT_SINK_INPUT) return;
   if (type != PA_SUBSCRIPTION_EVENT_NEW && type != PA_SUBSCRIPTION_EVENT_CHANGE) return;
 
-  // Query full info for this sink-input index
   auto op = pa_context_get_sink_input_info(c, idx, &PulseAudioRouterState::pa_sink_input_info_cb, userdata);
   if (op) pa_operation_unref(op);
 }

--- a/src/moonlight-server/audio/pulse_router.cpp
+++ b/src/moonlight-server/audio/pulse_router.cpp
@@ -63,10 +63,9 @@ void PulseAudioRouterState::rescan() {
 void PulseAudioRouterState::on_container_created(const events::DockerContainerCreated& ev) {
   if (ev.hostname.empty() || ev.session_id.empty()) return;
 
-  {
-    std::lock_guard<std::mutex> lk(map_mu);
-    host_to_session[ev.hostname] = ev.session_id;
-  }
+  host_to_session.update([&](auto m) {
+    return m.set(ev.hostname, ev.session_id);
+  });
 
   logs::log(logs::debug,
             "[PULSE_ROUTER] Map add host='{}' -> session='{}' (container_id='{}')",
@@ -81,16 +80,9 @@ void PulseAudioRouterState::on_container_created(const events::DockerContainerCr
 void PulseAudioRouterState::on_container_stopped(const events::DockerContainerStopped& ev) {
   if (ev.hostname.empty()) return;
 
-  {
-    std::lock_guard<std::mutex> lk(map_mu);
-    auto it = host_to_session.find(ev.hostname);
-    if (it != host_to_session.end()) {
-      // Optional: only erase if session matches (guards against hostname reuse)
-      if (ev.session_id.empty() || it->second == ev.session_id) {
-        host_to_session.erase(it);
-      }
-    }
-  }
+  host_to_session.update([&](auto m) {
+    return m.erase(ev.hostname);
+  });
 
   logs::log(logs::debug,
             "[PULSE_ROUTER] Map del host='{}' session='{}' (container_id='{}')",
@@ -164,12 +156,11 @@ void PulseAudioRouterState::route_sink_input_(pa_context* c, const pa_sink_input
 }
 
 std::optional<std::string> PulseAudioRouterState::target_sink_for_host_(std::string_view host) const {
-  std::lock_guard<std::mutex> lk(map_mu);
-  auto it = host_to_session.find(std::string(host));
-  if (it == host_to_session.end()) return std::nullopt;
-  if (it->second.empty()) return std::nullopt;
-
-  return sink_prefix + it->second;
+  auto m = host_to_session.load();
+  if (auto session = m->find(std::string(host))) {
+    return sink_prefix + *session;
+  }
+  return std::nullopt;
 }
 
 } // namespace wolf::core::audio

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <events/events.hpp>
+#include <immer/box.hpp>
+
+#include <atomic>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+// Forward-declare PulseAudio types (include <pulse/pulseaudio.h> in the .cpp)
+struct pa_context;
+struct pa_operation;
+struct pa_sink_input_info;
+
+namespace wolf::core::audio {
+
+// Forward-declare the Wolf Pulse server handle (defined in core/audio.*)
+struct Server;
+
+/**
+ * Routes PulseAudio sink-inputs to the correct per-session virtual sink.
+ *
+ * Mapping source:
+ *  - events::DockerContainerCreated / events::DockerContainerStopped
+ *    (hostname -> session_id)
+ *
+ * Routing rule:
+ *  - For any sink-input where application.process.host == hostname:
+ *      move sink-input to sink "virtual_sink_<session_id>"
+ *
+ * Intended to be created once (when the audio server is enabled) and kept alive
+ * for the lifetime of the Wolf process.
+ */
+class PulseAudioRouter {
+public:
+  PulseAudioRouter(std::shared_ptr<events::EventBusType> ev_bus,
+                   std::shared_ptr<audio::Server> pulse_server,
+                   std::string sink_prefix = "virtual_sink_");
+
+  ~PulseAudioRouter();
+
+  PulseAudioRouter(const PulseAudioRouter &) = delete;
+  PulseAudioRouter &operator=(const PulseAudioRouter &) = delete;
+
+  /// Registers event-bus handlers and enables PulseAudio sink-input subscription.
+  /// Safe to call multiple times; subsequent calls are no-ops.
+  void start();
+
+  /// Unregisters handlers and disables routing (best-effort).
+  /// Safe to call multiple times.
+  void stop();
+
+  /// Force a rescan of existing sink-inputs and route anything that matches the map.
+  void rescan();
+
+private:
+  // ---- Wolf event handlers ----
+  void on_container_created(const events::DockerContainerCreated &ev);
+  void on_container_stopped(const events::DockerContainerStopped &ev);
+
+  // ---- PulseAudio subscription ----
+  void enable_pulse_subscribe();
+  void disable_pulse_subscribe();
+
+  // Callback for pa_context_subscribe events
+  static void pa_subscribe_cb(pa_context *c, unsigned int t, unsigned int idx, void *userdata);
+
+  // Callback for pa_context_get_sink_input_info (and list)
+  static void pa_sink_input_info_cb(pa_context *c, const pa_sink_input_info *info, int eol, void *userdata);
+
+  // Core routing decision for one sink-input
+  void route_sink_input_(pa_context *c, const pa_sink_input_info *info);
+
+  // Compute target sink for a given host (container hostname)
+  std::optional<std::string> target_sink_for_host_(std::string_view host) const;
+
+private:
+  std::shared_ptr<events::EventBusType> ev_bus_;
+  std::shared_ptr<audio::Server> pulse_server_;
+  std::string sink_prefix_;
+
+  // Keep handler registrations alive
+  immer::box<events::EventBusHandlers> created_handler_;
+  immer::box<events::EventBusHandlers> stopped_handler_;
+
+  // hostname -> session_id
+  mutable std::mutex map_mu_;
+  std::unordered_map<std::string, std::string> host_to_session_;
+
+  std::atomic<bool> started_{false};
+};
+
+} // namespace wolf::core::audio

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -9,7 +9,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
-
+#include <state/sessions.hpp>
 #include <pulse/pulseaudio.h>
 
 struct pa_context;

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -29,6 +29,9 @@ struct PulseAudioRouterState {
   // hostname -> session_id
   immer::atom<immer::map<std::string, std::string>> host_to_session{immer::map<std::string, std::string>{}};
 
+  // session_id -> sink_index (from VirtualAudioSinkCreated)
+  immer::atom<immer::map<std::string, uint32_t>> session_to_sink_idx{immer::map<std::string, uint32_t>{}};
+
   // Pulse subscribe / callbacks
   void enable_pulse_subscribe();
   void rescan();
@@ -39,8 +42,9 @@ struct PulseAudioRouterState {
   void on_container_created(const events::DockerContainerCreated& ev);
   void on_container_stopped(const events::DockerContainerStopped& ev);
 
+  void on_virtual_sink_created(const events::VirtualAudioSinkCreated& ev);
+
   void route_sink_input_(pa_context* c, const pa_sink_input_info* info);
-  std::optional<std::string> target_sink_for_host_(std::string_view host) const;
 };
 
 /**

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -38,12 +38,11 @@ struct PulseAudioRouterState {
 
   static void pa_subscribe_cb(pa_context* c, pa_subscription_event_type_t t, uint32_t idx, void* userdata);
   static void pa_sink_input_info_cb(pa_context* c, const pa_sink_input_info* info, int eol, void* userdata);
+  static void pa_sink_info_cb(pa_context* c, const pa_sink_info* info, int eol, void* userdata);
 
   void on_container_created(const events::DockerContainerCreated& ev);
   void on_container_stopped(const events::DockerContainerStopped& ev);
 
-  void on_virtual_sink_created(const events::VirtualAudioSinkCreated& ev, std::shared_ptr<PulseAudioRouterState> state_sp);
-  static void pa_sink_info_by_name_cb(pa_context* c, const pa_sink_info* info, int eol, void* userdata);
   void route_sink_input_(pa_context* c, const pa_sink_input_info* info);
 };
 

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -10,6 +10,8 @@
 #include <string_view>
 #include <unordered_map>
 
+#include <pulse/pulseaudio.h>
+
 struct pa_context;
 struct pa_sink_input_info;
 
@@ -34,7 +36,7 @@ struct PulseAudioRouterState {
   void disable_pulse_subscribe();
   void rescan();
 
-  static void pa_subscribe_cb(pa_context* c, unsigned int t, unsigned int idx, void* userdata);
+  static void pa_subscribe_cb(pa_context* c, pa_subscription_event_type_t t, uint32_t idx, void* userdata);
   static void pa_sink_input_info_cb(pa_context* c, const pa_sink_input_info* info, int eol, void* userdata);
 
   void on_container_created(const events::DockerContainerCreated& ev);

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -2,95 +2,57 @@
 
 #include <events/events.hpp>
 #include <immer/box.hpp>
+#include <immer/vector.hpp>
 
-#include <atomic>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
-// Forward-declare PulseAudio types (include <pulse/pulseaudio.h> in the .cpp)
 struct pa_context;
-struct pa_operation;
 struct pa_sink_input_info;
 
 namespace wolf::core::audio {
 
-// Forward-declare the Wolf Pulse server handle (defined in core/audio.*)
 struct Server;
 
 /**
- * Routes PulseAudio sink-inputs to the correct per-session virtual sink.
- *
- * Mapping source:
- *  - events::DockerContainerCreated / events::DockerContainerStopped
- *    (hostname -> session_id)
- *
- * Routing rule:
- *  - For any sink-input where application.process.host == hostname:
- *      move sink-input to sink "virtual_sink_<session_id>"
- *
- * Intended to be created once (when the audio server is enabled) and kept alive
- * for the lifetime of the Wolf process.
+ * PulseAudio routing state.
+ * Kept alive by the caller together with the returned handler registrations.
  */
-class PulseAudioRouter {
-public:
-  PulseAudioRouter(std::shared_ptr<events::EventBusType> ev_bus,
-                   std::shared_ptr<audio::Server> pulse_server,
-                   std::string sink_prefix = "virtual_sink_");
-
-  ~PulseAudioRouter();
-
-  PulseAudioRouter(const PulseAudioRouter &) = delete;
-  PulseAudioRouter &operator=(const PulseAudioRouter &) = delete;
-
-  /// Registers event-bus handlers and enables PulseAudio sink-input subscription.
-  /// Safe to call multiple times; subsequent calls are no-ops.
-  void start();
-
-  /// Unregisters handlers and disables routing (best-effort).
-  /// Safe to call multiple times.
-  void stop();
-
-  /// Force a rescan of existing sink-inputs and route anything that matches the map.
-  void rescan();
-
-private:
-  // ---- Wolf event handlers ----
-  void on_container_created(const events::DockerContainerCreated &ev);
-  void on_container_stopped(const events::DockerContainerStopped &ev);
-
-  // ---- PulseAudio subscription ----
-  void enable_pulse_subscribe();
-  void disable_pulse_subscribe();
-
-  // Callback for pa_context_subscribe events
-  static void pa_subscribe_cb(pa_context *c, unsigned int t, unsigned int idx, void *userdata);
-
-  // Callback for pa_context_get_sink_input_info (and list)
-  static void pa_sink_input_info_cb(pa_context *c, const pa_sink_input_info *info, int eol, void *userdata);
-
-  // Core routing decision for one sink-input
-  void route_sink_input_(pa_context *c, const pa_sink_input_info *info);
-
-  // Compute target sink for a given host (container hostname)
-  std::optional<std::string> target_sink_for_host_(std::string_view host) const;
-
-private:
-  std::shared_ptr<events::EventBusType> ev_bus_;
-  std::shared_ptr<audio::Server> pulse_server_;
-  std::string sink_prefix_;
-
-  // Keep handler registrations alive
-  immer::box<events::EventBusHandlers> created_handler_;
-  immer::box<events::EventBusHandlers> stopped_handler_;
+struct PulseAudioRouterState {
+  std::shared_ptr<audio::Server> pulse_server;
+  std::string sink_prefix = "virtual_sink_";
 
   // hostname -> session_id
-  mutable std::mutex map_mu_;
-  std::unordered_map<std::string, std::string> host_to_session_;
+  mutable std::mutex map_mu;
+  std::unordered_map<std::string, std::string> host_to_session;
 
-  std::atomic<bool> started_{false};
+  // Pulse subscribe / callbacks
+  void enable_pulse_subscribe();
+  void disable_pulse_subscribe();
+  void rescan();
+
+  static void pa_subscribe_cb(pa_context* c, unsigned int t, unsigned int idx, void* userdata);
+  static void pa_sink_input_info_cb(pa_context* c, const pa_sink_input_info* info, int eol, void* userdata);
+
+  void on_container_created(const events::DockerContainerCreated& ev);
+  void on_container_stopped(const events::DockerContainerStopped& ev);
+
+  void route_sink_input_(pa_context* c, const pa_sink_input_info* info);
+  std::optional<std::string> target_sink_for_host_(std::string_view host) const;
 };
+
+/**
+ * Registers event handlers needed for routing, and enables PulseAudio subscribe.
+ *
+ * IMPORTANT:
+ * - The returned handlers must be kept alive, otherwise handlers unregister.
+ * - `state` must be kept alive as long as PulseAudio callbacks can fire.
+ */
+immer::vector<immer::box<events::EventBusHandlers>>
+setup_pulseaudio_router_handlers(const immer::box<state::AppState>& app_state,
+                                 std::shared_ptr<PulseAudioRouterState> state);
 
 } // namespace wolf::core::audio

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -31,8 +31,6 @@ struct PulseAudioRouterState {
   immer::atom<immer::map<std::string, std::string>> host_to_session{immer::map<std::string, std::string>{}};
 
   // Pulse subscribe / callbacks
-  void enable_pulse_subscribe();
-  void disable_pulse_subscribe();
   void rescan();
 
   static void pa_subscribe_cb(pa_context* c, pa_subscription_event_type_t t, uint32_t idx, void* userdata);

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -28,8 +28,7 @@ struct PulseAudioRouterState {
   std::string sink_prefix = "virtual_sink_";
 
   // hostname -> session_id
-  mutable std::mutex map_mu;
-  std::unordered_map<std::string, std::string> host_to_session;
+  immer::atom<immer::map<std::string, std::string>> host_to_session{immer::map<std::string, std::string>{}};
 
   // Pulse subscribe / callbacks
   void enable_pulse_subscribe();

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -25,12 +25,12 @@ struct Server;
  */
 struct PulseAudioRouterState {
   std::shared_ptr<audio::Server> pulse_server;
-  std::string sink_prefix = "virtual_sink_";
 
   // hostname -> session_id
   immer::atom<immer::map<std::string, std::string>> host_to_session{immer::map<std::string, std::string>{}};
 
   // Pulse subscribe / callbacks
+  void enable_pulse_subscribe();
   void rescan();
 
   static void pa_subscribe_cb(pa_context* c, pa_subscription_event_type_t t, uint32_t idx, void* userdata);

--- a/src/moonlight-server/audio/pulse_router.hpp
+++ b/src/moonlight-server/audio/pulse_router.hpp
@@ -42,8 +42,8 @@ struct PulseAudioRouterState {
   void on_container_created(const events::DockerContainerCreated& ev);
   void on_container_stopped(const events::DockerContainerStopped& ev);
 
-  void on_virtual_sink_created(const events::VirtualAudioSinkCreated& ev);
-
+  void on_virtual_sink_created(const events::VirtualAudioSinkCreated& ev, std::shared_ptr<PulseAudioRouterState> state_sp);
+  static void pa_sink_info_by_name_cb(pa_context* c, const pa_sink_info* info, int eol, void* userdata);
   void route_sink_input_(pa_context* c, const pa_sink_input_info* info);
 };
 

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -283,12 +283,6 @@ struct AudioSession {
   wolf::core::audio::AudioMode audio_mode;
 };
 
-struct VirtualAudioSinkCreated {
-  std::string session_id;
-  uint32_t sink_index;
-  std::string sink_name;
-};
-
 struct IDRRequestEvent {
   // A unique ID that identifies this session
   std::size_t session_id;
@@ -360,8 +354,7 @@ using EventBusHandlers = dp::handler_registration<immer::box<PlugDeviceEvent>,
                                                   immer::box<StopLobbyEvent>,
                                                   immer::box<SwitchStreamProducerEvents>,
                                                   immer::box<DockerContainerCreated>,
-                                                  immer::box<DockerContainerStopped>,
-                                                  immer::box<VirtualAudioSinkCreated>>;
+                                                  immer::box<DockerContainerStopped>>;
 using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<PairSignal>,
                                    immer::box<UnplugDeviceEvent>,
@@ -382,8 +375,7 @@ using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<StopLobbyEvent>,
                                    immer::box<SwitchStreamProducerEvents>,
                                    immer::box<DockerContainerCreated>,
-                                   immer::box<DockerContainerStopped>,
-                                   immer::box<VirtualAudioSinkCreated>>;
+                                   immer::box<DockerContainerStopped>>;
 using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<PairSignal>,
                                    immer::box<UnplugDeviceEvent>,
@@ -404,8 +396,7 @@ using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<StopLobbyEvent>,
                                    immer::box<SwitchStreamProducerEvents>,
                                    immer::box<DockerContainerCreated>,
-                                   immer::box<DockerContainerStopped>,
-                                   immer::box<VirtualAudioSinkCreated>>;
+                                   immer::box<DockerContainerStopped>>;
 
 /**
  * A StreamSession is created when a Moonlight user call `launch`

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -283,6 +283,12 @@ struct AudioSession {
   wolf::core::audio::AudioMode audio_mode;
 };
 
+struct VirtualAudioSinkCreated {
+  std::string session_id;
+  uint32_t sink_index;
+  std::string sink_name;
+};
+
 struct IDRRequestEvent {
   // A unique ID that identifies this session
   std::size_t session_id;
@@ -354,7 +360,8 @@ using EventBusHandlers = dp::handler_registration<immer::box<PlugDeviceEvent>,
                                                   immer::box<StopLobbyEvent>,
                                                   immer::box<SwitchStreamProducerEvents>,
                                                   immer::box<DockerContainerCreated>,
-                                                  immer::box<DockerContainerStopped>>;
+                                                  immer::box<DockerContainerStopped>,
+                                                  immer::box<VirtualAudioSinkCreated>>;
 using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<PairSignal>,
                                    immer::box<UnplugDeviceEvent>,
@@ -375,7 +382,8 @@ using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<StopLobbyEvent>,
                                    immer::box<SwitchStreamProducerEvents>,
                                    immer::box<DockerContainerCreated>,
-                                   immer::box<DockerContainerStopped>>;
+                                   immer::box<DockerContainerStopped>,
+                                   immer::box<VirtualAudioSinkCreated>>;
 using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<PairSignal>,
                                    immer::box<UnplugDeviceEvent>,
@@ -396,7 +404,8 @@ using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<StopLobbyEvent>,
                                    immer::box<SwitchStreamProducerEvents>,
                                    immer::box<DockerContainerCreated>,
-                                   immer::box<DockerContainerStopped>>;
+                                   immer::box<DockerContainerStopped>,
+                                   immer::box<VirtualAudioSinkCreated>>;
 
 /**
  * A StreamSession is created when a Moonlight user call `launch`

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -206,6 +206,18 @@ struct DockerPullImageEndEvent {
   bool success;
 };
 
+struct DockerContainerCreated {
+  std::string container_id;
+  std::string hostname; 
+  std::string session_id; 
+};
+
+struct DockerContainerStopped {
+  std::string container_id;
+  std::string hostname;
+  std::string session_id;
+};
+
 using MouseTypes = std::variant<input::Mouse, virtual_display::WaylandMouse>;
 using KeyboardTypes = std::variant<input::Keyboard, virtual_display::WaylandKeyboard>;
 using TouchScreenTypes = std::variant<input::TouchScreen, virtual_display::WaylandTouchScreen>;
@@ -340,7 +352,9 @@ using EventBusHandlers = dp::handler_registration<immer::box<PlugDeviceEvent>,
                                                   immer::box<LeaveLobbyEvent>,
                                                   immer::box<CreateLobbyEvent>,
                                                   immer::box<StopLobbyEvent>,
-                                                  immer::box<SwitchStreamProducerEvents>>;
+                                                  immer::box<SwitchStreamProducerEvents>,
+                                                  immer::box<DockerContainerCreated>,
+                                                  immer::box<DockerContainerStopped>>;
 using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<PairSignal>,
                                    immer::box<UnplugDeviceEvent>,
@@ -359,7 +373,9 @@ using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<LeaveLobbyEvent>,
                                    immer::box<CreateLobbyEvent>,
                                    immer::box<StopLobbyEvent>,
-                                   immer::box<SwitchStreamProducerEvents>>;
+                                   immer::box<SwitchStreamProducerEvents>,
+                                   immer::box<DockerContainerCreated>,
+                                   immer::box<DockerContainerStopped>>;
 using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<PairSignal>,
                                    immer::box<UnplugDeviceEvent>,
@@ -378,7 +394,9 @@ using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<LeaveLobbyEvent>,
                                    immer::box<CreateLobbyEvent>,
                                    immer::box<StopLobbyEvent>,
-                                   immer::box<SwitchStreamProducerEvents>>;
+                                   immer::box<SwitchStreamProducerEvents>,
+                                   immer::box<DockerContainerCreated>,
+                                   immer::box<DockerContainerStopped>>;
 
 /**
  * A StreamSession is created when a Moonlight user call `launch`

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -199,12 +199,12 @@ void RunDocker::run(std::string_view session_id,
     std::string inspected_hostname;
     if (auto inspected = docker_api.get_by_id(container_id)) {
       inspected_hostname = inspected->hostname;
-      this->ev_bus->fire_event(immer::box<events::DockerContainerCreated>(
+      this->ev_bus->fire_event(immer::box<events::DockerContainerCreated>{
           events::DockerContainerCreated{
               . = container_id,
               .hostname = inspected->hostname,
               .session_id = std::string(session_id),
-          }));
+          }});
     } else {
       logs::log(logs::warning, "[DOCKER] Unable to inspect container {} for hostname", container_id);
     }
@@ -285,12 +285,12 @@ void RunDocker::run(std::string_view session_id,
     logs::log(logs::debug, "[DOCKER] Container logs: \n{}", docker_api.get_logs(container_id));
     logs::log(logs::debug, "[DOCKER] Stopping container: {}", docker_container->name);
 
-    this->ev_bus->fire_event(immer::box<events::DockerContainerStopped>(
+    this->ev_bus->fire_event(immer::box<events::DockerContainerStopped>{
     events::DockerContainerStopped{
         .container_id = container_id,
         .hostname = inspected_hostname,
         .session_id = std::string(session_id),
-    }));
+    }});
     
     if (const auto env = utils::get_env("WOLF_STOP_CONTAINER_ON_EXIT")) {
       if (std::string(env) == "TRUE") {

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -201,7 +201,7 @@ void RunDocker::run(std::string_view session_id,
       inspected_hostname = inspected->hostname;
       this->ev_bus->fire_event(immer::box<events::DockerContainerCreated>{
           events::DockerContainerCreated{
-              . = container_id,
+              .container_id = container_id,
               .hostname = inspected->hostname,
               .session_id = std::string(session_id),
           }});

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -195,6 +195,19 @@ void RunDocker::run(std::string_view session_id,
 
     logs::log(logs::info, "[DOCKER] Starting container: {}", docker_container->name);
     logs::log(logs::debug, "[DOCKER] Starting container: {}", *docker_container);
+    
+    std::string inspected_hostname;
+    if (auto inspected = docker_api.get_by_id(container_id)) {
+      inspected_hostname = inspected->hostname;
+      this->ev_bus->push_event(immer::box<events::DockerContainerCreated>(
+          events::DockerContainerCreated{
+              .container_id = container_id,
+              .hostname = inspected->hostname,
+              .session_id = std::string(session_id),
+          }));
+    } else {
+      logs::log(logs::warning, "[DOCKER] Unable to inspect container {} for hostname", container_id);
+    }
 
     auto terminate_handler = this->ev_bus->register_handler<immer::box<events::StopStreamEvent>>(
         [session_id, container_id, this](const immer::box<events::StopStreamEvent> &terminate_ev) {
@@ -271,12 +284,21 @@ void RunDocker::run(std::string_view session_id,
 
     logs::log(logs::debug, "[DOCKER] Container logs: \n{}", docker_api.get_logs(container_id));
     logs::log(logs::debug, "[DOCKER] Stopping container: {}", docker_container->name);
+
+    this->ev_bus->push_event(immer::box<events::DockerContainerStopped>(
+    events::DockerContainerStopped{
+        .container_id = container_id,
+        .hostname = inspected_hostname,
+        .session_id = std::string(session_id),
+    }));
+    
     if (const auto env = utils::get_env("WOLF_STOP_CONTAINER_ON_EXIT")) {
       if (std::string(env) == "TRUE") {
         docker_api.stop_by_id(container_id);
         docker_api.remove_by_id(container_id);
       }
     }
+    
     logs::log(logs::info, "Stopped container: {}", docker_container->name);
     try {
       std::filesystem::remove_all(udev_base_path);

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -199,9 +199,9 @@ void RunDocker::run(std::string_view session_id,
     std::string inspected_hostname;
     if (auto inspected = docker_api.get_by_id(container_id)) {
       inspected_hostname = inspected->hostname;
-      this->ev_bus->push_event(immer::box<events::DockerContainerCreated>(
+      this->ev_bus->fire_event(immer::box<events::DockerContainerCreated>(
           events::DockerContainerCreated{
-              .container_id = container_id,
+              . = container_id,
               .hostname = inspected->hostname,
               .session_id = std::string(session_id),
           }));
@@ -285,7 +285,7 @@ void RunDocker::run(std::string_view session_id,
     logs::log(logs::debug, "[DOCKER] Container logs: \n{}", docker_api.get_logs(container_id));
     logs::log(logs::debug, "[DOCKER] Stopping container: {}", docker_container->name);
 
-    this->ev_bus->push_event(immer::box<events::DockerContainerStopped>(
+    this->ev_bus->fire_event(immer::box<events::DockerContainerStopped>(
     events::DockerContainerStopped{
         .container_id = container_id,
         .hostname = inspected_hostname,

--- a/src/moonlight-server/sessions/common.cpp
+++ b/src/moonlight-server/sessions/common.cpp
@@ -2,6 +2,7 @@
 #include <immer/map_transient.hpp>
 #include <platforms/hw.hpp>
 #include <sessions/handlers.hpp>
+#include <sessions/common.hpp>
 
 namespace wolf::core::sessions {
 
@@ -19,7 +20,7 @@ void start_runner(std::shared_ptr<events::Runner> runner,
   full_env.set("XDG_RUNTIME_DIR", args->xdg_runtime_dir);
   full_env.set("WOLF_SESSION_ID", args->session_id);
 
-  auto pulse_sink_name = fmt::format("virtual_sink_{}", args->session_id);
+  auto pulse_sink_name = fmt::format("{}{}", VIRTUAL_SINK_PREFIX, args->session_id);
   auto audio_server_name = args->audio_server ? audio::get_server_name(args->audio_server->server) : "";
   // TODO: properly separate XDG_RUNTIME_DIR from <pulse socket path>
   // for example on my dev machine it's ${XDG_RUNTIME_DIR}/pulse/native

--- a/src/moonlight-server/sessions/common.hpp
+++ b/src/moonlight-server/sessions/common.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <string_view>
+
+namespace wolf::core::sessions {
+constexpr std::string_view VIRTUAL_SINK_PREFIX = "virtual_sink_";
+}

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -160,6 +160,16 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
 
             lobby->audio_sink->store(v_device);
 
+            std::thread([ev_bus, lobby, v_device, pulse_sink_name] {
+              uint32_t idx = v_device->sink_idx.get_future().get();   // blocks until created
+              ev_bus->fire_event(immer::box<events::VirtualAudioSinkCreated>(
+              events::VirtualAudioSinkCreated{
+                .session_id = lobby->id,
+                .sink_index = idx,
+                .sink_name  = pulse_sink_name,
+              }));
+            }).detach();
+
             // Start Gstreamer producer pipeline
             std::thread([lobby, audio_server = audio_server->server, ev_bus, channel_count]() {
               auto sink_name = fmt::format("{}{}.monitor", VIRTUAL_SINK_PREFIX, lobby->id);

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -161,7 +161,8 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
             lobby->audio_sink->store(v_device);
 
             std::thread([ev_bus, lobby, v_device, pulse_sink_name] {
-              uint32_t idx = v_device->sink_idx.get_future().get();   // blocks until created
+              // set to 0 to avoid competing with vsink removal (and the sink_idx was the modlue idx instead, not useful here)
+              uint32_t idx = 0; // v_device->sink_idx.get_future().get();   // blocks until created
               ev_bus->fire_event(immer::box<events::VirtualAudioSinkCreated>(
               events::VirtualAudioSinkCreated{
                 .session_id = lobby->id,

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -160,17 +160,6 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
 
             lobby->audio_sink->store(v_device);
 
-            std::thread([ev_bus, lobby, v_device, pulse_sink_name] {
-              // set to 0 to avoid competing with vsink removal (and the sink_idx was the modlue idx instead, not useful here)
-              uint32_t idx = 0; // v_device->sink_idx.get_future().get();   // blocks until created
-              ev_bus->fire_event(immer::box<events::VirtualAudioSinkCreated>(
-              events::VirtualAudioSinkCreated{
-                .session_id = lobby->id,
-                .sink_index = idx,
-                .sink_name  = pulse_sink_name,
-              }));
-            }).detach();
-
             // Start Gstreamer producer pipeline
             std::thread([lobby, audio_server = audio_server->server, ev_bus, channel_count]() {
               auto sink_name = fmt::format("{}{}.monitor", VIRTUAL_SINK_PREFIX, lobby->id);

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -1,5 +1,6 @@
 #include <immer/vector_transient.hpp>
 #include <sessions/handlers.hpp>
+#include <sessions/common.hpp>
 #include <state/config.hpp>
 #include <state/data-structures.hpp>
 #include <state/sessions.hpp>
@@ -150,7 +151,7 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
 
         { // Create audio virtual sink
           logs::log(logs::debug, "[LOBBY] Create audio virtual sink");
-          auto pulse_sink_name = fmt::format("virtual_sink_{}", lobby->id);
+          auto pulse_sink_name = fmt::format("{}{}", VIRTUAL_SINK_PREFIX,  lobby->id);
           if (audio_server && audio_server->server) {
             auto channel_count = lobby_settings->audio_settings.channel_count;
             auto v_device = audio::create_virtual_sink(
@@ -161,7 +162,7 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
 
             // Start Gstreamer producer pipeline
             std::thread([lobby, audio_server = audio_server->server, ev_bus, channel_count]() {
-              auto sink_name = fmt::format("virtual_sink_{}.monitor", lobby->id);
+              auto sink_name = fmt::format("{}{}.monitor", VIRTUAL_SINK_PREFIX, lobby->id);
               streaming::start_audio_producer(lobby->id,
                                               ev_bus,
                                               channel_count,

--- a/src/moonlight-server/sessions/moonlight.cpp
+++ b/src/moonlight-server/sessions/moonlight.cpp
@@ -2,6 +2,7 @@
 #include <immer/map_transient.hpp>
 #include <immer/vector_transient.hpp>
 #include <sessions/handlers.hpp>
+#include <sessions/common.hpp>
 #include <state/sessions.hpp>
 #include <streaming/streaming.hpp>
 
@@ -135,7 +136,7 @@ setup_moonlight_handlers(const immer::box<state::AppState> &app_state,
 
         /* Create audio virtual sink */
         logs::log(logs::debug, "[STREAM_SESSION] Create virtual audio sink");
-        auto pulse_sink_name = fmt::format("virtual_sink_{}", session->session_id);
+        auto pulse_sink_name = fmt::format("{}{}", VIRTUAL_SINK_PREFIX,  session->session_id);
         std::shared_ptr<audio::VSink> v_device;
         if (session->app->start_audio_server && audio_server && audio_server->server) {
           v_device = audio::create_virtual_sink(
@@ -145,7 +146,7 @@ setup_moonlight_handlers(const immer::box<state::AppState> &app_state,
           session->audio_sink->store(v_device);
 
           std::thread([session, audio_server = audio_server->server]() {
-            auto sink_name = fmt::format("virtual_sink_{}.monitor", session->session_id);
+            auto sink_name = fmt::format("{}{}.monitor", VIRTUAL_SINK_PREFIX, session->session_id);
             streaming::start_audio_producer(std::to_string(session->session_id),
                                             session->event_bus,
                                             session->audio_channel_count,
@@ -245,7 +246,7 @@ setup_moonlight_handlers(const immer::box<state::AppState> &app_state,
           // Start streaming
           auto audio_server_name = audio_server ? audio::get_server_name(audio_server->server)
                                                 : std::optional<std::string>();
-          auto sink_name = fmt::format("virtual_sink_{}.monitor", sess->session_id);
+          auto sink_name = fmt::format("{}{}.monitor", VIRTUAL_SINK_PREFIX, sess->session_id);
           auto server_name = audio_server_name ? audio_server_name.value() : "";
 
           streaming::start_streaming_audio(sess,

--- a/src/moonlight-server/sessions/moonlight.cpp
+++ b/src/moonlight-server/sessions/moonlight.cpp
@@ -147,7 +147,8 @@ setup_moonlight_handlers(const immer::box<state::AppState> &app_state,
 
           auto ev_bus = app_state->event_bus;
           std::thread([ev_bus, session, v_device, pulse_sink_name] {
-            uint32_t idx = v_device->sink_idx.get_future().get();   // blocks until created
+            //set to 0 since it is not used, also to avoid competing on future with vsink removal
+            uint32_t idx = 0; // v_device->sink_idx.get_future().get();   // blocks until created
             ev_bus->fire_event(immer::box<events::VirtualAudioSinkCreated>(
             events::VirtualAudioSinkCreated{
               .session_id = std::to_string(session->session_id),

--- a/src/moonlight-server/sessions/moonlight.cpp
+++ b/src/moonlight-server/sessions/moonlight.cpp
@@ -145,18 +145,6 @@ setup_moonlight_handlers(const immer::box<state::AppState> &app_state,
                                  .mode = state::get_audio_mode(session->audio_channel_count, true)});
           session->audio_sink->store(v_device);
 
-          auto ev_bus = app_state->event_bus;
-          std::thread([ev_bus, session, v_device, pulse_sink_name] {
-            //set to 0 since it is not used, also to avoid competing on future with vsink removal
-            uint32_t idx = 0; // v_device->sink_idx.get_future().get();   // blocks until created
-            ev_bus->fire_event(immer::box<events::VirtualAudioSinkCreated>(
-            events::VirtualAudioSinkCreated{
-              .session_id = std::to_string(session->session_id),
-              .sink_index = idx,
-              .sink_name  = pulse_sink_name,
-            }));
-          }).detach();
-
           std::thread([session, audio_server = audio_server->server]() {
             auto sink_name = fmt::format("{}{}.monitor", VIRTUAL_SINK_PREFIX, session->session_id);
             streaming::start_audio_producer(std::to_string(session->session_id),

--- a/src/moonlight-server/sessions/moonlight.cpp
+++ b/src/moonlight-server/sessions/moonlight.cpp
@@ -145,6 +145,17 @@ setup_moonlight_handlers(const immer::box<state::AppState> &app_state,
                                  .mode = state::get_audio_mode(session->audio_channel_count, true)});
           session->audio_sink->store(v_device);
 
+          auto ev_bus = app_state->event_bus;
+          std::thread([ev_bus, session, v_device, pulse_sink_name] {
+            uint32_t idx = v_device->sink_idx.get_future().get();   // blocks until created
+            ev_bus->fire_event(immer::box<events::VirtualAudioSinkCreated>(
+            events::VirtualAudioSinkCreated{
+              .session_id = std::to_string(session->session_id),
+              .sink_index = idx,
+              .sink_name  = pulse_sink_name,
+            }));
+          }).detach();
+
           std::thread([session, audio_server = audio_server->server]() {
             auto sink_name = fmt::format("{}{}.monitor", VIRTUAL_SINK_PREFIX, session->session_id);
             streaming::start_audio_producer(std::to_string(session->session_id),

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -227,7 +227,7 @@ void run() {
   // PulseAudio sink-input router (hostname -> session_id -> virtual_sink_<session>)
   auto pulse_router_state = std::make_shared<audio::PulseAudioRouterState>();
   pulse_router_state->pulse_server = audio_server->server;
-  auto pulse_router_handlers = audio::setup_pulseaudio_router_handlers(app_state, pulse_router_state);
+  auto pulse_router_handlers = audio::setup_pulseaudio_router_handlers(local_state, pulse_router_state);
   // Setup event handlers for Moonlight related events (Start/Stop stream, hotplug, etc)
   auto moonlight_sess_handlers = sessions::setup_moonlight_handlers(local_state, runtime_dir, audio_server);
   // Setup event handlers for player Lobbies

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -225,8 +225,7 @@ void run() {
 
   auto audio_server = setup_audio_server(local_state->host->host_xdg_runtime_dir, runtime_dir);
   // PulseAudio sink-input router (hostname -> session_id -> virtual_sink_<session>)
-  auto pulse_router_state = std::make_shared<audio::PulseAudioRouterState>();
-  pulse_router_state->pulse_server = audio_server->server;
+  auto pulse_router_state = std::make_shared<audio::PulseAudioRouterState>(audio_server->server);
   auto pulse_router_handlers = audio::setup_pulseaudio_router_handlers(local_state, pulse_router_state);
   // Setup event handlers for Moonlight related events (Start/Stop stream, hotplug, etc)
   auto moonlight_sess_handlers = sessions::setup_moonlight_handlers(local_state, runtime_dir, audio_server);

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -1,4 +1,5 @@
 #include <api/api.hpp>
+#include <audio/pulse_router.hpp>
 #include <boost/asio.hpp>
 #include <chrono>
 #include <control/control.hpp>
@@ -223,6 +224,13 @@ void run() {
   }).detach();
 
   auto audio_server = setup_audio_server(local_state->host->host_xdg_runtime_dir, runtime_dir);
+  // PulseAudio sink-input router (hostname -> session_id -> virtual_sink_<session>)
+  std::shared_ptr<audio::PulseAudioRouter> pulse_router;
+  if (audio_server && audio_server->server) {
+    logs::log(logs::info, "[PULSE_ROUTER] Starting PulseAudio router");
+    pulse_router = std::make_shared<audio::PulseAudioRouter>(local_state->event_bus, audio_server->server);
+    pulse_router->start();
+  }
   // Setup event handlers for Moonlight related events (Start/Stop stream, hotplug, etc)
   auto moonlight_sess_handlers = sessions::setup_moonlight_handlers(local_state, runtime_dir, audio_server);
   // Setup event handlers for player Lobbies

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -225,12 +225,9 @@ void run() {
 
   auto audio_server = setup_audio_server(local_state->host->host_xdg_runtime_dir, runtime_dir);
   // PulseAudio sink-input router (hostname -> session_id -> virtual_sink_<session>)
-  std::shared_ptr<audio::PulseAudioRouter> pulse_router;
-  if (audio_server && audio_server->server) {
-    logs::log(logs::info, "[PULSE_ROUTER] Starting PulseAudio router");
-    pulse_router = std::make_shared<audio::PulseAudioRouter>(local_state->event_bus, audio_server->server);
-    pulse_router->start();
-  }
+  auto pulse_router_state = std::make_shared<audio::PulseAudioRouterState>();
+  pulse_router_state->pulse_server = audio_server->server;
+  auto pulse_router_handlers = audio::setup_pulseaudio_router_handlers(app_state, pulse_router_state);
   // Setup event handlers for Moonlight related events (Start/Stop stream, hotplug, etc)
   auto moonlight_sess_handlers = sessions::setup_moonlight_handlers(local_state, runtime_dir, audio_server);
   // Setup event handlers for player Lobbies


### PR DESCRIPTION
Implemented a pulse router to ensure correct sound input -> pulse sink routing. Some APPs ignore the $PULSE_SINK env and choose the wrong sink to output sound breaking multiuser isolation.