### PR TITLE
Embed Wolf Den into the Wolf container

### DIFF
--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -44,4 +44,17 @@ else
     export WOLF_EMBED_PULSE=false
 fi
 
+# Embedded Wolf Den: the .NET management UI runs as another supervised process
+# inside this container instead of the legacy separate "wolf-den" container.
+# Wolf creates its control socket at WOLF_SOCKET_PATH; Wolf Den connects to that
+# same socket (it wants a unix:// URI). Its state (SQLite DB + data-protection
+# keys) lives under the persisted state folder so it survives container replacement.
+export WOLF_SOCKET_PATH=${WOLF_SOCKET_PATH:-/var/run/wolf/wolf.sock}
+mkdir -p "$(dirname "$WOLF_SOCKET_PATH")"
+export WOLF_DEN_SOCKET="unix://$WOLF_SOCKET_PATH"
+mkdir -p "$HOST_APPS_STATE_FOLDER/wolf-den"
+# Enable the embedded Wolf Den by default; set WOLF_EMBED_DEN=false to disable it
+# (e.g. if you run Wolf Den elsewhere). Gates its autostart in supervisord.conf.
+export WOLF_EMBED_DEN=${WOLF_EMBED_DEN:-true}
+
 exec supervisord -c /etc/supervisord.conf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,8 +1,8 @@
-; Supervises the processes that make up Wolf. Today that's PulseAudio + Wolf;
-; drop in another [program:...] block to add more (e.g. Wolf Den).
+; Supervises the processes that make up Wolf: PulseAudio, Wolf, and the Wolf Den
+; management UI. Drop in another [program:...] block to add more.
 ;
-; Env (PULSE_SERVER, WOLF_EMBED_PULSE, ...) is exported by startup.sh and
-; inherited here. Program logs are forwarded to the container's stdout/stderr.
+; Env (PULSE_SERVER, WOLF_EMBED_PULSE, WOLF_EMBED_DEN, ...) is exported by
+; startup.sh and inherited here. Program logs go to the container stdout/stderr.
 
 [supervisord]
 nodaemon=true
