### PR TITLE
Harden NVIDIA device and PulseAudio startup handling

### DIFF
--- a/src/gst-video-context/gst-video-context/stub/cuda.h
+++ b/src/gst-video-context/gst-video-context/stub/cuda.h
@@ -39,6 +39,10 @@ typedef guint64 CUtexObject;
 typedef guintptr CUdeviceptr;
 typedef gint CUdevice;
 
+typedef struct CUuuid_st {                                /**< CUDA definition of UUID */
+  char bytes[16];
+} CUuuid;
+
 typedef enum {
   CUDA_SUCCESS = 0,
   CUDA_ERROR_NO_DEVICE = 100,

--- a/src/gst-video-context/gst-video-context/stub/cuda.h
+++ b/src/gst-video-context/gst-video-context/stub/cuda.h
@@ -39,7 +39,7 @@ typedef guint64 CUtexObject;
 typedef guintptr CUdeviceptr;
 typedef gint CUdevice;
 
-typedef struct CUuuid_st {                                /**< CUDA definition of UUID */
+typedef struct CUuuid_st { /**< CUDA definition of UUID */
   char bytes[16];
 } CUuuid;
 

--- a/src/moonlight-server/platforms/hw_linux.cpp
+++ b/src/moonlight-server/platforms/hw_linux.cpp
@@ -12,6 +12,7 @@
 #include <net/ethernet.h>
 #include <netinet/in.h>
 #include <optional>
+#include <system_error>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -105,6 +106,19 @@ std::shared_ptr<drmDevice> drm_open_device(std::string_view device) {
           }};
 }
 
+void add_character_device(std::vector<std::string> &devices, std::string_view path) {
+  std::error_code err;
+  auto device_path = std::filesystem::path(path);
+  if (std::filesystem::is_character_file(device_path, err)) {
+    devices.emplace_back(path);
+    return;
+  }
+
+  if (!err && std::filesystem::exists(device_path, err)) {
+    logs::log(logs::warning, "Skipping {}, it exists but is not a character device", path);
+  }
+}
+
 std::vector<std::string> linked_devices(std::string_view gpu) {
   std::vector<std::string> found_devices;
 
@@ -118,20 +132,11 @@ std::vector<std::string> linked_devices(std::string_view gpu) {
     std::string primary_node = device->nodes[DRM_NODE_PRIMARY];
     found_devices.emplace_back(primary_node);
     if (auto nvidia_node = get_nvidia_node(primary_node)) {
-      found_devices.emplace_back(nvidia_node.value());
-
-      if (std::filesystem::exists("/dev/nvidia-modeset")) {
-        found_devices.emplace_back("/dev/nvidia-modeset");
-      }
-      if (std::filesystem::exists("/dev/nvidia-uvm")) {
-        found_devices.emplace_back("/dev/nvidia-uvm");
-      }
-      if (std::filesystem::exists("/dev/nvidia-uvm-tools")) {
-        found_devices.emplace_back("/dev/nvidia-uvm-tools");
-      }
-      if (std::filesystem::exists("/dev/nvidiactl")) {
-        found_devices.emplace_back("/dev/nvidiactl");
-      }
+      add_character_device(found_devices, nvidia_node.value());
+      add_character_device(found_devices, "/dev/nvidia-modeset");
+      add_character_device(found_devices, "/dev/nvidia-uvm");
+      add_character_device(found_devices, "/dev/nvidia-uvm-tools");
+      add_character_device(found_devices, "/dev/nvidiactl");
     }
 
     std::string render_node = device->nodes[DRM_NODE_RENDER];

--- a/src/moonlight-server/platforms/hw_linux.cpp
+++ b/src/moonlight-server/platforms/hw_linux.cpp
@@ -106,7 +106,7 @@ std::shared_ptr<drmDevice> drm_open_device(std::string_view device) {
           }};
 }
 
