### PR TITLE
ci: image smoke-test harness

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,9 +5,18 @@ on:
     paths-ignore:
       - "docs/**"
       - ".github/**"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - ".github/**"
 
 jobs:
   buildx:
+    # Avoid running twice for same-repo PRs (push + pull_request). Same-repo
+    # branches run on push; fork PRs (which can't trigger push here) run on
+    # pull_request, where secrets are unavailable so the build loads the image
+    # locally and smoke-tests it instead of pushing. See linux-build-test.yml.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -123,6 +132,11 @@ jobs:
           context: .
           file: docker/wolf.Dockerfile
           push: ${{ steps.prep.outputs.push }}
+          # Load into the local docker daemon when we aren't pushing to a
+          # registry (fork PRs, missing secrets) so the smoke-test step
+          # below can run `docker image inspect` and `docker run` against
+          # the image we just built.
+          load: ${{ steps.prep.outputs.push != 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -131,7 +145,26 @@ jobs:
           cache-from: ${{ steps.prep.outputs.cache_from }}
           cache-to: ${{ steps.prep.outputs.cache_to }}
 
+      # Smoke-test the image we just built. Two ingest paths because the
+      # build step's output differs by context:
+      #   * push=true  -> registry got the image; `docker pull` fetches it.
+      #   * push=false -> `load: true` put it in the local daemon; no fetch.
+      # Either way we then invoke bin/test-image.sh, which runs the 3-layer
+      # harness (structural + cont-init smoke + docker/tests/smoke.sh).
+      - name: Smoke test wolf image
+        run: |
+          set -euo pipefail
+          tag='${{ fromJSON(steps.meta.outputs.json).tags[0] }}'
+          if [[ "${{ steps.prep.outputs.push }}" == "true" ]]; then
+            echo "==> pulling ${tag} from registry"
+            docker pull "${tag}"
+          else
+            echo "==> using locally-loaded image (no registry push)"
+          fi
+          ./bin/test-image.sh "${tag}"
+
   test_devcontainer:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     needs: buildx
     steps:

--- a/bin/test-image.sh
+++ b/bin/test-image.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Smoke-test a built Wolf image.
+#
+# Usage: bin/test-image.sh <image-tag> [--keep-logs]
+#
+# Runs three layers of validation against the already-built image:
+#
+#   1. Structural  -- docker inspect: image present, entrypoint set,
+#                     image.source label set, Moonlight ports exposed.
+#   2. Init smoke  -- `docker run --rm <tag> <sentinel>` exercises every
+#                     /etc/cont-init.d/*.sh script inherited from the GOW
+#                     base image as root, then exits. Catches regressions
+#                     in user/device/nvidia setup before they bite a real
+#                     client session.
+#   3. Image smoke -- runs docker/tests/smoke.sh inside the container
+#                     (bind-mounted at /smoke), with a 180s timeout. This
+#                     is where wolf-specific assertions live (wolf +
+#                     fake-udev binaries present + ldd-clean, custom
+#                     gst-plugin-waylanddisplay loads, shipped startup
+#                     script present, key env vars set).
+#
+# The harness is single-image because wolf is a single-image project; no
+# --docker-path / --variant flags like in games-on-whales/gow.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 <image-tag> [--keep-logs]
+
+Examples:
+  $0 ghcr.io/games-on-whales/wolf:edge
+  $0 ghcr.io/games-on-whales/wolf:sha-$(git rev-parse --short HEAD 2>/dev/null || echo abcdef1)
+EOF
+  exit 64
+}
+
+[[ $# -ge 1 ]] || usage
+IMAGE_TAG="$1"
+shift
+
+KEEP_LOGS=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-logs) KEEP_LOGS=1; shift;;
+    -h|--help)   usage;;
+    *) echo "!! unknown argument: $1" >&2; usage;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SMOKE_DIR="$REPO_ROOT/docker/tests"
+COMMON_DIR="$REPO_ROOT/bin/tests"
+
+# ---- output helpers -------------------------------------------------------
+TOTAL=0; FAIL=0
+step() { printf '\n==> %s\n' "$*"; }
+pass() { TOTAL=$((TOTAL+1)); printf '   ok   %s\n' "$*"; }
+fail() { TOTAL=$((TOTAL+1)); FAIL=$((FAIL+1)); printf '   FAIL %s\n' "$*" >&2; }
+dump() { sed 's/^/   | /' "$1" >&2; }
+
+INIT_LOG=$(mktemp)
+SMOKE_LOG=$(mktemp)
+cleanup() {
+  if [[ -n "$KEEP_LOGS" ]]; then
+    echo "   (logs kept: $INIT_LOG $SMOKE_LOG)" >&2
+  else
+    rm -f "$INIT_LOG" "$SMOKE_LOG"
+  fi
+}
+trap cleanup EXIT
+
+# ---- layer 1: structural --------------------------------------------------
+step "Layer 1 -- structural checks ($IMAGE_TAG)"
+
+if ! docker image inspect "$IMAGE_TAG" >/dev/null 2>&1; then
+  fail "image present ($IMAGE_TAG)"
+  exit 1
+fi
+pass "image present ($IMAGE_TAG)"
+
+EP=$(docker image inspect --format '{{json .Config.Entrypoint}}' "$IMAGE_TAG")
+if [[ "$EP" == *"/entrypoint.sh"* ]]; then
+  pass "entrypoint is /entrypoint.sh ($EP)"
+else
+  fail "entrypoint is /entrypoint.sh (got $EP)"
+fi
+
+SRC_LABEL=$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.source"}}' "$IMAGE_TAG" 2>/dev/null || true)
+if [[ -n "$SRC_LABEL" ]]; then
+  pass "has org.opencontainers.image.source label ($SRC_LABEL)"
+else
+  fail "has org.opencontainers.image.source label"
+fi
+
+# Moonlight wire protocol: clients assume these ports. Losing an EXPOSE
+# doesn't break docker itself, but it breaks compose files + auto-detection
+# tooling that reads the exposed-ports set, so treat it as a regression.
+EXPECTED_PORTS=(47984/tcp 47989/tcp 47999/udp 48010/tcp 48100/udp 48200/udp)
+EXPOSED=$(docker image inspect --format '{{range $p, $_ := .Config.ExposedPorts}}{{$p}} {{end}}' "$IMAGE_TAG" 2>/dev/null || true)
+for p in "${EXPECTED_PORTS[@]}"; do
+  if [[ " $EXPOSED " == *" $p "* ]]; then
+    pass "exposes $p"
+  else
+    fail "exposes $p (got: $EXPOSED)"
+  fi
+done
+
+# ---- layer 2: init smoke --------------------------------------------------
+# Wolf inherits its entrypoint from the GOW base image. That entrypoint
+# sources /etc/cont-init.d/*.sh as root when $(id -u) is 0 and then, if
+# positional args were given, runs `bash -c "$@"` instead of the usual
+# startup script. Pass a sentinel echo so every init script executes and
+# the container exits 0.
+step "Layer 2 -- init smoke (/etc/cont-init.d scripts run clean)"
+
+SENTINEL="__wolf_init_ok_$$__"
+if timeout 60 docker run --rm \
+      --name "test-wolf-init-$$" \
+      "$IMAGE_TAG" \
+      "echo $SENTINEL" \
+      >"$INIT_LOG" 2>&1; then
+  if grep -q "$SENTINEL" "$INIT_LOG"; then
+    pass "cont-init.d scripts exit clean"
+  else
+    fail "cont-init.d scripts exit clean (sentinel missing; see log)"
+    dump "$INIT_LOG"
+  fi
+else
+  fail "cont-init.d scripts exit clean (run failed, see log)"
+  dump "$INIT_LOG"
+fi
+
+# Even with a zero exit, catch latent dynamic-linker / missing-binary chatter.
+FATAL_PATTERNS='error while loading shared libraries|cannot open shared object|segmentation fault|command not found'
+if grep -Eiq "$FATAL_PATTERNS" "$INIT_LOG"; then
+  fail "cont-init.d output is free of fatal-looking errors"
+  grep -Eni "$FATAL_PATTERNS" "$INIT_LOG" | sed 's/^/   | /' >&2
+else
+  pass "cont-init.d output is free of fatal-looking errors"
+fi
+
+# ---- layer 3: image smoke ------------------------------------------------
+SMOKE="$SMOKE_DIR/smoke.sh"
+if [[ -f "$SMOKE" ]]; then
+  step "Layer 3 -- image smoke (docker/tests/smoke.sh)"
+
+  # smoke.sh and the shared lib.sh are bind-mounted read-only; image stays
+  # untouched. The entrypoint still runs cont-init.d before handing control
+  # to the script, so smoke assertions see the same runtime state as a
+  # production container.
+  if timeout 180 docker run --rm \
+        --name "test-wolf-smoke-$$" \
+        -v "$COMMON_DIR:/smoke-common:ro" \
+        -v "$SMOKE_DIR:/smoke:ro" \
+        "$IMAGE_TAG" \
+        "/smoke/smoke.sh" \
+        >"$SMOKE_LOG" 2>&1; then
+    pass "image smoke exits clean"
+    dump "$SMOKE_LOG"
+  else
+    rc=$?
+    fail "image smoke exits clean (exit $rc)"
+    dump "$SMOKE_LOG"
+  fi
+else
+  step "Layer 3 -- SKIPPED (no docker/tests/smoke.sh)"
+fi
+
+# ---- result --------------------------------------------------------------
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+  printf '== PASS == %d/%d checks passed for wolf (%s)\n' "$TOTAL" "$TOTAL" "$IMAGE_TAG"
+  exit 0
+else
+  printf '== FAIL == %d/%d checks failed for wolf (%s)\n' "$FAIL" "$TOTAL" "$IMAGE_TAG" >&2
+  exit 1
+fi