@@ -52,6 +52,25 @@ startretries=3
 stopsignal=INT
 stopwaitsecs=30
 priority=20
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+
+; Wolf Den, the .NET management UI, embedded here instead of the legacy separate
+; "wolf-den" container. autostart is gated on WOLF_EMBED_DEN so it can be turned
+; off. It waits for Wolf's control socket before starting (the dependency, no
+; fixed timeout), and connects to that socket directly via WOLF_SOCKET_PATH
+; (a unix:// URI, set per-program so it doesn't clash with the bare path Wolf
+; uses to create the socket). Highest priority, so on shutdown supervisord stops
+; it first (UI down before Wolf and PulseAudio). Listens on :8080.
+[program:wolf-den]
+command=bash -c 'sock="${WOLF_SOCKET_PATH#unix://}"; echo "[wolf-den] waiting for Wolf socket $sock"; until [ -S "$sock" ]; do sleep 0.5; done; cd /app && exec dotnet /app/WolfLeash.dll'
+autostart=%(ENV_WOLF_EMBED_DEN)s
+autorestart=true
+startretries=3
+priority=30
+environment=ASPNETCORE_HTTP_PORTS="8080",WOLF_SOCKET_PATH="%(ENV_WOLF_DEN_SOCKET)s",DOTNET_RUNNING_IN_CONTAINER="true",DOTNET_CLI_HOME="/tmp",HOME="/tmp"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -107,6 +107,23 @@ RUN apt-get update -y && \
     pulseaudio pulseaudio-utils supervisor \
     && rm -rf /var/lib/apt/lists/*
 
+# Embedded Wolf Den: the .NET management UI runs as another supervised process
+# inside this container (see supervisord.conf + startup.sh) instead of the legacy
+# separate "wolf-den" container. We bring in the published app and the .NET
+# runtime straight from the Wolf Den image; its state (SQLite DB + data-protection
+# keys) lives in /etc/wolf/wolf-den (the persisted Wolf state folder), so it
+# survives container replacement. libstdc++6/zlib1g are the .NET native deps not
+# already pulled in above (libicu76, libssl3, ca-certificates are).
+ARG WOLF_DEN_IMAGE=ghcr.io/games-on-whales/wolf-den:stable
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+    libstdc++6 zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=${WOLF_DEN_IMAGE} /usr/share/dotnet /usr/share/dotnet
+COPY --from=${WOLF_DEN_IMAGE} /app /app
+RUN ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet && \
+    ln -sfn /etc/wolf/wolf-den /app/wolf-den
+
 COPY docker/supervisord.conf /etc/supervisord.conf
 
 ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -1,4 +1,12 @@
 ARG BASE_IMAGE=ghcr.io/games-on-whales/gstreamer:1.26.7
+# Wolf Den image we pull the embedded .NET app + runtime from (see runner stage).
+# Declared in the global scope so it can be used in the FROM below; BuildKit does
+# not allow variable expansion directly in `COPY --from=`.
+ARG WOLF_DEN_IMAGE=ghcr.io/games-on-whales/wolf-den:stable
+########################################################
+# Alias stage for the Wolf Den image so the runner can COPY --from it.
+FROM ${WOLF_DEN_IMAGE} AS wolf-den-src
+
 ########################################################
 FROM $BASE_IMAGE AS wolf-builder
 
@@ -113,14 +121,14 @@ RUN apt-get update -y && \
 # runtime straight from the Wolf Den image; its state (SQLite DB + data-protection
 # keys) lives in /etc/wolf/wolf-den (the persisted Wolf state folder), so it
 # survives container replacement. libstdc++6/zlib1g are the .NET native deps not
-# already pulled in above (libicu76, libssl3, ca-certificates are).
-ARG WOLF_DEN_IMAGE=ghcr.io/games-on-whales/wolf-den:stable
+# already pulled in above (libicu76, libssl3, ca-certificates are). The source
+# image is the wolf-den-src stage (set via the WOLF_DEN_IMAGE build arg).
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
     libstdc++6 zlib1g \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=${WOLF_DEN_IMAGE} /usr/share/dotnet /usr/share/dotnet
-COPY --from=${WOLF_DEN_IMAGE} /app /app
+COPY --from=wolf-den-src /usr/share/dotnet /usr/share/dotnet
+COPY --from=wolf-den-src /app /app
 RUN ln -sf /usr/share/dotnet/dotnet /usr/bin/dotnet && \
     ln -sfn /etc/wolf/wolf-den /app/wolf-den
 


### PR DESCRIPTION
Follows the same pattern as #422 (embedded PulseAudio): instead of running Wolf Den as a separate `wolf-den` container, run it as another supervised process inside the Wolf container.

## Changes
- `wolf.Dockerfile`: copy the published Wolf Den app (`/app`) and the .NET runtime (`/usr/share/dotnet`) from `ghcr.io/games-on-whales/wolf-den:stable` (overridable via the `WOLF_DEN_IMAGE` build arg), install the `.NET` native deps not already present (`libstdc++6`, `zlib1g`), and symlink `dotnet` + point `/app/wolf-den` at the persisted state folder.
- `supervisord.conf`: add a `[program:wolf-den]` block. It waits for Wolf's control socket, then runs `dotnet WolfLeash.dll` on `:8080`. `priority=30` so it starts after Wolf and stops first on shutdown. autostart gated on `WOLF_EMBED_DEN`.
- `startup.sh`: default `WOLF_SOCKET_PATH=/var/run/wolf/wolf.sock` (Wolf creates it; Wolf Den connects to it via a `unix://` URI), create the Wolf Den state dir under the persisted state folder, and set `WOLF_EMBED_DEN=true` by default.

State (SQLite DB + data-protection keys) lives in `/etc/wolf/wolf-den`, so it survives container replacement. Set `WOLF_EMBED_DEN=false` to disable the embedded UI (e.g. if you run Wolf Den elsewhere).

## Validation (on a real Proxmox CT)
Built the embedded stack and ran it as a PVE CT:
- supervisord brings up `pulseaudio`, `wolf`, and `wolf-den`, all `RUNNING`.
- Wolf Den waits for Wolf's socket, connects, and serves: `Now listening on http://[::]:8080`, `Application started`; an HTTP probe returns `200`.
- `docker stop` shuts everything down gracefully in order: `wolf-den` -> `wolf` -> `pulseaudio`, each `exit 0`, in ~4s.