### PR TITLE
ci: add Fedora PR build images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,9 @@ name: Docker build
 
 on:
   push:
+    branches:
+      - master
+      - stable
     paths-ignore:
       - "docs/**"
       - ".github/**"

--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -1,0 +1,170 @@
+name: PR Docker images
+
+on:
+  push:
+    branches:
+      - "pr-*-image"
+    paths-ignore:
+      - "docs/**"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+  workflow_dispatch:
+    inputs:
+      pr_id:
+        description: "Pull request number to use in image tags."
+        required: true
+      os:
+        description: "OS image variant to build."
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - ubuntu
+          - fedora
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  GSTREAMER_VERSION: 1.26.7
+
+jobs:
+  build_pr_image:
+    name: build ${{ matrix.os }} PR image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu
+            base_image: ghcr.io/games-on-whales/base-app:edge
+            gpu_file: docker/gpu-drivers.Dockerfile
+            gstreamer_file: docker/gstreamer.Dockerfile
+            wolf_file: docker/wolf.Dockerfile
+          - os: fedora
+            base_image: ghcr.io/games-on-whales/base-app:fedora
+            gpu_file: docker/gpu-drivers-fedora.Dockerfile
+            gstreamer_file: docker/gstreamer-fedora.Dockerfile
+            wolf_file: docker/wolf-fedora.Dockerfile
+
+    steps:
+      - name: Prepare image tag
+        id: vars
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          OS_VARIANT: ${{ matrix.os }}
+          PR_ID_INPUT: ${{ inputs.pr_id || '' }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
+          SELECTED_OS: ${{ inputs.os || 'all' }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_ID="$PULL_REQUEST_NUMBER"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            if [[ "$REF_NAME" =~ ^pr-([0-9]+)-([a-z]+)-image$ ]]; then
+              PR_ID="${BASH_REMATCH[1]}"
+              SELECTED_OS="${BASH_REMATCH[2]}"
+            elif [[ "$REF_NAME" =~ ^pr-([0-9]+)-image$ ]]; then
+              PR_ID="${BASH_REMATCH[1]}"
+            else
+              echo "::error::PR image branches must be named pr-{PR_ID}-{OS}-image or pr-{PR_ID}-image"
+              exit 1
+            fi
+          else
+            PR_ID="$PR_ID_INPUT"
+          fi
+
+          if [ -z "$PR_ID" ]; then
+            echo "::error::pr_id is required for manual PR image builds"
+            exit 1
+          fi
+
+          if [ "$SELECTED_OS" != "all" ] && [ "$SELECTED_OS" != "$OS_VARIANT" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping $OS_VARIANT; selected OS is $SELECTED_OS"
+            exit 0
+          fi
+
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+          echo "image_tag=pr-${PR_ID}-${OS_VARIANT}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.vars.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        if: steps.vars.outputs.enabled == 'true'
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+          version: latest
+          driver-opts: image=moby/buildkit:master
+
+      - name: Login to GitHub Container Registry
+        if: steps.vars.outputs.enabled == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN || github.token }}
+
+      - name: Build GPU Drivers
+        if: steps.vars.outputs.enabled == 'true'
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: docker/
+          file: ${{ matrix.gpu_file }}
+          push: true
+          build-args: |
+            BASE_IMAGE=${{ matrix.base_image }}
+          tags: ghcr.io/${{ github.repository_owner }}/gpu-drivers:${{ steps.vars.outputs.image_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.description=Wolf ${{ steps.vars.outputs.image_tag }} GPU driver base
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/gpu-drivers:buildcache-${{ steps.vars.outputs.image_tag }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/gpu-drivers:buildcache-${{ steps.vars.outputs.image_tag }},mode=max
+
+      - name: Build GStreamer
+        if: steps.vars.outputs.enabled == 'true'
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: docker/
+          file: ${{ matrix.gstreamer_file }}
+          push: true
+          build-args: |
+            GSTREAMER_VERSION=${{ env.GSTREAMER_VERSION }}
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gpu-drivers:${{ steps.vars.outputs.image_tag }}
+          tags: ghcr.io/${{ github.repository_owner }}/gstreamer:${{ steps.vars.outputs.image_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.description=Wolf ${{ steps.vars.outputs.image_tag }} GStreamer base
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/gstreamer:buildcache-${{ steps.vars.outputs.image_tag }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/gstreamer:buildcache-${{ steps.vars.outputs.image_tag }},mode=max
+
+      - name: Build Wolf
+        if: steps.vars.outputs.enabled == 'true'
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: ${{ matrix.wolf_file }}
+          push: true
+          build-args: |
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gstreamer:${{ steps.vars.outputs.image_tag }}
+            IMAGE_SOURCE=${{ github.server_url }}/${{ github.repository }}
+          tags: ghcr.io/${{ github.repository_owner }}/wolf:${{ steps.vars.outputs.image_tag }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.description=Wolf ${{ steps.vars.outputs.image_tag }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:buildcache-${{ steps.vars.outputs.image_tag }}
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:buildcache-${{ steps.vars.outputs.image_tag }},mode=max

--- a/docker/gpu-drivers-fedora.Dockerfile
+++ b/docker/gpu-drivers-fedora.Dockerfile
@@ -1,0 +1,78 @@
+ARG BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
+FROM $BASE_IMAGE
+
+# Intel VA-API / QSV drivers and VPL runtime
+# intel-media-driver lives in RPM Fusion free on Fedora (not in the base repos),
+# so enable it first; libvpl and mesa-va-drivers come from the main repos.
+ARG REQUIRED_PACKAGES="libva libva-utils \
+                       intel-media-driver \
+                       libvpl \
+                       mesa-va-drivers"
+
+RUN dnf install -y \
+      https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm && \
+    dnf install -y --skip-unavailable $REQUIRED_PACKAGES && \
+    dnf clean all
+
+# libmfx is not available in Fedora so we build from sources (see: https://github.com/games-on-whales/wolf/issues/221)
+RUN <<_BUILD_LIBMFX
+    #!/bin/bash
+    set -e
+
+    dnf install -y curl git gcc gcc-c++ cmake pkg-config \
+                   libdrm-devel libva-devel libX11-devel libxcb-devel libXext-devel
+
+    cd /tmp
+    git clone https://github.com/Intel-Media-SDK/MediaSDK msdk
+    cd msdk
+    git submodule init
+    git pull
+
+    # Patch to fix compilation error on modern gcc
+    curl -fsSL https://patch-diff.githubusercontent.com/raw/Intel-Media-SDK/MediaSDK/pull/3005.patch | git apply -
+    grep -q "#include <cstdint>" samples/sample_vpp/src/sample_vpp_frc_adv.cpp || \
+      sed -i "/#include <algorithm>/a #include <cstdint>" samples/sample_vpp/src/sample_vpp_frc_adv.cpp
+
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_WAYLAND=ON -DENABLE_X11_DRI3=ON -DENABLE_OPENCL=ON ../
+    make -j$(nproc)
+    make install -j$(nproc)
+
+    # Adjust library path
+    echo "/opt/intel/mediasdk/lib" >> /etc/ld.so.conf.d/msdk.conf
+    echo "/opt/intel/mediasdk/plugins" >> /etc/ld.so.conf.d/msdk.conf
+    ldconfig
+
+    # Cleanup
+    dnf clean all
+    rm -rf /tmp/*
+_BUILD_LIBMFX
+
+# Adding missing libnvrtc.so and libnvrtc-bulletins.so for Nvidia
+# https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/LICENSE.txt
+RUN <<_ADD_NVRTC
+    #!/bin/bash
+    set -e
+
+    dnf install -y unzip curl
+
+    cd /tmp
+    curl -fsSL -o nvidia_cuda_nvrtc_linux_x86_64.whl "https://developer.download.nvidia.com/compute/redist/nvidia-cuda-nvrtc/nvidia_cuda_nvrtc-11.0.221-cp36-cp36m-linux_x86_64.whl"
+    unzip -joq -d ./nvrtc nvidia_cuda_nvrtc_linux_x86_64.whl
+    cd nvrtc
+    chmod 755 libnvrtc*
+    find . -maxdepth 1 -type f -name "*libnvrtc.so.*" -exec sh -c 'ln -snf $(basename {}) libnvrtc.so' \;
+    mkdir -p /usr/local/nvidia/lib
+    mv -f libnvrtc* /usr/local/nvidia/lib
+    rm -rf /tmp/*
+
+    echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+    # Cleanup
+    dnf clean all
+_ADD_NVRTC
+
+LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
+LABEL org.opencontainers.image.description="A base image with all the required GPU drivers (Fedora)"

--- a/docker/gstreamer-fedora.Dockerfile
+++ b/docker/gstreamer-fedora.Dockerfile
@@ -1,0 +1,83 @@
+ARG BASE_IMAGE=ghcr.io/games-on-whales/gpu-drivers:pr-396-fedora
+FROM $BASE_IMAGE AS builder
+
+ARG GSTREAMER_VERSION=1.26.7
+ENV GSTREAMER_VERSION=$GSTREAMER_VERSION
+
+ENV SOURCE_PATH=/sources/
+WORKDIR $SOURCE_PATH
+
+RUN <<_GSTREAMER_INSTALL
+    #!/bin/bash
+    set -e
+
+    DEV_PACKAGES=" \
+        gcc gcc-c++ ninja-build meson cmake ccache bison libatomic \
+        ca-certificates git \
+        flex x265-devel opus-devel nasm zxing-cpp-devel zbar-devel libdrm-devel libva-devel \
+        libvpl-devel libunwind libcap \
+        libX11-devel libxcb-devel libXfixes-devel libXdamage-devel wayland-devel wayland-protocols-devel pulseaudio-libs-devel glib2-devel \
+        openjpeg2-devel lcms2-devel cairo-devel cairo-gobject-devel libwebp librsvg2-devel libaom-devel \
+        harfbuzz-devel pango-devel libsoup-devel libglvnd-devel mesa-libgbm-devel mesa-libEGL-devel \
+        mesa-libGLU-devel freeglut-devel mesa-libGL-devel mesa-libGLES-devel libgudev-devel
+        "
+    dnf install -y $DEV_PACKAGES
+
+    # Build gstreamer
+    git clone https://gitlab.freedesktop.org/gstreamer/gstreamer.git $SOURCE_PATH/gstreamer
+    cd ${SOURCE_PATH}/gstreamer
+    git checkout $GSTREAMER_VERSION
+    git submodule update --recursive --remote
+    # see the list of possible options here: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/meson_options.txt
+    meson setup \
+        --buildtype=release \
+        --strip \
+        -Dgst-full-libraries=app,video \
+        -Dorc=disabled \
+        -Dgpl=enabled  \
+        -Dbase=enabled \
+        -Dgood=enabled  \
+        -Dugly=enabled \
+        -Drs=disabled \
+        -Dtls=disabled \
+        -Dgst-examples=disabled \
+        -Dlibav=disabled \
+        -Dtests=disabled \
+        -Dexamples=disabled \
+        -Ddoc=disabled \
+        -Dpython=disabled \
+        -Drtsp_server=disabled \
+        -Dqt5=disabled \
+        -Dbad=enabled \
+        -Dgst-plugins-good:soup=disabled \
+        -Dgst-plugins-good:ximagesrc=enabled \
+        -Dgst-plugins-good:pulse=enabled \
+        -Dgst-plugins-bad:x265=enabled  \
+        -Dgst-plugins-bad:qsv=enabled \
+        -Dgst-plugins-bad:aom=enabled \
+        -Dgst-plugins-bad:nvcodec=enabled  \
+        -Dgst-plugins-base:gl=enabled  \
+        -Dgstreamer-vaapi:x11=disabled \
+        -Dgst-plugins-base:gl_winsys=wayland,egl,gbm,surfaceless  \
+        -Dvaapi=enabled \
+        build
+    meson compile -C build
+    meson install -C build
+
+    # Add GstInterpipe
+    git clone https://github.com/games-on-whales/gst-interpipe.git $SOURCE_PATH/gst-interpipe
+    cd $SOURCE_PATH/gst-interpipe
+    mkdir build
+    meson build -Denable-gtk-doc=false
+    meson install -C build
+
+    # Final cleanup stage
+    dnf clean all
+    rm -rf $SOURCE_PATH
+_GSTREAMER_INSTALL
+
+LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
+LABEL org.opencontainers.image.description="GStreamer: https://gstreamer.freedesktop.org/ (Fedora)"
+
+ENTRYPOINT []
+CMD ["/usr/local/bin/gst-inspect-1.0"]

--- a/docker/wolf-fedora.Dockerfile
+++ b/docker/wolf-fedora.Dockerfile
@@ -1,0 +1,154 @@
+ARG BASE_IMAGE=ghcr.io/games-on-whales/gstreamer:pr-396-fedora
+########################################################
+FROM $BASE_IMAGE AS wolf-builder
+
+RUN dnf install -y \
+    curl \
+    ca-certificates \
+    ninja-build \
+    cmake \
+    pkg-config \
+    ccache \
+    git \
+    clang \
+    gcc-c++ \
+    glibc-static \
+    libstdc++-static \
+    boost-devel \
+    wayland-devel libinput-devel libxkbcommon-devel mesa-libgbm-devel \
+    libcurl-devel \
+    openssl-devel \
+    libevdev-devel \
+    pulseaudio-libs-devel \
+    libunwind-devel \
+    systemd-devel \
+    libdrm-devel \
+    pciutils-devel \
+    glib2-devel mesa-libEGL-devel mesa-libGLES-devel libglvnd-devel \
+    && dnf clean all
+
+## Install Rust in order to build our custom compositor
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="$HOME/.cargo/bin:${PATH}"
+
+ARG RUST_VERSION=1.91.1
+ENV RUST_VERSION=$RUST_VERSION
+RUN rustup install $RUST_VERSION && rustup default $RUST_VERSION
+
+WORKDIR /tmp/
+RUN <<_GST_WAYLAND_DISPLAY
+    #!/bin/bash
+    set -e
+
+    git clone https://github.com/games-on-whales/gst-wayland-display
+    cd gst-wayland-display
+    git checkout 67b1183
+    # Pinned to 0.10.20: 0.10.21+ requires rustc 1.92, upgrade RUST_VERSION above if unpinning
+    cargo install cargo-c@0.10.20 --locked
+    cargo cinstall --features="cuda" --prefix=/usr/local/lib/x86_64-linux-gnu/ --libdir=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0
+_GST_WAYLAND_DISPLAY
+
+COPY . /wolf/
+WORKDIR /wolf
+
+ENV CCACHE_DIR=/cache/ccache
+ENV CMAKE_BUILD_DIR=/cache/cmake-build
+RUN --mount=type=cache,target=/cache/ccache \
+    cmake -B$CMAKE_BUILD_DIR \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_CXX_EXTENSIONS=OFF \
+    -DCMAKE_CXX_FLAGS="-Wno-missing-template-arg-list-after-template-kw" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBoost_USE_STATIC_LIBS=ON \
+    -DBUILD_FAKE_UDEV_CLI=ON \
+    -DBUILD_TESTING=OFF \
+    -G Ninja && \
+    ninja -C $CMAKE_BUILD_DIR wolf && \
+    ninja -C $CMAKE_BUILD_DIR fake-udev && \
+    # We have to copy out the built executables because this will only be available inside the buildkit cache
+    cp $CMAKE_BUILD_DIR/src/moonlight-server/wolf /wolf/wolf && \
+    cp $CMAKE_BUILD_DIR/src/fake-udev/fake-udev /wolf/fake-udev
+
+########################################################
+FROM $BASE_IMAGE AS runner
+
+# Wolf runtime dependencies
+RUN dnf install -y \
+    ca-certificates \
+    openssl-libs \
+    libicu \
+    libevdev \
+    systemd-libs \
+    libcurl \
+    libdrm \
+    pciutils-libs \
+    libunwind \
+    && dnf clean all
+
+# gst-plugin-wayland runtime dependencies
+RUN dnf install -y \
+    libwayland-server libinput libxkbcommon mesa-libgbm \
+    libglvnd mesa-libGL mesa-libEGL mesa-libGLES xorg-x11-server-Xwayland hwdata \
+    && dnf clean all
+
+ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
+# Copying out our custom compositor from the build stage
+COPY --from=wolf-builder /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/* $GST_PLUGIN_PATH
+COPY --from=wolf-builder /usr/local/lib/liblibgstwaylanddisplay* /usr/local/lib/
+
+# Bundle the exact libicu the builder linked wolf against, so a builder/runner
+# layer-cache skew can't produce a wolf binary that can't resolve its own
+# libicuuc soname at runtime.
+COPY --from=wolf-builder /usr/lib64/libicu*.so.* /usr/lib64/
+
+WORKDIR /wolf
+
+ENV WOLF_CFG_FOLDER=/etc/wolf/cfg
+
+COPY --from=wolf-builder /wolf/wolf /wolf/wolf
+COPY --from=wolf-builder /wolf/fake-udev /wolf/fake-udev
+
+ENV GST_GL_API=gles2 \
+    GST_GL_PLATFORM=egl \
+    GST_GL_WINDOW=surfaceless \
+    WOLF_USE_ZERO_COPY=TRUE \
+    WOLF_LOG_LEVEL=INFO \
+    WOLF_CFG_FILE=$WOLF_CFG_FOLDER/config.toml \
+    WOLF_PRIVATE_KEY_FILE=$WOLF_CFG_FOLDER/key.pem \
+    WOLF_PRIVATE_CERT_FILE=$WOLF_CFG_FOLDER/cert.pem \
+    WOLF_PULSE_IMAGE=ghcr.io/games-on-whales/pulseaudio:master \
+    WOLF_RENDER_NODE=/dev/dri/renderD128 \
+    WOLF_STOP_CONTAINER_ON_EXIT=TRUE \
+    WOLF_DOCKER_SOCKET=/var/run/docker.sock \
+    RUST_BACKTRACE=full \
+    RUST_LOG=WARN \
+    HOST_APPS_STATE_FOLDER=/etc/wolf \
+    GST_DEBUG=2 \
+    PUID=0 \
+    PGID=0 \
+    UNAME="root"
+
+# Setting up XDG_RUNTIME_DIR this will automatically create a volume when starting the container
+VOLUME /run/user/wolf/
+ENV XDG_RUNTIME_DIR=/run/user/wolf
+
+# HTTPS
+EXPOSE 47984/tcp
+# HTTP
+EXPOSE 47989/tcp
+# Control
+EXPOSE 47999/udp
+# RTSP
+EXPOSE 48010/tcp
+# Video
+EXPOSE 48100/udp
+# Audio
+EXPOSE 48200/udp
+
+LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
+LABEL org.opencontainers.image.description="Wolf: stream virtual desktops and games in Docker (Fedora)"
+
+# See GOW/base-app
+COPY --chmod=777 docker/startup.sh /opt/gow/startup-app.sh
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Split out of #396 (party-mode split rendering), which had bundled unrelated CI infrastructure.

## What changed
- Fedora-based build images: `gpu-drivers`, `gstreamer`, and `wolf`
- a `pr-images` workflow that builds and tags per-PR images
- `docker-build` now also runs on pushes to `master`/`stable`

## Why
This is CI/build-image infrastructure unrelated to the party-mode feature; keeping it in its own PR makes both changes reviewable in isolation.