--- a/bin/tests/lib.sh
+++ b/bin/tests/lib.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Shared helpers for docker/tests/smoke.sh.
+#
+# Mount layout inside the container (set up by bin/test-image.sh):
+#   /smoke/smoke.sh         <- the wolf smoke test
+#   /smoke-common/lib.sh    <- this file
+#
+# Usage inside smoke.sh:
+#
+#     source /smoke-common/lib.sh
+#     assert_has       xwayland gst-inspect-1.0
+#     assert_version   /wolf/fake-udev --help
+#     assert_shared_ok /wolf/wolf
+#     smoke_report
+
+set -u -o pipefail
+
+_OK=0 _FAIL=0
+
+log()  { printf '[smoke] %s\n' "$*"; }
+ok()   { _OK=$((_OK+1));     printf '   ok   %s\n' "$*"; }
+bad()  { _FAIL=$((_FAIL+1)); printf '   FAIL %s\n' "$*" >&2; }
+
+# ---- result ---------------------------------------------------------------
+# Call once at the end of smoke.sh. Exits non-zero if any assertion failed.
+smoke_report() {
+  local total=$((_OK + _FAIL))
+  if [[ "$_FAIL" -eq 0 ]]; then
+    log "PASS ${_OK}/${total}"
+    exit 0
+  fi
+  log "FAIL ${_FAIL}/${total}"
+  exit 1
+}
+
+# ---- assertions -----------------------------------------------------------
+
+# assert_has <bin> [<bin>...]
+#   Every argument must resolve via `command -v`.
+assert_has() {
+  for bin in "$@"; do
+    if command -v "$bin" >/dev/null 2>&1; then
+      ok "binary on PATH: $bin ($(command -v "$bin"))"
+    else
+      bad "binary on PATH: $bin"
+    fi
+  done
+}
+
+# assert_path <path> [<path>...]
+#   Every argument must exist as a file or dir.
+assert_path() {
+  for p in "$@"; do
+    if [[ -e "$p" ]]; then
+      ok "path exists: $p"
+    else
+      bad "path exists: $p"
+    fi
+  done
+}
+
+# assert_version <argv...>
+#   Runs the given command with a short timeout. Any exit code is tolerated
+#   (some binaries exit 1 on --version), but missing shared libs and SIGSEGV
+#   fail the check. Stdout/stderr get captured and dumped on failure.
+assert_version() {
+  local out
+  if out=$(timeout 10 "$@" 2>&1); then
+    ok "runs: $* => $(printf '%s' "$out" | head -1)"
+    return 0
+  fi
+  local rc=$?
+  if printf '%s' "$out" | grep -Eiq 'error while loading shared libraries|cannot open shared object|segmentation fault|command not found'; then
+    bad "runs: $* (fatal: $(printf '%s' "$out" | head -1))"
+    return 1
+  fi
+  # Any other non-zero exit is still suspicious but not automatically fatal;
+  # surface it and count as pass so finicky --version commands don't break CI.
+  ok "runs: $* (exit $rc; $(printf '%s' "$out" | head -1))"
+}
+
+# assert_shared_ok <binary>
+#   Ensures every shared library the binary links against resolves. Catches
+#   the class of regressions where the builder stage installs -dev packages
+#   whose runtime .so isn't in the slim runtime stage.
+assert_shared_ok() {
+  local bin="$1"
+  if [[ ! -x "$bin" ]]; then
+    bad "ldd clean: $bin (not executable)"
+    return 1
+  fi
+  local missing missing_count
+  missing=$(ldd "$bin" 2>&1 | grep -E 'not found' || true)
+  if [[ -z "$missing" ]]; then
+    ok "ldd clean: $bin"
+  else
+    missing_count=$(printf '%s\n' "$missing" | grep -c 'not found')
+    bad "ldd clean: $bin ($missing_count missing)"
+    printf '%s\n' "$missing" | sed 's/^/     | /' >&2
+  fi
+}
+
+# assert_env <VAR> [<expected-substring>]
+#   Verifies VAR is set; optionally checks that its value contains a substring.
+assert_env() {
+  local var="$1"
+  local want="${2:-}"
+  local val="${!var:-}"
+  if [[ -z "$val" ]]; then
+    bad "env set: $var"
+    return 1
+  fi
+  if [[ -n "$want" && "$val" != *"$want"* ]]; then
+    bad "env set: $var (=$val, expected to contain '$want')"
+    return 1
+  fi
+  ok "env set: $var=$val"
+}

