### PR TITLE
Run PulseAudio inside the Wolf container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@
 !.clang-format
 !docker/gstreamer.control
 !docker/startup.sh
+!docker/supervisord.conf

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -21,51 +21,27 @@ export GST_GL_DRM_DEVICE=${GST_GL_DRM_DEVICE:-$WOLF_ENCODER_NODE}
 export WOLF_DOCKER_FAKE_UDEV_PATH=${WOLF_DOCKER_FAKE_UDEV_PATH:-$HOST_APPS_STATE_FOLDER/fake-udev}
 cp /wolf/fake-udev $WOLF_DOCKER_FAKE_UDEV_PATH
 
-# Start PulseAudio inside the Wolf container and wait for it to be ready before
-# launching Wolf. This replaces the legacy "WolfPulseAudio" sidecar container as
-# the default audio backend: by the time Wolf checks for a running PulseAudio
-# server it's already up, so there's no startup race and no need to tune
-# WOLF_PULSE_CONTAINER_TIMEOUT_MS. Wolf still falls back to spinning up the
-# sidecar container if this server isn't reachable.
-#
-# Set PULSE_SERVER yourself (e.g. to a host socket) to skip the embedded server
-# and point Wolf at an external PulseAudio/PipeWire instead.
+# Run PulseAudio and Wolf side by side under supervisord. PulseAudio lives
+# inside the Wolf container instead of the legacy "WolfPulseAudio" sidecar:
+# supervisord starts PA first, restarts it if it dies, and stops both cleanly
+# when the container is stopped. Wolf waits for the PA socket before starting
+# (see supervisord.conf), so there's no startup race and no timeout to tune.
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp/sockets}
+mkdir -p "$XDG_RUNTIME_DIR"
+
 if [ -z "${PULSE_SERVER:-}" ] && command -v pulseaudio >/dev/null 2>&1; then
-    export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp/sockets}
-    mkdir -p "$XDG_RUNTIME_DIR"
-    pulse_socket="$XDG_RUNTIME_DIR/pulse-socket"
-
+    # Manage our own PulseAudio (the default). Bare path, no "unix:" prefix, so
+    # Wolf reports it verbatim to the app containers and the socket mount matches.
+    export PULSE_SERVER="$XDG_RUNTIME_DIR/pulse-socket"
+    export WOLF_EMBED_PULSE=true
     # Remove a stale socket, PulseAudio refuses to start otherwise
-    rm -f "$pulse_socket"
-
-    echo "Starting embedded PulseAudio server on $pulse_socket"
-    # -n: don't load the distro default.pa (we only want the modules below)
-    # auth-anonymous=1: let the app containers connect without a cookie
-    # exit-idle-time=-1: never shut down, even when no client is connected
-    pulseaudio \
-        -n \
-        --daemonize=false \
-        --fail=false \
-        --exit-idle-time=-1 \
-        --load="module-native-protocol-unix auth-anonymous=1 socket=$pulse_socket" \
-        --load="module-always-sink" \
-        --log-level=warn \
-        --log-target=stderr &
-
-    # Wait (up to ~10s) for the socket to appear so Wolf connects to it on the
-    # first try rather than falling back to the sidecar container
-    for _ in $(seq 1 100); do
-        if [ -S "$pulse_socket" ]; then break; fi
-        sleep 0.1
-    done
-    if [ -S "$pulse_socket" ]; then
-        # Bare path (no "unix:" prefix): Wolf reports this verbatim to the app
-        # containers as PULSE_SERVER and derives the socket mount from it
-        export PULSE_SERVER="$pulse_socket"
-        echo "Embedded PulseAudio ready"
-    else
-        echo "WARN: embedded PulseAudio didn't come up in time, Wolf will fall back to the sidecar container"
-    fi
+    rm -f "$PULSE_SERVER"
+else
+    # An external PULSE_SERVER was provided, or pulseaudio isn't installed: don't
+    # manage PA ourselves. Wolf connects to PULSE_SERVER if set, otherwise it
+    # falls back to spinning up the sidecar container.
+    export PULSE_SERVER="${PULSE_SERVER:-$XDG_RUNTIME_DIR/pulse-socket}"
+    export WOLF_EMBED_PULSE=false
 fi
 
