### PR TITLE
fix(nvidia): bump gst-wayland-display to fix Blackwell black screen

### DIFF
--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -43,7 +43,9 @@ RUN <<_GST_WAYLAND_DISPLAY
 
     git clone https://github.com/games-on-whales/gst-wayland-display
     cd gst-wayland-display
-    git checkout 67b1183
+    # Includes e89c1a2 (proper VideoFormat-from-fourcc): without it the
+    # compositor's AR24 CUDA buffers decode to black frames on NVIDIA, see #417.
+    git checkout c49af96
     # Pinned to 0.10.20: 0.10.21+ requires rustc 1.92, upgrade RUST_VERSION above if unpinning
     cargo install cargo-c@0.10.20 --locked
     cargo cinstall --features="cuda" --prefix=/usr/local/lib/x86_64-linux-gnu/ --libdir=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0


### PR DESCRIPTION
## Problem

On NVIDIA GPUs the zero-copy CUDA pipeline shows a **black screen / no image** (reported in #417, seen on RTX 50xx). The stream connects and the encoder negotiates, but every frame is black.

## Root cause

The virtual compositor renders into an `AR24` (BGRA) dmabuf and imports it into CUDA. To build the `GstCudaMemory` it derives a `VideoFormat` from the DRM fourcc, but the pinned `gst-wayland-display` (`67b1183`) used `VideoFormat::from_fourcc`, whose underlying `gst_video_format_from_fourcc` **only handles YUV formats**. For `AR24` it returns the wrong/unknown format, so the buffer is built with the wrong layout and decodes to black.

This was already fixed upstream in gst-wayland-display by [`e89c1a2`](https://github.com/games-on-whales/gst-wayland-display/commit/e89c1a2) ("use proper function to get `VideoFormat` from fourcc", switching to `gst_video_dma_drm_fourcc_to_format`). The wolf image just pins a commit that predates it.

## Fix

Bump the pinned `gst-wayland-display` from `67b1183` to current stable `c49af96`, which includes `e89c1a2`. No other changes.

## Testing

RTX 5080 (driver 610.43.02, CUDA 13, sm_120): with `67b1183` the zero-copy CUDA stream is black; rebuilt against `c49af96` it streams correctly (verified in-game in Steam). The EGL→CUDA frame imports as a CUDA array and `cudaconvertscale`/nvenc produce a correct image.

Fixes #417