-void add_character_device(std::vector<std::string> &devices, std::string_view path) {
+void add_character_device(std::vector<std::string> &devices, std::string_view path, bool optional = false) {
   std::error_code err;
   auto device_path = std::filesystem::path(path);
   if (std::filesystem::is_character_file(device_path, err)) {
@@ -115,7 +115,14 @@ void add_character_device(std::vector<std::string> &devices, std::string_view pa
   }
 
   if (!err && std::filesystem::exists(device_path, err)) {
-    logs::log(logs::warning, "Skipping {}, it exists but is not a character device", path);
+    if (optional) {
+      logs::log(logs::warning, "Skipping {}, it exists but is not a character device", path);
+    } else {
+      logs::log(logs::error,
+                "{} exists but is not a character device; this NVIDIA device is required and the container may not "
+                "work correctly. In LXC containers, ensure the device is properly mapped as a character device.",
+                path);
+    }
   }
 }
 
@@ -135,7 +142,7 @@ std::vector<std::string> linked_devices(std::string_view gpu) {
       add_character_device(found_devices, nvidia_node.value());
       add_character_device(found_devices, "/dev/nvidia-modeset");
       add_character_device(found_devices, "/dev/nvidia-uvm");
-      add_character_device(found_devices, "/dev/nvidia-uvm-tools");
+      add_character_device(found_devices, "/dev/nvidia-uvm-tools", true);
       add_character_device(found_devices, "/dev/nvidiactl");
     }
 

--- a/src/moonlight-server/platforms/hw_linux.cpp
+++ b/src/moonlight-server/platforms/hw_linux.cpp
@@ -12,8 +12,8 @@
 #include <net/ethernet.h>
 #include <netinet/in.h>
 #include <optional>
-#include <system_error>
 #include <sys/socket.h>
+#include <system_error>
 #include <unistd.h>
 
 extern "C" {

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -139,7 +139,7 @@ std::optional<sessions::AudioServer> setup_audio_server(const std::string &host_
             .status = docker::CREATED,
             .ports = {},
             .mounts = {docker::MountPoint{.source = host_runtime_dir, .destination = "/tmp/pulse/", .mode = "rw"}},
-            .env = {"XDG_RUNTIME_DIR=/tmp/pulse/", "UNAME=retro", "UID=1000", "GID=1000"}},
+            .env = {"XDG_RUNTIME_DIR=/tmp/pulse/", "UNAME=retro", "UID=1000", "GID=1000", "HOME=/home/retro"}},
         // The following is needed when using podman (or any container that uses SELINUX). This way we can access the
         // socket that is created by PulseAudio from other containers (including this one).
         R"({

--- a/tests/platforms/linux/nvidia.cpp
+++ b/tests/platforms/linux/nvidia.cpp
@@ -3,6 +3,7 @@
 #include <catch2/matchers/catch_matchers_contains.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
+#include <algorithm>
 #include <filesystem>
 #include <helpers/logger.hpp>
 #include <platforms/hw.hpp>
@@ -36,7 +37,11 @@ TEST_CASE("libdrm find linked devices", "[NVIDIA]") {
   REQUIRE_THAT(devices, Contains("/dev/nvidia0"));
   REQUIRE_THAT(devices, Contains("/dev/nvidia-modeset"));
   REQUIRE_THAT(devices, Contains("/dev/nvidia-uvm"));
-  REQUIRE_THAT(devices, Contains("/dev/nvidia-uvm-tools"));
+  if (std::filesystem::is_character_file("/dev/nvidia-uvm-tools")) {
+    REQUIRE_THAT(devices, Contains("/dev/nvidia-uvm-tools"));
+  } else {
+    REQUIRE(std::find(devices.begin(), devices.end(), "/dev/nvidia-uvm-tools") == devices.end());
+  }
   REQUIRE_THAT(devices, Contains("/dev/nvidiactl"));
 
   REQUIRE_THAT(linked_devices("/dev/dri/a_non_existing_thing"), SizeIs(0));


### PR DESCRIPTION
## Summary
- skip linked NVIDIA device paths unless they are character devices before passing them to Docker app containers
- set HOME=/home/retro when Wolf launches the PulseAudio helper container
- update the NVIDIA linked-device test to reflect optional /dev/nvidia-uvm-tools availability

## Testing
- git diff --check
- attempted CMake configure with `cmake -S /home/virant/gow/.aimee-wolf-019df7dc -B /tmp/wolf-pr-build -DBUILD_TESTING=ON`; stopped after dependency FetchContent remained stuck in Boost download for several minutes