### PR TITLE
gpu-drivers: add Kisak-Mesa PPA for latest Mesa drivers

### DIFF
--- a/docker/gpu-drivers.Dockerfile
+++ b/docker/gpu-drivers.Dockerfile
@@ -12,12 +12,8 @@ ARG REQUIRED_PACKAGES="va-driver-all intel-media-va-driver-non-free \
                        libva-drm2 libva-x11-2 libvpl2"
 
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:kisak/kisak-mesa && \
-    apt-get update -y && \
     apt-get install -y --no-install-recommends \
     $REQUIRED_PACKAGES && \
-    apt-get remove -y --purge software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
 # libmfx is not available in Ubuntu 25.04 so we are building from sources (see: https://github.com/games-on-whales/wolf/issues/221)

--- a/docker/gpu-drivers.Dockerfile
+++ b/docker/gpu-drivers.Dockerfile
@@ -12,8 +12,12 @@ ARG REQUIRED_PACKAGES="va-driver-all intel-media-va-driver-non-free \
                        libva-drm2 libva-x11-2 libvpl2"
 
 RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository -y ppa:kisak/kisak-mesa && \
+    apt-get update -y && \
     apt-get install -y --no-install-recommends \
     $REQUIRED_PACKAGES && \
+    apt-get remove -y --purge software-properties-common && \
     rm -rf /var/lib/apt/lists/*
 
 # libmfx is not available in Ubuntu 25.04 so we are building from sources (see: https://github.com/games-on-whales/wolf/issues/221)

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -45,7 +45,7 @@ RUN <<_GST_WAYLAND_DISPLAY
     cd gst-wayland-display
     git checkout 67b1183
     # Pinned to 0.10.20: 0.10.21+ requires rustc 1.92, upgrade RUST_VERSION above if unpinning
-    cargo install cargo-c@0.10.20
+    cargo install cargo-c@0.10.20 --locked
     cargo cinstall --features="cuda" --prefix=/usr/local/lib/x86_64-linux-gnu/ --libdir=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
 _GST_WAYLAND_DISPLAY
 

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -44,7 +44,8 @@ RUN <<_GST_WAYLAND_DISPLAY
     git clone https://github.com/games-on-whales/gst-wayland-display
     cd gst-wayland-display
     git checkout 67b1183
-    cargo install cargo-c
+    # Pinned to 0.10.20: 0.10.21+ requires rustc 1.92, upgrade RUST_VERSION above if unpinning
+    cargo install cargo-c@0.10.20
     cargo cinstall --features="cuda" --prefix=/usr/local/lib/x86_64-linux-gnu/ --libdir=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
 _GST_WAYLAND_DISPLAY
 


### PR DESCRIPTION
## Summary
- Adds the [Kisak-Mesa PPA](https://launchpad.net/~kisak/+archive/ubuntu/kisak-mesa) to the GPU drivers container build
- GPU driver packages (`va-driver-all`, `intel-media-va-driver-non-free`, etc.) now resolve from the PPA's newer Mesa builds instead of the base image's default repositories
- `software-properties-common` is installed temporarily and purged after adding the PPA to keep the image lean

## Test plan
- [ ] Verify container builds successfully with the PPA
- [ ] Confirm Mesa driver versions in the built image come from Kisak-Mesa
- [ ] Test GPU acceleration functionality with the updated drivers