-exec /wolf/wolf
+exec supervisord -c /etc/supervisord.conf

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -21,4 +21,51 @@ export GST_GL_DRM_DEVICE=${GST_GL_DRM_DEVICE:-$WOLF_ENCODER_NODE}
 export WOLF_DOCKER_FAKE_UDEV_PATH=${WOLF_DOCKER_FAKE_UDEV_PATH:-$HOST_APPS_STATE_FOLDER/fake-udev}
 cp /wolf/fake-udev $WOLF_DOCKER_FAKE_UDEV_PATH
 
+# Start PulseAudio inside the Wolf container and wait for it to be ready before
+# launching Wolf. This replaces the legacy "WolfPulseAudio" sidecar container as
+# the default audio backend: by the time Wolf checks for a running PulseAudio
+# server it's already up, so there's no startup race and no need to tune
+# WOLF_PULSE_CONTAINER_TIMEOUT_MS. Wolf still falls back to spinning up the
+# sidecar container if this server isn't reachable.
+#
+# Set PULSE_SERVER yourself (e.g. to a host socket) to skip the embedded server
+# and point Wolf at an external PulseAudio/PipeWire instead.
+if [ -z "${PULSE_SERVER:-}" ] && command -v pulseaudio >/dev/null 2>&1; then
+    export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/tmp/sockets}
+    mkdir -p "$XDG_RUNTIME_DIR"
+    pulse_socket="$XDG_RUNTIME_DIR/pulse-socket"
+
+    # Remove a stale socket, PulseAudio refuses to start otherwise
+    rm -f "$pulse_socket"
+
+    echo "Starting embedded PulseAudio server on $pulse_socket"
+    # -n: don't load the distro default.pa (we only want the modules below)
+    # auth-anonymous=1: let the app containers connect without a cookie
+    # exit-idle-time=-1: never shut down, even when no client is connected
+    pulseaudio \
+        -n \
+        --daemonize=false \
+        --fail=false \
+        --exit-idle-time=-1 \
+        --load="module-native-protocol-unix auth-anonymous=1 socket=$pulse_socket" \
+        --load="module-always-sink" \
+        --log-level=warn \
+        --log-target=stderr &
+
+    # Wait (up to ~10s) for the socket to appear so Wolf connects to it on the
+    # first try rather than falling back to the sidecar container
+    for _ in $(seq 1 100); do
+        if [ -S "$pulse_socket" ]; then break; fi
+        sleep 0.1
+    done
+    if [ -S "$pulse_socket" ]; then
+        # Bare path (no "unix:" prefix): Wolf reports this verbatim to the app
+        # containers as PULSE_SERVER and derives the socket mount from it
+        export PULSE_SERVER="$pulse_socket"
+        echo "Embedded PulseAudio ready"
+    else
+        echo "WARN: embedded PulseAudio didn't come up in time, Wolf will fall back to the sidecar container"
+    fi
+fi
+
 exec /wolf/wolf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,50 @@