--- a/docker/tests/smoke.sh
+++ b/docker/tests/smoke.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Smoke test for the wolf runtime image.
+#
+# Runs inside the built image after cont-init.d has executed (see
+# bin/test-image.sh). Asserts the things a running wolf depends on:
+# the two binaries we build (wolf + fake-udev), their shared-lib
+# closure, the custom gst-plugin-waylanddisplay actually loading,
+# and the runtime helpers the startup script shells out to.
+
+source /smoke-common/lib.sh
+
+# --- wolf + fake-udev binaries ---------------------------------------------
+# The two executables the builder stage copies into /wolf.
+assert_path /wolf/wolf /wolf/fake-udev
+
+# ldd-clean catches the "build stage installed libfoo-dev, runtime stage
+# forgot to install libfoo" class of regression. Wolf links against a lot
+# (boost, curl, ssl, evdev, udev, drm, pci, unwind, glib/gl/egl) so this
+# is the single highest-value check in the whole harness.
+assert_shared_ok /wolf/wolf
+assert_shared_ok /wolf/fake-udev
+
+# fake-udev's --help is self-contained (no netlink socket needed), so
+# exercising it end-to-end proves the binary is actually usable, not
+# just ldd-clean.
+assert_version /wolf/fake-udev --help
+
+# --- gstreamer custom compositor -------------------------------------------
+# Wolf builds its own gst plugin (gst-wayland-display) and the runtime
+# stage copies the plugin artefacts (.so/.a/.pc) into GST_PLUGIN_PATH. The
+# gst-wayland-display C API is linked statically into wolf, so there is no
+# separate companion .so to ship. Registration data is cached on first use.
+assert_has gst-inspect-1.0
+assert_env GST_PLUGIN_PATH gstreamer-1.0
+
+# The plugin artefacts themselves. shopt -s nullglob so the check
+# fails loud-and-clear if the COPY --from=wolf-builder glob ever
+# expands to nothing.
+shopt -s nullglob
+gst_plugins=("$GST_PLUGIN_PATH"/libgstwaylanddisplay*)
+shopt -u nullglob
+if (( ${#gst_plugins[@]} > 0 )); then
+  ok "gst-plugin-waylanddisplay present (${gst_plugins[*]})"
+else
+  bad "gst-plugin-waylanddisplay present in $GST_PLUGIN_PATH"
+fi
+
+# End-to-end plugin load: gst-inspect-1.0 dlopens the plugin and queries
+# its element factory. waylanddisplaysrc is the element wolf instantiates
+# in its pipelines (see streaming.cpp), so this is the name that has to
+# resolve. This catches ABI drift between the builder and runtime stages'
+# gstreamer (e.g. someone bumps GSTREAMER_VERSION in the build-args for one
+# stage but not the other) in a way that pure ldd can't -- gstreamer uses
+# its own symbol-version dance on top of ld.so.
+if timeout 15 gst-inspect-1.0 waylanddisplaysrc >/dev/null 2>&1; then
+  ok "gst-inspect-1.0 waylanddisplaysrc loads the plugin"
+else
+  bad "gst-inspect-1.0 waylanddisplaysrc loads the plugin (see: gst-inspect-1.0 waylanddisplaysrc)"
+fi
+
+# --- runtime helpers wolf shells out to ------------------------------------
+# The compositor needs Xwayland; startup.sh assumes a working /wolf
+# working directory and /opt/gow/startup-app.sh (the base-app entrypoint
+# hands control to this when UNAME is set).
+assert_has Xwayland
+assert_path /opt/gow/startup-app.sh /wolf
+
+# --- key env vars the startup path assumes --------------------------------
+# These are set via ENV in docker/wolf.Dockerfile. A regression here
+# (someone unsets WOLF_CFG_FOLDER in a cont-init script, say) would
+# make the container crash on first run with a confusing "cannot
+# create /cfg" message rather than a clean failure here.
+assert_env WOLF_CFG_FOLDER     /etc/wolf
+assert_env WOLF_RENDER_NODE    /dev/dri
+assert_env GST_GL_API          gles2
+assert_env GST_GL_PLATFORM     egl
+assert_env HOST_APPS_STATE_FOLDER /etc/wolf
+assert_env UNAME
+
+smoke_report


### PR DESCRIPTION
Adds an image smoke-test harness for the built `wolf` image.

`bin/test-image.sh` runs three layers:
1. **structural** — `docker inspect` (entrypoint, exposed ports, key labels)
2. **cont-init smoke** — the GOW cont-init scripts run without error
3. `docker/tests/smoke.sh` — in-container assertions: `wolf` + `fake-udev` present and `ldd`-clean, the custom `waylanddisplaysrc` gst plugin loads, and the key runtime env vars are set

`bin/tests/lib.sh` provides the `assert_*` helpers. Wired into `docker-build.yml`: on PRs without registry secrets the image is `load:`-ed into the local daemon and the harness runs against it; on push it's pulled and tested.

> Pared down to just the smoke harness. The Fedora image switch moved to #450 (Wolf vulkan), and the embedded-PulseAudio (#422), wayland-socket-wait (#418), pulse ready-guard (#420) and boost::json migration have since merged to `stable` independently. Supersedes #399. Rebased onto current `stable`.
