### PR TITLE
Make default run UID/GID configurable, fix UID following GID on update

### DIFF
--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -691,6 +691,20 @@ These are the default values, if you want to assign custom ports you can set the
 
 ====
 
+[TIP]
+====
+Apps run as UID/GID `1000:1000` by default. Newly paired clients inherit this,
+and you can change it per client later from xref:wolf-ui.adoc[]. If your host
+uses a different convention (for example Unraid, where `nobody` is `99:100`),
+set the defaults for every new client with the environment variables:
+
+* `WOLF_DEFAULT_RUN_UID`
+* `WOLF_DEFAULT_RUN_GID`
+
+These only affect the defaults applied to *new* clients; existing clients keep
+their saved values.
+====
+
 == Moonlight pairing
 
 You should now be able to point Moonlight to the IP address of the server and start the pairing process:

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -568,7 +568,7 @@ void UnixSocketServer::endpoint_UpdateClientSettings(const HTTPRequest &req, std
       .client_cert = current_client->client_cert, // Immutable, changing this would mean a new client
       .app_state_folder = payload.app_state_folder.get().value_or(current_client->app_state_folder),
       .settings = config::ClientSettings{
-          .run_uid = new_settings.run_gid.value_or(current_settings.run_uid),
+          .run_uid = new_settings.run_uid.value_or(current_settings.run_uid),
           .run_gid = new_settings.run_gid.value_or(current_settings.run_gid),
           .controllers_override = new_settings.controllers_override.value_or(current_settings.controllers_override),
           .mouse_acceleration = new_settings.mouse_acceleration.value_or(current_settings.mouse_acceleration),

--- a/src/moonlight-server/state/serialised_config.hpp
+++ b/src/moonlight-server/state/serialised_config.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstdlib>
 #include <rfl.hpp>
+#include <string>
 
 namespace wolf::config {
 
@@ -11,9 +13,28 @@ enum class ControllerType {
   AUTO
 };
 
+/**
+ * The UID/GID that apps run as defaults to 1000:1000, but can be overridden via
+ * the WOLF_DEFAULT_RUN_UID / WOLF_DEFAULT_RUN_GID environment variables. This
+ * lets deployments that don't use the conventional 1000:1000 — for example
+ * Unraid, where `nobody` is 99:100 — set sensible defaults for every newly
+ * paired client without editing each one by hand. Falls back to the given
+ * default when the variable is unset or not a valid number.
+ */
+inline uint env_default_run_id(const char *env_var, uint fallback) {
+  if (const char *value = std::getenv(env_var)) {
+    try {
+      return static_cast<uint>(std::stoul(value));
+    } catch (...) {
+      // Ignore malformed values and use the fallback instead.
+    }
+  }
+  return fallback;
+}
+
 struct ClientSettings {
-  uint run_uid = 1000;
-  uint run_gid = 1000;
+  uint run_uid = env_default_run_id("WOLF_DEFAULT_RUN_UID", 1000);
+  uint run_gid = env_default_run_id("WOLF_DEFAULT_RUN_GID", 1000);
   /* A list of forced controller overrides, the position in the array denotes the controller number */
   std::vector<ControllerType> controllers_override = {};
   /* Values above 1.0 will make it faster, between 0.0 and 1.0 will make it slower */

--- a/src/moonlight-server/state/serialised_config.hpp
+++ b/src/moonlight-server/state/serialised_config.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdlib>
+#include <helpers/utils.hpp>
 #include <rfl.hpp>
 #include <string>
 
@@ -13,28 +13,14 @@ enum class ControllerType {
   AUTO
 };
 
-/**
- * The UID/GID that apps run as defaults to 1000:1000, but can be overridden via
- * the WOLF_DEFAULT_RUN_UID / WOLF_DEFAULT_RUN_GID environment variables. This
- * lets deployments that don't use the conventional 1000:1000 — for example
- * Unraid, where `nobody` is 99:100 — set sensible defaults for every newly
- * paired client without editing each one by hand. Falls back to the given
- * default when the variable is unset or not a valid number.
- */
-inline uint env_default_run_id(const char *env_var, uint fallback) {
-  if (const char *value = std::getenv(env_var)) {
-    try {
-      return static_cast<uint>(std::stoul(value));
-    } catch (...) {
-      // Ignore malformed values and use the fallback instead.
-    }
-  }
-  return fallback;
-}
-
 struct ClientSettings {
-  uint run_uid = env_default_run_id("WOLF_DEFAULT_RUN_UID", 1000);
-  uint run_gid = env_default_run_id("WOLF_DEFAULT_RUN_GID", 1000);
+  /* The UID/GID that apps run as defaults to 1000:1000, but the defaults applied
+   * to newly paired clients can be overridden via the WOLF_DEFAULT_RUN_UID /
+   * WOLF_DEFAULT_RUN_GID environment variables. This lets deployments that don't
+   * use the conventional 1000:1000 — for example Unraid, where `nobody` is
+   * 99:100 — set sensible defaults without editing each client by hand. */
+  uint run_uid = std::stoul(utils::get_env("WOLF_DEFAULT_RUN_UID", "1000"));
+  uint run_gid = std::stoul(utils::get_env("WOLF_DEFAULT_RUN_GID", "1000"));
   /* A list of forced controller overrides, the position in the array denotes the controller number */
   std::vector<ControllerType> controllers_override = {};
   /* Values above 1.0 will make it faster, between 0.0 and 1.0 will make it slower */


### PR DESCRIPTION
## Problem

Apps run as `1000:1000` by default, which bakes in a UID/GID convention that
isn't universal. On **Unraid** the `nobody` user is `99:100`, so the defaults
never matched the host and every newly paired client had to be corrected by
hand.

That manual correction was also broken. In `endpoint_UpdateClientSettings`,
the `run_uid` field was assigned from `new_settings.run_gid`:

```cpp
.run_uid = new_settings.run_gid.value_or(current_settings.run_uid),
.run_gid = new_settings.run_gid.value_or(current_settings.run_gid),
```

So whatever GID you submitted was copied into the UID too — you could only ever
end up with `99:99` or `100:100`, never `99:100`. Submitting only a new UID
(no GID) silently dropped the change, because the `value_or` fell through to the
current value. On Unraid this left Steam and other apps running with a UID
outside the expected `1000–60000` range and with file ownership that didn't line
up with the host, which broke streaming.

## Changes

- **Configurable defaults via env vars.** `ClientSettings::run_uid` / `run_gid`
  now read `WOLF_DEFAULT_RUN_UID` / `WOLF_DEFAULT_RUN_GID` (falling back to
  `1000`). Both new-client paths (`endpoint_Pair`-time session creation and the
  pairing event handler) default-construct `ClientSettings`, so they inherit the
  override. Persisted clients keep their saved values, so this only affects
  *new* clients. Malformed/empty values fall back to `1000`.
- **Fix the UID-follows-GID bug.** `endpoint_UpdateClientSettings` now reads
  `new_settings.run_uid` for the `run_uid` field, so UID and GID can be set
  independently.
- **Docs.** Document the two new environment variables in the quickstart.

## Why env vars

This is what lets the Unraid plugin (and any other turnkey deployment) ship the
right defaults: the plugin controls Wolf's container environment, so it can set
`WOLF_DEFAULT_RUN_UID=99` / `WOLF_DEFAULT_RUN_GID=100` and every new client is
correct out of the box, with no per-client editing.

## Testing

The new `env_default_run_id` helper was compiled standalone with
`-std=c++17 -Wall -Wextra` and verified for the unset / valid / malformed cases.
I was not able to run a full Wolf build locally; relying on CI for the
integration build.