### PR TITLE
fix(rtsp): keep RTSP server alive when a client disconnects mid-request

### DIFF
--- a/src/moonlight-server/rtsp/net.hpp
+++ b/src/moonlight-server/rtsp/net.hpp
@@ -50,8 +50,16 @@ public:
    */
   void close() {
     logs::log(logs::trace, "[RTSP] closing socket");
-    socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
-    socket_.close();
+    // Use the non-throwing overloads. If the peer has already gone away (it
+    // sent a malformed request and reset, or simply hung up) the socket is no
+    // longer connected and shutdown()/close() would throw — e.g. ENOTCONN,
+    // "Transport endpoint is not connected". That exception unwinds out of
+    // io_context.run() in run_server() and tears down the whole RTSP server,
+    // so a single early-disconnecting client stops all future streaming.
+    // Swallowing the error keeps the server alive.
+    boost::system::error_code ec;
+    socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+    socket_.close(ec);
   }
 
   static std::optional<events::StreamSession> get_session(const immer::vector<events::StreamSession> &sessions,
@@ -81,10 +89,23 @@ public:
    *  4- send back the response message
    */
   void start() {
-    logs::log(logs::trace, "[RTSP] received connection from IP: {}", socket().remote_endpoint().address().to_string());
-    receive_message([self = shared_from_this()](auto parsed_msg) {
+    // Resolve the peer address up front and non-throwing. A client that sent a
+    // request and immediately reset (Moonlight does this on a rejected message)
+    // leaves the socket disconnected, and remote_endpoint() would otherwise
+    // throw ENOTCONN — which, thrown from this async handler, would unwind out
+    // of io_context.run() and take the whole RTSP server down. If the peer is
+    // already gone there is nothing to serve, so bail cleanly.
+    boost::system::error_code ep_ec;
+    auto remote = socket_.remote_endpoint(ep_ec);
+    if (ep_ec) {
+      logs::log(logs::debug, "[RTSP] connection gone before processing: {}", ep_ec.message());
+      close();
+      return;
+    }
+    std::string user_ip = remote.address().to_string();
+    logs::log(logs::trace, "[RTSP] received connection from IP: {}", user_ip);
+    receive_message([self = shared_from_this(), user_ip](auto parsed_msg) {
       if (parsed_msg) {
-        auto user_ip = self->socket().remote_endpoint().address().to_string();
         auto session = get_session(self->stream_sessions->load(), parsed_msg.value(), user_ip);
         if (session) {
           auto response = commands::message_handler(parsed_msg.value(), session.value());
@@ -232,13 +253,19 @@ private:
    * request, and then calls start_accept() to initiate the next accept operation.
    */
   void handle_accept(const tcp_connection::pointer &new_connection, const boost::system::error_code &error) {
+    // Re-arm the acceptor FIRST, so that anything going wrong while servicing
+    // this connection (e.g. the peer reset and a socket op throws) cannot stop
+    // the server from accepting future connections.
+    start_accept();
     if (!error) {
-      new_connection->start();
+      try {
+        new_connection->start();
+      } catch (const std::exception &e) {
+        logs::log(logs::warning, "[RTSP] error servicing connection: {}", e.what());
+      }
     } else {
       logs::log(logs::error, "[RTSP] error during connection: {}", error.message());
     }
-
-    start_accept();
   }
 
   boost::asio::io_context &io_context_;
@@ -250,14 +277,25 @@ private:
  * Starts a new RTSP server, calling this method will block execution.
  */
 void run_server(int port, const state::SessionsAtoms &running_sessions) {
+  boost::asio::io_context io_context;
   try {
-    boost::asio::io_context io_context;
     tcp_server server(io_context, port, running_sessions);
 
     logs::log(logs::info, "RTSP server started on port: {}", port);
 
-    // This will block here until the context is stopped
-    io_context.run();
+    // Block here processing connections until the context is stopped. A single
+    // misbehaving connection handler must never take the whole server down: if
+    // one throws, log it and resume the accept loop (the acceptor is still
+    // alive) instead of letting the exception unwind run_server and leave the
+    // RTSP port dead until Wolf restarts.
+    while (true) {
+      try {
+        io_context.run();
+        break; // clean stop: no more work queued
+      } catch (const std::exception &e) {
+        logs::log(logs::warning, "[RTSP] connection handler exception: {} (resuming)", e.what());
+      }
+    }
   } catch (std::exception &e) {
     logs::log(logs::error, "Unable to create RTSP server on port: {} ex: {}", port, e.what());
   }


### PR DESCRIPTION
## Problem

A client that opens an RTSP connection, sends a malformed/partial request, and immediately resets the connection (Moonlight does exactly this on a rejected message) leaves the socket disconnected. Wolf then performed socket operations on the dead socket that throw `boost::system::system_error` (ENOTCONN, *"Transport endpoint is not connected"*):

- `tcp_connection::close()` used the **throwing** `shutdown()`/`close()` overloads;
- `start()` called `socket().remote_endpoint()` on the now-disconnected socket.

These run inside `io_context.run()`, so the exception unwinds all the way out of `run_server()`, which logs:

```
ERROR | Unable to create RTSP server on port: 48010 ex: shutdown: Transport endpoint is not connected [system:107 ...]
```

and returns — **the entire RTSP server dies**. Every subsequent connection gets `ECONNREFUSED`, so no stream can be set up (clients report being unable to start the RTSP handshake). A single early-disconnecting client takes down streaming for everyone until Wolf restarts.

Reproduced with a packet capture: client sends a 1-byte message then RSTs → Wolf sends `400 BAD REQUEST` → `close()` → `shutdown()` throws → server gone.

## Fix

- **`close()`** — use the non-throwing `error_code` overloads of `shutdown()`/`close()`.
- **`start()`** — resolve `remote_endpoint()` non-throwing and bail cleanly if the peer is already gone (also avoids a redundant second `remote_endpoint()` call).
- **`handle_accept()`** — re-arm the acceptor *before* servicing the connection and wrap `start()` in try/catch, so one bad connection can never stop the accept loop.
- **`run_server()`** — resume `io_context.run()` after a handler exception instead of letting it tear the server down (defense in depth).

## Testing

Verified on a live deployment: before the fix, a single `\n`+RST probe to :48010 killed the server (subsequent connects refused); after, the server survives repeated reset-probes and keeps serving, and Moonlight streaming (Wolf UI + Steam) works.