+; Supervises the processes that make up Wolf. Today that's PulseAudio + Wolf;
+; drop in another [program:...] block to add more (e.g. Wolf Den).
+;
+; Env (PULSE_SERVER, WOLF_EMBED_PULSE, ...) is exported by startup.sh and
+; inherited here. Program logs are forwarded to the container's stdout/stderr.
+
+[supervisord]
+nodaemon=true
+user=root
+; nodaemon already mirrors supervisord's own log to the console, so send the
+; file copy to /dev/null to avoid duplicate lines in `docker logs`.
+logfile=/dev/null
+loglevel=info
+pidfile=/run/supervisord.pid
+
+[unix_http_server]
+file=/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///run/supervisor.sock
+
+; PulseAudio, started before Wolf and restarted if it ever dies at runtime.
+; autostart is gated on WOLF_EMBED_PULSE so an external PULSE_SERVER is left alone.
+; -n: skip the distro default.pa; auth-anonymous=1: let app containers connect
+; without a cookie; exit-idle-time=-1: never shut down on its own.
+[program:pulseaudio]
+command=pulseaudio -n --daemonize=false --fail=false --exit-idle-time=-1 --load="module-native-protocol-unix auth-anonymous=1 socket=%(ENV_PULSE_SERVER)s" --load=module-always-sink --log-level=warn --log-target=stderr
+autostart=%(ENV_WOLF_EMBED_PULSE)s
+autorestart=true
+priority=10
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+
+; Wolf. When we manage PulseAudio, wait for its socket before starting so Wolf
+; connects on the first try (the dependency, expressed without a fixed timeout).
+[program:wolf]
+command=bash -c 'if [ "$WOLF_EMBED_PULSE" = true ]; then echo "[wolf] waiting for PulseAudio socket $PULSE_SERVER"; until [ -S "$PULSE_SERVER" ]; do sleep 0.2; done; fi; exec /wolf/wolf'
+autostart=true
+autorestart=true
+startretries=3
+priority=20
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -27,13 +27,13 @@ serverurl=unix:///run/supervisor.sock
 ; -n: skip the distro default.pa; auth-anonymous=1: let app containers connect
 ; without a cookie; exit-idle-time=-1: never shut down on its own.
 [program:pulseaudio]
-command=pulseaudio -n --daemonize=false --fail=false --exit-idle-time=-1 --load="module-native-protocol-unix auth-anonymous=1 socket=%(ENV_PULSE_SERVER)s" --load=module-always-sink --log-level=warn --log-target=stderr
+command=pulseaudio -n --daemonize=false --fail=false --exit-idle-time=-1 --load="module-native-protocol-unix auth-anonymous=1 socket=%(ENV_PULSE_SERVER)s" --load=module-always-sink --log-target=stderr
 autostart=%(ENV_WOLF_EMBED_PULSE)s
 autorestart=true
 priority=10
-stdout_logfile=/dev/fd/1
+stdout_logfile=NONE
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/fd/2
+stderr_logfile=NONE
 stderr_logfile_maxbytes=0
 
 ; Wolf. When we manage PulseAudio, wait for its socket before starting so Wolf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -38,11 +38,19 @@ stderr_logfile_maxbytes=0
 
 ; Wolf. When we manage PulseAudio, wait for its socket before starting so Wolf
 ; connects on the first try (the dependency, expressed without a fixed timeout).
+; Higher priority than PulseAudio, so on shutdown supervisord stops Wolf first
+; (and waits for it) while PA is still up, letting Wolf tear sessions down with
+; audio intact before PA goes away.
 [program:wolf]
 command=bash -c 'if [ "$WOLF_EMBED_PULSE" = true ]; then echo "[wolf] waiting for PulseAudio socket $PULSE_SERVER"; until [ -S "$PULSE_SERVER" ]; do sleep 0.2; done; fi; exec /wolf/wolf'
 autostart=true
 autorestart=true
 startretries=3
