### PR TITLE
fix(docker): resume the running session instead of killing its container on re-launch

### DIFF
--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -400,6 +400,12 @@ std::string get_rtsp_ip_string(const std::string &local_ip, const events::Stream
   return use_fake_ip ? session.rtsp_fake_ip : local_ip;
 }
 
+// Forward declaration so launch() can delegate to resume() when a session is already running.
+void resume(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::Response> &response,
+            const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::Request> &request,
+            const state::PairedClient &current_client,
+            const immer::box<state::AppState> &state);
+
 void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::Response> &response,
             const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::Request> &request,
             const state::PairedClient &current_client,
@@ -413,6 +419,15 @@ void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
     server_error<SimpleWeb::HTTPS>(response);
     return;
   }
+
+  // Re-launching while a session is already running would start a second runner that removes the
+  // live container out from under the first one. Resume the existing session instead.
+  if (state::get_session_by_client(state->running_sessions->load(), current_client)) {
+    logs::log(logs::info, "[HTTP] Client already has a running session, resuming instead of relaunching");
+    resume(response, request, current_client, state);
+    return;
+  }
+
   auto client_ip = get_client_ip<SimpleWeb::HTTPS>(request);
   auto new_session = create_run_session(request->parse_query_string(), client_ip, current_client, state, app.value());
   state->event_bus->fire_event(immer::box<events::StreamSession>(*new_session));

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -279,7 +279,8 @@ void RunDocker::run(std::string_view session_id,
 
       std::this_thread::sleep_for(500ms);
 
-    } while (docker_api.get_by_id(container_id)->status == RUNNING);
+      // value_or() avoids dereferencing nullopt when the container was removed mid-session.
+    } while (docker_api.get_by_id(container_id).value_or(Container{.status = EXITED}).status == RUNNING);
 
     logs::log(logs::debug, "[DOCKER] Container logs: \n{}", docker_api.get_logs(container_id));
     logs::log(logs::debug, "[DOCKER] Stopping container: {}", docker_container->name);

--- a/tests/docker/testDocker.cpp
+++ b/tests/docker/testDocker.cpp
@@ -56,6 +56,11 @@ TEST_CASE("Docker API", "[DOCKER]") {
   REQUIRE(!docker_api.remove_by_id(first_container->id)); // This container doesn't exist anymore
   REQUIRE(docker_api.remove_by_id(second_container->id));
 
+  // get_by_id() must return std::nullopt for a removed / non-existent container (not throw): the
+  // runner's monitor loop relies on this to stop cleanly instead of dereferencing an empty optional.
+  REQUIRE(!docker_api.get_by_id(second_container->id).has_value());
+  REQUIRE(!docker_api.get_by_id("0000000000000000000000000000000000000000000000000000000000000000").has_value());
+
   REQUIRE(docker_api.inspect_image("hello-world").has_value());
   REQUIRE(!docker_api.inspect_image("hello-world:non-existent-tag").has_value());
 }


### PR DESCRIPTION
## Summary

Re-launching or reconnecting to an app a client is **already running** dropped the player back to a fresh launcher: the running container was destroyed and recreated, and the old runner's monitor thread was left polling the now-gone container, logging `[CURL] error 404 - No such container`.

(This started as an attempt at #364, but per discussion that issue looks unrelated — this is a distinct re-launch/reconnect bug that reproduces on its own.)

## Root cause

`session_id` is derived from the client certificate (`state/sessions.hpp`), so the app container name `"{app}_{session_id}"` is **stable across reconnects**. `launch()` (`rest/endpoints.hpp`) does no dedup — it always starts a runner → `RunDocker::run` → `DockerAPI::create()`. With `force_recreate_if_present` defaulting to `true`, a name conflict makes `create()` remove the **still-running** container out from under the first runner. That first runner's monitor loop then dereferenced the now-empty `get_by_id()` optional (UB).

`resume()` is the correct re-init path: it reuses the session and carries over the wayland display + devices without starting a runner. `launch()` just never checked.

## Changes

1. **`rest/endpoints.hpp`** — `launch()` delegates to `resume()` when the client already has a running session, so the container is reused (and the wayland display + devices carried over) instead of recreated. This is the actual fix.

2. **`runners/docker.cpp`** — guard the monitor loop's `get_by_id(...)->status` with `value_or(Container{.status = EXITED})` so a container that has gone away is treated as not-running and the loop exits cleanly, rather than dereferencing `std::nullopt`. (This is the original change from the first round of review.)

`tests/docker/testDocker.cpp` adds a small regression asserting `get_by_id()` returns `std::nullopt` for a removed / non-existent container.

## Reproduced + verified end-to-end

Reproduced the bug and verified the fix on a real Wolf instance (RTX 4090); a self-contained reproducer script and before/after output are in a comment below. Two `/launch` calls for the same app+client:

- **before:** session container id changes (killed + recreated), `already present, removing first` + a `No such container` 404 loop;
- **after:** same container id, no recreate, no 404 loop, `launch()` routes to `resume()`. GPU pipeline still comes up normally.

## Notes

Changed files are `clang-format` (v18) clean. Layer 1 (`launch()`→`resume()`) is protocol-facing — happy to adjust the routing/policy if you'd prefer a different approach at the session layer.

(An earlier revision also added a `DockerAPI::get_by_name` + a reattach-to-running-container path in the runner as defense-in-depth; dropped it to keep this focused, since `launch()`→`resume()` already prevents the duplicate runner.)
