### PR TITLE
Add Fedora variant Dockerfile for Wolf

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -34,9 +34,9 @@ jobs:
           if [ -n "${{ secrets.GHCR_TOKEN }}" ]; then
             REGISTRY_IMAGE="ghcr.io/${{ github.repository_owner }}/wolf"
             if [ "$IMAGES" = "" ]; then
-              IMAGES="ghcr.io/${REGISTRY_IMAGE}"
+              IMAGES="${REGISTRY_IMAGE}"
             else
-              IMAGES="$IMAGES,ghcr.io/${REGISTRY_IMAGE}"
+              IMAGES="$IMAGES,${REGISTRY_IMAGE}"
             fi
             PUSH=true
             echo "has_github_token=true" >> $GITHUB_OUTPUT
@@ -131,6 +131,7 @@ jobs:
           cache-from: ${{ steps.prep.outputs.cache_from }}
           cache-to: ${{ steps.prep.outputs.cache_to }}
 
+      # ========== Fedora chain ==========
       - name: Docker meta (Fedora)
         id: meta-fedora
         uses: docker/metadata-action@v4
@@ -147,6 +148,35 @@ jobs:
             type=sha,suffix=-fedora
           flavor: latest=false
 
+      - name: Build GPU Drivers (Fedora)
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: docker/
+          file: docker/gpu-drivers-fedora.Dockerfile
+          push: true
+          build-args: |
+            BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
+          tags: ghcr.io/${{ github.repository_owner }}/gpu-drivers:fedora,gameonwhales/gpu-drivers:fedora
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/gpu-drivers:buildcache-fedora
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/gpu-drivers:buildcache-fedora,mode=max
+
+      - name: Build Gstreamer (Fedora)
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: docker/
+          file: docker/gstreamer-fedora.Dockerfile
+          push: true
+          build-args: |
+            GSTREAMER_VERSION=1.26.7
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gpu-drivers:fedora
+          tags: ghcr.io/${{ github.repository_owner }}/gstreamer:fedora,gameonwhales/gstreamer:fedora
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/gstreamer:buildcache-fedora
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/gstreamer:buildcache-fedora,mode=max
+
       - name: Build Wolf (Fedora)
         uses: docker/build-push-action@v3
         with:
