### PR TITLE
Fix session containers to run as retro

### DIFF
--- a/src/moonlight-server/sessions/common.cpp
+++ b/src/moonlight-server/sessions/common.cpp
@@ -65,6 +65,7 @@ void start_runner(std::shared_ptr<events::Runner> runner,
 
   full_env.set("PUID", std::to_string(args->client_settings->run_uid));
   full_env.set("PGID", std::to_string(args->client_settings->run_gid));
+  full_env.set("UNAME", "retro");
 
   // Add fake-udev and udev mounts
   mounted_paths.push_back(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRC_LIST
         testCrypto.cpp
         testGSTPlugin.cpp
         testMoonlight.cpp
+        testRunner.cpp
         testRTSP.cpp
         testWolfAPI.cpp
         testBatchedSend.cpp)

--- a/tests/testRunner.cpp
+++ b/tests/testRunner.cpp
@@ -1,0 +1,78 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <events/events.hpp>
+#include <sessions/handlers.hpp>
+#include <state/data-structures.hpp>
+#include <map>
+#include <memory>
+#include <optional>
+
+using namespace wolf::core;
+
+namespace {
+
+class RecordingRunner : public events::Runner {
+public:
+  std::map<std::string, std::string> env;
+
+  void run(std::string_view,
+           std::string_view,
+           std::string_view,
+           std::shared_ptr<events::devices_atom_queue>,
+           const immer::array<std::string> &,
+           const immer::array<std::pair<std::string, std::string>> &,
+           const immer::map<std::string, std::string> &env_variables,
+           std::string_view) override {
+    for (const auto &[key, value] : env_variables) {
+      env.emplace(key, value);
+    }
+  }
+
+  events::RunnerTypes serialize() const override {
+    return config::AppCMD{"true"};
+  }
+};
+
+} // namespace
+
+TEST_CASE("Session runners use the retro user", "[Runner]") {
+  auto runner = std::make_shared<RecordingRunner>();
+  auto plugged_devices_queue = std::make_shared<events::devices_atom_queue>();
+
+  auto host = immer::box<state::Host>{state::Host{{},
+                                                  {},
+                                                  nullptr,
+                                                  nullptr,
+                                                  {},
+                                                  {},
+                                                  "/tmp/wolf-host-state",
+                                                  "/tmp/wolf-local-state",
+                                                  "/tmp/wolf-runtime"}};
+
+  auto client_settings = immer::box<config::ClientSettings>{config::ClientSettings{1000, 1000, {}, 1.0f, 1.0f, 1.0f}};
+
+  const std::string session_id = "session-123";
+  const std::string app_local_state_folder = "/tmp/wolf-app-local";
+  const std::string app_host_state_folder = "/tmp/wolf-app-host";
+  const std::string xdg_runtime_dir = "/run/user/wolf";
+  const std::optional<sessions::AudioServer> audio_server = std::nullopt;
+  const std::shared_ptr<audio::VSink> audio_sink = nullptr;
+  const events::VideoSettings video_settings{1920, 1080, 60, "", "/tmp/does-not-exist", "video/x-raw"};
+
+  sessions::start_runner(runner,
+                         plugged_devices_queue,
+                         immer::box<sessions::RunnerArgs>{sessions::RunnerArgs{session_id,
+                                                                              video_settings,
+                                                                              nullptr,
+                                                                              audio_server,
+                                                                              audio_sink,
+                                                                              host,
+                                                                              app_local_state_folder,
+                                                                              app_host_state_folder,
+                                                                              xdg_runtime_dir,
+                                                                              client_settings}});
+
+  REQUIRE(runner->env.at("PUID") == "1000");
+  REQUIRE(runner->env.at("PGID") == "1000");
+  REQUIRE(runner->env.at("UNAME") == "retro");
+}

--- a/tests/testRunner.cpp
+++ b/tests/testRunner.cpp
@@ -3,6 +3,7 @@
 #include <events/events.hpp>
 #include <sessions/handlers.hpp>
 #include <state/data-structures.hpp>
+#include <state/serialised_config.hpp>
 #include <map>
 #include <memory>
 #include <optional>
@@ -29,7 +30,7 @@ public:
   }
 
   events::RunnerTypes serialize() const override {
-    return config::AppCMD{"true"};
+    return wolf::config::AppCMD{"true"};
   }
 };
 
@@ -49,7 +50,8 @@ TEST_CASE("Session runners use the retro user", "[Runner]") {
                                                   "/tmp/wolf-local-state",
                                                   "/tmp/wolf-runtime"}};
 
-  auto client_settings = immer::box<config::ClientSettings>{config::ClientSettings{1000, 1000, {}, 1.0f, 1.0f, 1.0f}};
+  auto client_settings = immer::box<wolf::config::ClientSettings>{
+      wolf::config::ClientSettings{1000, 1000, {}, 1.0f, 1.0f, 1.0f}};
 
   const std::string session_id = "session-123";
   const std::string app_local_state_folder = "/tmp/wolf-app-local";


### PR DESCRIPTION
## Summary
- set `UNAME=retro` for Wolf-launched session containers alongside the existing `PUID` and `PGID` overrides
- add a regression test around `sessions::start_runner` so session container env construction keeps the non-root runtime user

## Root Cause
Wolf already overrides the numeric runtime IDs for session containers, but it does not override `UNAME`. GoW images such as `wolf-ui` default that variable to `root`, and the base entrypoint only switches to the non-root path when `UNAME != root`. That leaves session containers running as root even when Wolf is trying to launch them with the paired client's runtime UID/GID.

## Validation
- `git diff --check`
- added a focused `start_runner` regression test covering the session env
