### PR TITLE
fix(nvidia): zero-copy via dmabuftocuda

### DIFF
--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -301,7 +301,12 @@ Config load_or_default(const std::string &source,
   if (use_zero_copy) {
     switch (video_encoder) {
     case NVIDIA: {
-      default_base_video.producer_buffer_caps = "video/x-raw(memory:CUDAMemory)";
+      // Carry an NV12 DMABuf over the interpipe and import it into CUDA in the
+      // consumer (dmabuftocuda, see nvcodec video_params_zero_copy). A CUDAMemory
+      // buffer can't cross the interpipe -- it's tied to a CUDA context/stream the
+      // per-client encoder pipeline doesn't share -- so the producer must hand off
+      // the context-free dmabuf, exactly like the VAAPI path below.
+      default_base_video.producer_buffer_caps = "video/x-raw(memory:DMABuf), drm-format=NV12";
       break;
     }
     case VAAPI:

--- a/src/moonlight-server/state/default/config.v7.toml
+++ b/src/moonlight-server/state/default/config.v7.toml
@@ -339,8 +339,14 @@ video/x-raw(memory:CUDAMemory), width={width}, height={height}, \
 chroma-site={color_range}, format=NV12, colorimetry={color_space}, pixel-aspect-ratio=1/1\
 """
 
+# Zero-copy carries an NV12 DMABuf over the interpipe (a CUDAMemory buffer can't
+# cross the interpipe boundary -- it's bound to a CUDA context/stream the consumer
+# pipeline doesn't share). dmabuftocuda imports that DMABuf into CUDA here in the
+# consumer (via EGLImage, no system-memory copy), where the encoder's CUDA context
+# is available; cudaupload can't (it has no DMABuf sink caps).
 video_params_zero_copy = """
-cudaupload !
+queue !
+dmabuftocuda !
 cudaconvertscale add-borders=true !
 video/x-raw(memory:CUDAMemory),format=NV12, width={width}, height={height}, pixel-aspect-ratio=1/1
 """


### PR DESCRIPTION
Nvidia zero-copy was broken. The producer pushed `memory:CUDAMemory` over the interpipe; CUDAMemory can't cross it (bound to a CUDA context the per-client consumer do't share), and `cudaupload` has no `memory:DMABuf` sink caps, so it can't import the dmabuf either.

VAAPI works because it carries a DMABuf over the interpipe. This makes Nvidia do the same.

**Fix (2 files):**
- producer caps: `memory:CUDAMemory` → `memory:DMABuf, drm-format=NV12`
- nvcodec `video_params_zero_copy`: `cudaupload` → `queue ! dmabuftocuda`

`dmabuftocuda` imports the dmabuf into CUDA in the consumer (EGLImage, no sysmem copy), where the encoder's CUDA context lives.

**Needs:** gst-wayland-display built with the cuda feature (provides `dmabuftocuda`). The Dockerfile pin predates it bump the pin.

**Tested** on an RTX 5080: the chain `waylanddisplaysrc → DMABuf(NV12) → interpipe → queue → dmabuftocuda → cudaconvertscale → CUDAMemory → nvh265enc` encodes H.265. Daemon boots logging `Using zero copy pipeline on Nvidia`. Not run: a live Moonlight session.