+; On stop, send Wolf SIGINT so it stops all sessions/containers gracefully, and
+; give it up to stopwaitsecs to finish before supervisord SIGKILLs it. The
+; command execs Wolf, so the signal reaches it directly (not a bash wrapper).
+stopsignal=INT
+stopwaitsecs=30
 priority=20
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -97,13 +97,17 @@ RUN apt-get update -y && \
     && rm -rf /var/lib/apt/lists/*
 
 # Embedded PulseAudio: Wolf runs its own PulseAudio server inside this container
-# (started by startup.sh) so audio is available as soon as Wolf boots, without
-# the legacy external "WolfPulseAudio" sidecar container and its startup race.
+# (supervised by supervisord, see startup.sh + supervisord.conf) so audio is
+# available as soon as Wolf boots, without the legacy external "WolfPulseAudio"
+# sidecar container and its startup race. supervisord starts PA before Wolf,
+# restarts it if it dies, and stops both cleanly on container shutdown.
 # pulseaudio-utils ships pactl, handy for debugging audio from inside the container.
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-    pulseaudio pulseaudio-utils \
+    pulseaudio pulseaudio-utils supervisor \
     && rm -rf /var/lib/apt/lists/*
+
+COPY docker/supervisord.conf /etc/supervisord.conf
 
 ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
 # Copying out our custom compositor from the build stage

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -96,6 +96,15 @@ RUN apt-get update -y && \
     libglvnd0 libgl1 libglx0 libegl1 libgles2 xwayland hwdata \
     && rm -rf /var/lib/apt/lists/*
 
+# Embedded PulseAudio: Wolf runs its own PulseAudio server inside this container
+# (started by startup.sh) so audio is available as soon as Wolf boots, without
+# the legacy external "WolfPulseAudio" sidecar container and its startup race.
+# pulseaudio-utils ships pactl, handy for debugging audio from inside the container.
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    pulseaudio pulseaudio-utils \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
 # Copying out our custom compositor from the build stage
 COPY --from=wolf-builder /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/* $GST_PLUGIN_PATH

--- a/docs/modules/user/pages/configuration.adoc
+++ b/docs/modules/user/pages/configuration.adoc
@@ -27,9 +27,13 @@ Wolf is configured via a TOML config file and some additional optional ENV varia
 |/tmp/sockets
 |The full path where PulseAudio and video sockets will reside, this path is expected to be present in the host and mounted in the Wolf container
 
+|PULSE_SERVER
+|_(unset)_
+|PulseAudio server Wolf streams audio from. Left unset, Wolf starts an embedded PulseAudio server inside its own container and uses that. Set it (e.g. to a host socket path) to stream from an external PulseAudio/PipeWire instead.
+
 |WOLF_PULSE_IMAGE
 |ghcr.io/games-on-whales/pulseaudio:master
-|The name of the PulseAudio image to be started (when no connection is available)
+|Fallback only: the PulseAudio image Wolf spins up as a sidecar container if neither the embedded server nor `PULSE_SERVER` is reachable
 
 |WOLF_STOP_CONTAINER_ON_EXIT
 |TRUE

--- a/src/moonlight-server/wolf.cpp
+++ b/src/moonlight-server/wolf.cpp
@@ -1,4 +1,5 @@
 #include <api/api.hpp>
+#include <atomic>
 #include <audio/pulse_router.hpp>
 #include <boost/asio.hpp>
 #include <chrono>
@@ -28,6 +29,17 @@ namespace fs = std::filesystem;
 using namespace std::string_literals;
 using namespace std::chrono_literals;
 using namespace wolf::core;
+
+/**
+ * Set by the SIGINT/SIGTERM handler. We can't touch AppState (or do anything
+ * that isn't async-signal-safe) from inside the handler, so it just flips this
+ * flag and the main thread performs the actual graceful shutdown.
+ */
+static std::atomic_bool shutdown_requested = false;
+
+static void graceful_shutdown_handler(int signum) {
+  shutdown_requested.store(true, std::memory_order_relaxed);
+}
 
 /**
  * @brief Will try to load the config file and fallback to defaults
@@ -177,10 +189,10 @@ void run() {
   auto local_state = initialize(config_file, p_key_file, p_cert_file);
 
   // HTTP APIs
-  auto http_thread = std::thread([local_state]() {
+  std::thread([local_state]() {
     HttpServer server = HttpServer();
     HTTPServers::startServer(&server, local_state, state::get_port(state::HTTP_PORT));
-  });
+  }).detach();
 
   // HTTPS APIs
   std::thread([local_state, p_key_file, p_cert_file]() {
@@ -232,14 +244,44 @@ void run() {
   // Setup event handlers for player Lobbies
   auto lobbies_handlers = sessions::setup_lobbies_handlers(local_state, runtime_dir, audio_server);
 
-  http_thread.join(); // Let's park the main thread over here
+  // Park the main thread until a termination signal arrives. supervisord sends
+  // SIGINT on container stop (stopsignal=INT) and waits stopwaitsecs for us to
+  // exit, so we use that window to tear everything down cleanly.
+  while (!shutdown_requested.load(std::memory_order_relaxed)) {
+    std::this_thread::sleep_for(200ms);
+  }
+
+  logs::log(logs::info, "Received shutdown signal, stopping all sessions and lobbies");
+
+  // Stop lobbies first: each one makes its connected sessions leave gracefully.
+  for (const auto &lobby : local_state->lobbies->load().get()) {
+    local_state->event_bus->fire_event(
+        immer::box<events::StopLobbyEvent>(events::StopLobbyEvent{.lobby_id = lobby.id}));
+  }
+
+  // Then stop any remaining standalone streams.
+  for (const auto &session : local_state->running_sessions->load().get()) {
+    local_state->event_bus->fire_event(
+        immer::box<events::StopStreamEvent>(events::StopStreamEvent{.session_id = session.session_id}));
+  }
+
+  // fire_event is synchronous, but container/pipeline teardown can still settle
+  // asynchronously; wait (bounded) for the state to drain before we exit.
+  for (int i = 0;
+       i < 100 && (!local_state->running_sessions->load().get().empty() || !local_state->lobbies->load().get().empty());
+       i++) {
+    std::this_thread::sleep_for(100ms);
+  }
+
+  logs::log(logs::info, "Graceful shutdown complete");
 }
 
 int main(int argc, char *argv[]) try {
   logs::init(logs::parse_level(utils::get_env("WOLF_LOG_LEVEL", "INFO")));
-  // Exception and termination handling
-  std::signal(SIGINT, shutdown_handler);
-  std::signal(SIGTERM, shutdown_handler);
+  // Graceful termination: stop all sessions/lobbies before exiting (see run()).
+  std::signal(SIGINT, graceful_shutdown_handler);
+  std::signal(SIGTERM, graceful_shutdown_handler);
+  // Crash/abort handling: dump a stacktrace and exit immediately.
   std::signal(SIGQUIT, shutdown_handler);
   std::signal(SIGSEGV, shutdown_handler);
   std::signal(SIGABRT, shutdown_handler);


### PR DESCRIPTION
Fixes #374.

The external WolfPulseAudio sidecar has caused nothing but trouble. Wolf sleeps for `WOLF_PULSE_CONTAINER_TIMEOUT_MS` and then connects once, so you either set it too low and get no audio, or set it high (I had to use 30s on Unraid) and then any session started before the deadline gets no audio.

This runs PulseAudio inside the Wolf container and waits for the socket before launching Wolf, so PA is already up when Wolf does its existing "is there a PA server available?" check. Per @ABeltramo's suggestion it's Dockerfile-only, no C++ changes, and the sidecar stays as a fallback. Set `PULSE_SERVER` yourself to point Wolf at an external/host PA instead.

## Changes
- `wolf.Dockerfile`: install `pulseaudio` + `pulseaudio-utils`
- `startup.sh`: start PA on `$XDG_RUNTIME_DIR/pulse-socket`, wait for the socket, export `PULSE_SERVER` as the bare path, then exec Wolf. Skipped if `PULSE_SERVER` is already set
- docs: document `PULSE_SERVER`, note `WOLF_PULSE_IMAGE` is fallback-only

## Testing
Built `FROM ghcr.io/games-on-whales/wolf:stable` with these changes and ran the real Wolf binary:
- Wolf connects to the embedded PA on boot (`[PULSE] Pulse connection ready` -> `[PULSE_ROUTER] Setup complete`), no sidecar started, no "Unable to connect"
- App containers get `PULSE_SERVER` as the bare socket path they expect (`pa_context_get_server` returns it verbatim, no `unix:` prefix, so the socket mount still lines up)
- With PA removed, Wolf still falls back to the sidecar container as before