### PR TITLE
fix(fake-udev): persist /run/udev/data so libudev can enumerate devices

### DIFF
--- a/src/fake-udev/fake-udev-cli.cpp
+++ b/src/fake-udev/fake-udev-cli.cpp
@@ -36,9 +36,8 @@ static void persist_udev_db(const std::string &msg) {
       tags = v;
     else if (k == "USEC_INITIALIZED")
       usec = v;
-    else if (!k.empty() && k[0] != '.' && k != "DEVPATH" && k != "SUBSYSTEM" && k != "DEVNAME" &&
-             k != "DEVTYPE" && k != "SEQNUM" && k != "DRIVER" && k != "MODALIAS" && k != "SYNTH_UUID" &&
-             k != "DEVLINKS")
+    else if (!k.empty() && k[0] != '.' && k != "DEVPATH" && k != "SUBSYSTEM" && k != "DEVNAME" && k != "DEVTYPE" &&
+             k != "SEQNUM" && k != "DRIVER" && k != "MODALIAS" && k != "SYNTH_UUID" && k != "DEVLINKS")
       props.emplace_back(k, v);
   }
 

--- a/src/fake-udev/fake-udev-cli.cpp
+++ b/src/fake-udev/fake-udev-cli.cpp
@@ -5,6 +5,81 @@
 #include <unistd.h>
 
 constexpr int UDEV_EVENT_MODE = 2;
+
+/**
+ * Broadcasting the uevent is not enough on its own: libudev consumers (e.g. SDL)
+ * enumerate devices from the on-disk udev database, not from the netlink event.
+ * In containers without a running udevd nothing writes that database, so a device
+ * we advertise is never tagged (ID_INPUT_JOYSTICK, etc.) and applications ignore
+ * it. Persist the same record systemd-udevd would, keyed on MAJOR:MINOR.
+ */
+static void persist_udev_db(const std::string &msg) {
+  std::string action, major, minor, tags, usec;
+  std::vector<std::pair<std::string, std::string>> props;
+  for (size_t start = 0; start < msg.size();) {
+    size_t end = msg.find('\0', start);
+    if (end == std::string::npos)
+      end = msg.size();
+    const std::string tok = msg.substr(start, end - start);
+    start = end + 1;
+    const size_t eq = tok.find('=');
+    if (eq == std::string::npos)
+      continue;
+    const std::string k = tok.substr(0, eq), v = tok.substr(eq + 1);
+    if (k == "ACTION")
+      action = v;
+    else if (k == "MAJOR")
+      major = v;
+    else if (k == "MINOR")
+      minor = v;
+    else if ((k == "TAGS" || k == "CURRENT_TAGS") && tags.empty())
+      tags = v;
+    else if (k == "USEC_INITIALIZED")
+      usec = v;
+    else if (!k.empty() && k[0] != '.' && k != "DEVPATH" && k != "SUBSYSTEM" && k != "DEVNAME" &&
+             k != "DEVTYPE" && k != "SEQNUM" && k != "DRIVER" && k != "MODALIAS" && k != "SYNTH_UUID" &&
+             k != "DEVLINKS")
+      props.emplace_back(k, v);
+  }
+
+  // Input devices are character devices; the db key mirrors udev's c<maj>:<min>.
+  if (major.empty() || minor.empty())
+    return;
+  const std::string path = "/run/udev/data/c" + major + ":" + minor;
+
+  if (action == "remove") {
+    ::unlink(path.c_str());
+    return;
+  }
+
+  ::mkdir("/run/udev", 0755);
+  ::mkdir("/run/udev/data", 0755);
+  std::ofstream db(path, std::ios::trunc);
+  if (!db) {
+    std::cout << "Could not write udev db entry " << path << ": " << strerror(errno) << std::endl;
+    return;
+  }
+  if (!usec.empty())
+    db << "I:" << usec << "\n";
+  for (const auto &p : props)
+    db << "E:" << p.first << "=" << p.second << "\n";
+  // TAGS is formatted ":a:b:"; udev records every tag as G: and each sticky tag as Q:.
+  for (size_t i = 0; i < tags.size();) {
+    if (tags[i] == ':') {
+      ++i;
+      continue;
+    }
+    size_t j = tags.find(':', i);
+    if (j == std::string::npos)
+      j = tags.size();
+    const std::string tag = tags.substr(i, j - i);
+    db << "G:" << tag << "\n"
+       << "Q:" << tag << "\n";
+    i = j + 1;
+  }
+  db << "V:1\n";
+}
+
 int main(int argc, char *argv[]) {
   InputParser input(argc, argv);
   int rc = -1;
@@ -40,6 +115,10 @@ int main(int argc, char *argv[]) {
   if (!msg.empty()) {
     msg = base64_decode(msg);
     std::cout << "Sending " << msg << std::endl;
+
+    // Persist the udev database entry before broadcasting, so a consumer that
+    // looks the device up in response to the event finds a complete record.
+    persist_udev_db(msg);
 
     int domain = input.getCmdOption("--sock-domain", AF_NETLINK);
     int type = input.getCmdOption("--sock-type", SOCK_RAW);


### PR DESCRIPTION
## Problem
`fake-udev` only broadcasts the `NETLINK_KOBJECT_UEVENT`; it never writes the `/run/udev/data/c<maj>:<min>` database record. libudev consumers enumerate devices from that database, not from the netlink event. In session images that run no `udevd` (gamescope/Steam), a Wolf virtual gamepad is `mknod`'d and its evdev events flow, but SDL never sees `ID_INPUT_JOYSTICK` for it, so certain games ignore the controller. Keyboard/mouse are unaffected because they don't depend on that tag. The fake-udev docs already state it should "generate the appropriate DB entries in `/run/udev/data/`" — the code never did.

## Evidence
- `strace fake-udev -m <add event>`: `socket`/`bind`/`sendmsg` only; no `open`/`write` under `/run/udev`.
- With the record absent, SDL (`udev_enumerate_scan_devices`) skips the pad; writing the record by hand makes Steam detect it on its next scan.
- A Wolf build whose `fake-udev` writes this record runs controllers correctly in production; this change brings stock `fake-udev` to parity.

## Change
On `add`, parse the uevent payload and write the udev DB entry the way `systemd-udevd` does: `E:` device properties, `I:USEC_INITIALIZED`, `G:`/`Q:` tags, `V:1`, keyed on `MAJOR:MINOR`. On `remove`, unlink it. Written before the broadcast, so a consumer that looks the device up in response to the event finds a complete record. No-op when the payload carries no `MAJOR`/`MINOR`. No new dependencies — `<fstream>`/`<sys/stat.h>`/`<unistd.h>` are already included.