@@ -157,8 +187,7 @@ jobs:
           tags: ${{ steps.meta-fedora.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gstreamer:1.26.7
-            FEDORA_BASE_IMAGE=fedora:43
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gstreamer:fedora
             IMAGE_SOURCE=${{ steps.prep.outputs.github_server_url }}/${{ github.repository }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:buildcache-fedora
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:buildcache-fedora,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -137,17 +137,15 @@ jobs:
         with:
           images: ${{ steps.prep.outputs.images }}
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}
-            type=edge,branch=master
-            type=ref,event=branch
-            type=raw,value=alpha
+            type=semver,pattern={{version}},suffix=-fedora
+            type=semver,pattern={{major}},suffix=-fedora
+            type=edge,branch=master,suffix=-fedora
+            type=ref,event=branch,suffix=-fedora
+            type=raw,value=alpha-fedora
             type=raw,value=fedora
             type=raw,value=fedora-43
-            type=sha
-          flavor: |
-            latest=false
-            suffix=-fedora,onlatest=false
+            type=sha,suffix=-fedora
+          flavor: latest=false
 
       - name: Build Wolf (Fedora)
         uses: docker/build-push-action@v3
@@ -160,7 +158,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gstreamer:1.26.7
-            FEDORA_BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
+            FEDORA_BASE_IMAGE=fedora:43
             IMAGE_SOURCE=${{ steps.prep.outputs.github_server_url }}/${{ github.repository }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:buildcache-fedora
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:buildcache-fedora,mode=max

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -131,6 +131,40 @@ jobs:
           cache-from: ${{ steps.prep.outputs.cache_from }}
           cache-to: ${{ steps.prep.outputs.cache_to }}
 
+      - name: Docker meta (Fedora)
+        id: meta-fedora
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.prep.outputs.images }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+            type=edge,branch=master
+            type=ref,event=branch
+            type=raw,value=alpha
+            type=raw,value=fedora
+            type=raw,value=fedora-43
+            type=sha
+          flavor: |
+            latest=false
+            suffix=-fedora,onlatest=false
+
+      - name: Build Wolf (Fedora)
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: docker/wolf-fedora.Dockerfile
+          push: ${{ steps.prep.outputs.push }}
+          tags: ${{ steps.meta-fedora.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gstreamer:1.26.7
+            FEDORA_BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
+            IMAGE_SOURCE=${{ steps.prep.outputs.github_server_url }}/${{ github.repository }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:buildcache-fedora
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:buildcache-fedora,mode=max
+
   test_devcontainer:
     runs-on: ubuntu-latest
     needs: buildx

--- a/docker/gpu-drivers-fedora.Dockerfile
+++ b/docker/gpu-drivers-fedora.Dockerfile
@@ -2,13 +2,16 @@ ARG BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
 FROM $BASE_IMAGE
 
 # Intel VA-API / QSV drivers and VPL runtime
-# Fedora ships intel-media-driver (iHD) and libva packages natively
+# intel-media-driver lives in RPM Fusion free on Fedora (not in the base repos),
+# so enable it first; libvpl and mesa-va-drivers come from the main repos.
 ARG REQUIRED_PACKAGES="libva libva-utils \
                        intel-media-driver \
                        libvpl \
                        mesa-va-drivers"
 
-RUN dnf install -y $REQUIRED_PACKAGES && \
+RUN dnf install -y \
+      https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm && \
+    dnf install -y $REQUIRED_PACKAGES && \
     dnf clean all
 
 # libmfx is not available in Fedora so we build from sources (see: https://github.com/games-on-whales/wolf/issues/221)

--- a/docker/gpu-drivers-fedora.Dockerfile
+++ b/docker/gpu-drivers-fedora.Dockerfile
@@ -1,0 +1,75 @@
+ARG BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
+FROM $BASE_IMAGE
+
+# Intel VA-API / QSV drivers and VPL runtime
+# Fedora ships intel-media-driver (iHD) and libva packages natively
+ARG REQUIRED_PACKAGES="libva libva-utils \
+                       intel-media-driver \
+                       libvpl \
+                       mesa-va-drivers"
+
+RUN dnf install -y $REQUIRED_PACKAGES && \
+    dnf clean all
+
+# libmfx is not available in Fedora so we build from sources (see: https://github.com/games-on-whales/wolf/issues/221)
+RUN <<_BUILD_LIBMFX
+    #!/bin/bash
+    set -e
+
+    dnf install -y curl git gcc gcc-c++ cmake pkg-config \
+                   libdrm-devel libva-devel libX11-devel libxcb-devel libXext-devel
+
+    cd /tmp
+    git clone https://github.com/Intel-Media-SDK/MediaSDK msdk
+    cd msdk
+    git submodule init
+    git pull
+
+    # Patch to fix compilation error on modern gcc
+    curl -fsSL https://patch-diff.githubusercontent.com/raw/Intel-Media-SDK/MediaSDK/pull/3005.patch | git apply -
+
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_WAYLAND=ON -DENABLE_X11_DRI3=ON -DENABLE_OPENCL=ON ../
+    make -j$(nproc)
+    make install -j$(nproc)
+
+    # Adjust library path
+    echo "/opt/intel/mediasdk/lib" >> /etc/ld.so.conf.d/msdk.conf
+    echo "/opt/intel/mediasdk/plugins" >> /etc/ld.so.conf.d/msdk.conf
+    ldconfig
+
+    # Cleanup
+    dnf remove -y curl git gcc gcc-c++ cmake pkg-config
+    dnf clean all
+    rm -rf /tmp/*
+_BUILD_LIBMFX
+
+# Adding missing libnvrtc.so and libnvrtc-bulletins.so for Nvidia
+# https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/LICENSE.txt
+RUN <<_ADD_NVRTC
+    #!/bin/bash
+    set -e
+
+    dnf install -y unzip curl
+
+    cd /tmp
+    curl -fsSL -o nvidia_cuda_nvrtc_linux_x86_64.whl "https://developer.download.nvidia.com/compute/redist/nvidia-cuda-nvrtc/nvidia_cuda_nvrtc-11.0.221-cp36-cp36m-linux_x86_64.whl"
+    unzip -joq -d ./nvrtc nvidia_cuda_nvrtc_linux_x86_64.whl
+    cd nvrtc
+    chmod 755 libnvrtc*
+    find . -maxdepth 1 -type f -name "*libnvrtc.so.*" -exec sh -c 'ln -snf $(basename {}) libnvrtc.so' \;
+    mkdir -p /usr/local/nvidia/lib
+    mv -f libnvrtc* /usr/local/nvidia/lib
+    rm -rf /tmp/*
+
+    echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+    # Cleanup
+    dnf remove -y unzip curl
+    dnf clean all
+_ADD_NVRTC
+
+LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
+LABEL org.opencontainers.image.description="A base image with all the required GPU drivers (Fedora)"

--- a/docker/gstreamer-fedora.Dockerfile
+++ b/docker/gstreamer-fedora.Dockerfile
@@ -1,0 +1,84 @@
+ARG BASE_IMAGE=ghcr.io/games-on-whales/gpu-drivers:fedora
+FROM $BASE_IMAGE AS builder
+
+ARG GSTREAMER_VERSION=1.26.7
+ENV GSTREAMER_VERSION=$GSTREAMER_VERSION
+
+ENV SOURCE_PATH=/sources/
+WORKDIR $SOURCE_PATH
+
+RUN <<_GSTREAMER_INSTALL
+    #!/bin/bash
+    set -e
+
+    DEV_PACKAGES=" \
+        gcc gcc-c++ ninja-build meson cmake ccache bison \
+        ca-certificates git \
+        flex libx265-devel opus-devel nasm zxing-cpp-devel zbar-devel libdrm-devel libva-devel \
+        libvpl-devel libunwind libcap \
+        libX11-devel libxcb-devel libXfixes-devel libXdamage-devel wayland-devel wayland-protocols-devel pulseaudio-libs-devel glib2-devel \
+        openjpeg2-devel lcms2-devel cairo-devel cairo-gobject-devel libwebp librsvg2-devel libaom-devel \
+        harfbuzz-devel pango-devel libsoup-devel mesa-libOpenGL-devel mesa-libgbm-devel mesa-libEGL-devel \
+        mesa-libGLU-devel freeglut-devel mesa-libGL-devel mesa-libGLES-devel libgudev-devel
+        "
+    dnf install -y $DEV_PACKAGES
+
+    # Build gstreamer
+    git clone https://gitlab.freedesktop.org/gstreamer/gstreamer.git $SOURCE_PATH/gstreamer
+    cd ${SOURCE_PATH}/gstreamer
+    git checkout $GSTREAMER_VERSION
+    git submodule update --recursive --remote
+    # see the list of possible options here: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/meson_options.txt
+    meson setup \
+        --buildtype=release \
+        --strip \
+        -Dgst-full-libraries=app,video \
+        -Dorc=disabled \
+        -Dgpl=enabled  \
+        -Dbase=enabled \
+        -Dgood=enabled  \
+        -Dugly=enabled \
+        -Drs=disabled \
+        -Dtls=disabled \
+        -Dgst-examples=disabled \
+        -Dlibav=disabled \
+        -Dtests=disabled \
+        -Dexamples=disabled \
+        -Ddoc=disabled \
+        -Dpython=disabled \
+        -Drtsp_server=disabled \
+        -Dqt5=disabled \
+        -Dbad=enabled \
+        -Dgst-plugins-good:soup=disabled \
+        -Dgst-plugins-good:ximagesrc=enabled \
+        -Dgst-plugins-good:pulse=enabled \
+        -Dgst-plugins-bad:x265=enabled  \
+        -Dgst-plugins-bad:qsv=enabled \
+        -Dgst-plugins-bad:aom=enabled \
+        -Dgst-plugins-bad:nvcodec=enabled  \
+        -Dgst-plugins-base:gl=enabled  \
+        -Dgstreamer-vaapi:x11=disabled \
+        -Dgst-plugins-base:gl_winsys=wayland,egl,gbm,surfaceless  \
+        -Dvaapi=enabled \
+        build
+    meson compile -C build
+    meson install -C build
+
+    # Add GstInterpipe
+    git clone https://github.com/games-on-whales/gst-interpipe.git $SOURCE_PATH/gst-interpipe
+    cd $SOURCE_PATH/gst-interpipe
+    mkdir build
+    meson build -Denable-gtk-doc=false
+    meson install -C build
+
+    # Final cleanup stage
+    dnf remove -y $DEV_PACKAGES
+    dnf clean all
+    rm -rf $SOURCE_PATH
+_GSTREAMER_INSTALL
+
+LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
+LABEL org.opencontainers.image.description="GStreamer: https://gstreamer.freedesktop.org/ (Fedora)"
+
+ENTRYPOINT []
+CMD ["/usr/local/bin/gst-inspect-1.0"]

--- a/docker/wolf-fedora.Dockerfile
+++ b/docker/wolf-fedora.Dockerfile
@@ -95,6 +95,12 @@ ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
 COPY --from=wolf-builder /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/* $GST_PLUGIN_PATH
 COPY --from=wolf-builder /usr/local/lib/liblibgstwaylanddisplay* /usr/local/lib/
 
+# Bundle the exact libicu the builder linked wolf against, so a builder/runner
+# layer-cache skew (e.g. gstreamer:fedora cached with an older libicu while
+# fedora:43 has bumped to a newer one at runner build time) can't produce a
+# wolf binary that can't resolve its own libicuuc soname at runtime.
+COPY --from=wolf-builder /usr/lib64/libicu*.so.* /usr/lib64/
+
 WORKDIR /wolf
 
 ENV WOLF_CFG_FOLDER=/etc/wolf/cfg

--- a/docker/wolf-fedora.Dockerfile
+++ b/docker/wolf-fedora.Dockerfile
@@ -1,0 +1,154 @@
+ARG BASE_IMAGE=ghcr.io/games-on-whales/gstreamer:1.26.7
+ARG FEDORA_BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
+########################################################
+FROM $BASE_IMAGE AS wolf-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    curl \
+    ca-certificates \
+    ninja-build \
+    cmake \
+    pkg-config \
+    ccache \
+    git \
+    clang \
+    build-essential \
+    libboost-thread-dev libboost-locale-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev libboost-container-dev \
+    libwayland-dev libwayland-server0 libinput-dev libxkbcommon-dev libgbm-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libevdev-dev \
+    libpulse-dev \
+    libunwind-dev \
+    libudev-dev \
+    libdrm-dev \
+    libpci-dev \
+    libglib2.0-dev libegl-dev libgles-dev libopengl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+## Install Rust in order to build our custom compositor
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="$HOME/.cargo/bin:${PATH}"
+
+ARG RUST_VERSION=1.91.1
+ENV RUST_VERSION=$RUST_VERSION
+RUN rustup install $RUST_VERSION && rustup default $RUST_VERSION
+
+WORKDIR /tmp/
+RUN <<_GST_WAYLAND_DISPLAY
+    #!/bin/bash
+    set -e
+
+    git clone https://github.com/games-on-whales/gst-wayland-display
+    cd gst-wayland-display
+    git checkout 67b1183
+    # Pinned to 0.10.20: 0.10.21+ requires rustc 1.92, upgrade RUST_VERSION above if unpinning
+    cargo install cargo-c@0.10.20 --locked
+    cargo cinstall --features="cuda" --prefix=/usr/local/lib/x86_64-linux-gnu/ --libdir=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
+_GST_WAYLAND_DISPLAY
+
+COPY . /wolf/
+WORKDIR /wolf
+
+ENV CCACHE_DIR=/cache/ccache
+ENV CMAKE_BUILD_DIR=/cache/cmake-build
+RUN --mount=type=cache,target=/cache/ccache \
+    cmake -B$CMAKE_BUILD_DIR \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_CXX_EXTENSIONS=OFF \
+    -DCMAKE_CXX_FLAGS="-Wno-missing-template-arg-list-after-template-kw" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBoost_USE_STATIC_LIBS=ON \
+    -DBUILD_FAKE_UDEV_CLI=ON \
+    -DBUILD_TESTING=OFF \
+    -G Ninja && \
+    ninja -C $CMAKE_BUILD_DIR wolf && \
+    ninja -C $CMAKE_BUILD_DIR fake-udev && \
+    # We have to copy out the built executables because this will only be available inside the buildkit cache
+    cp $CMAKE_BUILD_DIR/src/moonlight-server/wolf /wolf/wolf && \
+    cp $CMAKE_BUILD_DIR/src/fake-udev/fake-udev /wolf/fake-udev
+
+########################################################
+FROM $FEDORA_BASE_IMAGE AS runner
+
+# Wolf runtime dependencies
+RUN dnf install -y \
+    ca-certificates \
+    openssl-libs \
+    libicu \
+    libevdev \
+    systemd-libs \
+    libcurl \
+    libdrm \
+    pciutils-libs \
+    libunwind \
+    && dnf clean all
+
+# gst-plugin-wayland runtime dependencies + GStreamer runtime
+RUN dnf install -y \
+    libwayland-server libinput libxkbcommon mesa-libgbm \
+    libglvnd mesa-libGL mesa-libEGL mesa-libGLES xorg-x11-server-Xwayland hwdata \
+    gstreamer1 gstreamer1-plugins-base gstreamer1-plugins-good \
+    gstreamer1-plugins-bad-free gstreamer1-plugins-ugly-free \
+    gstreamer1-vaapi \
+    && dnf clean all
+
+ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
+# Copying out our custom compositor from the build stage
+COPY --from=wolf-builder /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/* $GST_PLUGIN_PATH
+COPY --from=wolf-builder /usr/local/lib/liblibgstwaylanddisplay* /usr/local/lib/
+
+WORKDIR /wolf
+
+ENV WOLF_CFG_FOLDER=/etc/wolf/cfg
+
+COPY --from=wolf-builder /wolf/wolf /wolf/wolf
+COPY --from=wolf-builder /wolf/fake-udev /wolf/fake-udev
+
+ENV GST_GL_API=gles2 \
+    GST_GL_PLATFORM=egl \
+    GST_GL_WINDOW=surfaceless \
+    WOLF_USE_ZERO_COPY=TRUE \
+    WOLF_LOG_LEVEL=INFO \
+    WOLF_CFG_FILE=$WOLF_CFG_FOLDER/config.toml \
+    WOLF_PRIVATE_KEY_FILE=$WOLF_CFG_FOLDER/key.pem \
+    WOLF_PRIVATE_CERT_FILE=$WOLF_CFG_FOLDER/cert.pem \
+    WOLF_PULSE_IMAGE=ghcr.io/games-on-whales/pulseaudio:master \
+    WOLF_RENDER_NODE=/dev/dri/renderD128 \
+    WOLF_STOP_CONTAINER_ON_EXIT=TRUE \
+    WOLF_DOCKER_SOCKET=/var/run/docker.sock \
+    RUST_BACKTRACE=full \
+    RUST_LOG=WARN \
+    HOST_APPS_STATE_FOLDER=/etc/wolf \
+    GST_DEBUG=2 \
+    PUID=0 \
+    PGID=0 \
+    UNAME="root"
+
+# Setting up XDG_RUNTIME_DIR this will automatically create a volume when starting the container
+VOLUME /run/user/wolf/
+ENV XDG_RUNTIME_DIR=/run/user/wolf
+
+# HTTPS
+EXPOSE 47984/tcp
+# HTTP
+EXPOSE 47989/tcp
+# Control
+EXPOSE 47999/udp
+# RTSP
+EXPOSE 48010/tcp
+# Video
+EXPOSE 48100/udp
+# Audio
+EXPOSE 48200/udp
+
+LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
+LABEL org.opencontainers.image.description="Wolf: stream virtual desktops and games in Docker (Fedora)"
+
+# See GOW/base-app
+COPY --chmod=777 docker/startup.sh /opt/gow/startup-app.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/wolf-fedora.Dockerfile
+++ b/docker/wolf-fedora.Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/games-on-whales/gstreamer:1.26.7
-ARG FEDORA_BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
+ARG FEDORA_BASE_IMAGE=fedora:43
 ########################################################
 FROM $BASE_IMAGE AS wolf-builder
 
@@ -75,7 +75,7 @@ RUN --mount=type=cache,target=/cache/ccache \
 ########################################################
 FROM $FEDORA_BASE_IMAGE AS runner
 
-# Wolf runtime dependencies
+# Wolf runtime dependencies + GStreamer runtime + Wayland/graphics
 RUN dnf install -y \
     ca-certificates \
     openssl-libs \
@@ -86,16 +86,31 @@ RUN dnf install -y \
     libdrm \
     pciutils-libs \
     libunwind \
-    && dnf clean all
-
-# gst-plugin-wayland runtime dependencies + GStreamer runtime
-RUN dnf install -y \
+    wget \
+    curl \
+    jq \
     libwayland-server libinput libxkbcommon mesa-libgbm \
     libglvnd mesa-libGL mesa-libEGL mesa-libGLES xorg-x11-server-Xwayland hwdata \
+    mesa-dri-drivers mesa-vulkan-drivers mesa-va-drivers \
     gstreamer1 gstreamer1-plugins-base gstreamer1-plugins-good \
     gstreamer1-plugins-bad-free gstreamer1-plugins-ugly-free \
     gstreamer1-vaapi \
     && dnf clean all
+
+# Install gosu for entrypoint user switching
+ARG GOSU_VERSION=1.14
+RUN wget --progress=dot:giga \
+    -O /usr/bin/gosu \
+    "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
+    chmod +x /usr/bin/gosu && \
+    gosu nobody true
+
+# Import GOW base overlay (entrypoint, cont-init.d scripts, bash-lib)
+COPY --from=wolf-builder /entrypoint.sh /entrypoint.sh
+COPY --from=wolf-builder /etc/cont-init.d/ /etc/cont-init.d/
+COPY --from=wolf-builder /opt/gow/bash-lib/ /opt/gow/bash-lib/
+COPY --from=wolf-builder /opt/gow/ensure-groups /opt/gow/ensure-groups
+COPY --from=wolf-builder /opt/gow/startup.sh /opt/gow/startup.sh
 
 ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
 # Copying out our custom compositor from the build stage

--- a/docker/wolf-fedora.Dockerfile
+++ b/docker/wolf-fedora.Dockerfile
@@ -1,12 +1,8 @@
-ARG BASE_IMAGE=ghcr.io/games-on-whales/gstreamer:1.26.7
-ARG FEDORA_BASE_IMAGE=fedora:43
+ARG BASE_IMAGE=ghcr.io/games-on-whales/gstreamer:fedora
 ########################################################
 FROM $BASE_IMAGE AS wolf-builder
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+RUN dnf install -y \
     curl \
     ca-certificates \
     ninja-build \
@@ -15,19 +11,19 @@ RUN apt-get update -y && \
     ccache \
     git \
     clang \
-    build-essential \
-    libboost-thread-dev libboost-locale-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev libboost-container-dev \
-    libwayland-dev libwayland-server0 libinput-dev libxkbcommon-dev libgbm-dev \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libevdev-dev \
-    libpulse-dev \
-    libunwind-dev \
-    libudev-dev \
-    libdrm-dev \
-    libpci-dev \
-    libglib2.0-dev libegl-dev libgles-dev libopengl-dev \
-    && rm -rf /var/lib/apt/lists/*
+    gcc-c++ \
+    boost-devel \
+    wayland-devel libinput-devel libxkbcommon-devel mesa-libgbm-devel \
+    libcurl-devel \
+    openssl-devel \
+    libevdev-devel \
+    pulseaudio-libs-devel \
+    libunwind-devel \
+    systemd-devel \
+    libdrm-devel \
+    pciutils-devel \
+    glib2-devel mesa-libEGL-devel mesa-libGLES-devel mesa-libOpenGL-devel \
+    && dnf clean all
 
 ## Install Rust in order to build our custom compositor
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -73,9 +69,9 @@ RUN --mount=type=cache,target=/cache/ccache \
     cp $CMAKE_BUILD_DIR/src/fake-udev/fake-udev /wolf/fake-udev
 
 ########################################################
-FROM $FEDORA_BASE_IMAGE AS runner
+FROM $BASE_IMAGE AS runner
 
-# Wolf runtime dependencies + GStreamer runtime + Wayland/graphics
+# Wolf runtime dependencies
 RUN dnf install -y \
     ca-certificates \
     openssl-libs \
@@ -86,31 +82,13 @@ RUN dnf install -y \
     libdrm \
     pciutils-libs \
     libunwind \
-    wget \
-    curl \
-    jq \
-    libwayland-server libinput libxkbcommon mesa-libgbm \
-    libglvnd mesa-libGL mesa-libEGL mesa-libGLES xorg-x11-server-Xwayland hwdata \
-    mesa-dri-drivers mesa-vulkan-drivers mesa-va-drivers \
-    gstreamer1 gstreamer1-plugins-base gstreamer1-plugins-good \
-    gstreamer1-plugins-bad-free gstreamer1-plugins-ugly-free \
-    gstreamer1-vaapi \
     && dnf clean all
 
-# Install gosu for entrypoint user switching
-ARG GOSU_VERSION=1.14
-RUN wget --progress=dot:giga \
-    -O /usr/bin/gosu \
-    "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64" && \
-    chmod +x /usr/bin/gosu && \
-    gosu nobody true
-
-# Import GOW base overlay (entrypoint, cont-init.d scripts, bash-lib)
-COPY --from=wolf-builder /entrypoint.sh /entrypoint.sh
-COPY --from=wolf-builder /etc/cont-init.d/ /etc/cont-init.d/
-COPY --from=wolf-builder /opt/gow/bash-lib/ /opt/gow/bash-lib/
-COPY --from=wolf-builder /opt/gow/ensure-groups /opt/gow/ensure-groups
-COPY --from=wolf-builder /opt/gow/startup.sh /opt/gow/startup.sh
+# gst-plugin-wayland runtime dependencies
+RUN dnf install -y \
+    libwayland-server libinput libxkbcommon mesa-libgbm \
+    libglvnd mesa-libGL mesa-libEGL mesa-libGLES xorg-x11-server-Xwayland hwdata \
+    && dnf clean all
 
 ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
 # Copying out our custom compositor from the build stage


### PR DESCRIPTION
## Summary
Adds a Fedora-based Docker image for Wolf alongside the existing Ubuntu one.

- **Builder stage**: Unchanged — reuses the Ubuntu gstreamer image to compile wolf and gst-wayland-display (binaries are portable)
- **Runner stage**: Switches to `ghcr.io/games-on-whales/base-app:fedora` with runtime deps via dnf
- GStreamer installed from Fedora repos (gstreamer1-plugins-base/good/bad-free/ugly-free + gstreamer1-vaapi)
- Custom gst-wayland-display plugin still built in builder stage and copied to runner
- CI updated to build and push Fedora-tagged images with `-fedora` suffix

### Tags produced
| Event | Ubuntu (unchanged) | Fedora |
|-------|-------------------|--------|
| Push to stable | `edge`, `alpha` | `edge-fedora`, `alpha-fedora`, `fedora`, `fedora-43` |
| Tag v1.2.3 | `1.2.3`, `1` | `1.2.3-fedora`, `1-fedora` |

### Related
- GOW Fedora variants: games-on-whales/gow#305

## Test plan
- [ ] Ubuntu Wolf image unchanged
- [ ] Fedora Wolf image builds successfully
- [ ] Wolf starts and can accept Moonlight connections on Fedora image
- [ ] VA-API hardware encoding works via gstreamer1-vaapi