### PR TITLE
fix(test): static wayland registry listener

### DIFF
--- a/tests/platforms/linux/wayland-client.hpp
+++ b/tests/platforms/linux/wayland-client.hpp
@@ -50,7 +50,7 @@ static const struct xdg_wm_base_listener xdg_wm_base_listener = {
 
 std::shared_ptr<WClientState> w_get_state(std::shared_ptr<wl_display> wd) {
   struct wl_registry *registry = wl_display_get_registry(wd.get());
-  struct wl_registry_listener listener = {
+  static const struct wl_registry_listener listener = {
       [](void *data, struct wl_registry *registry, uint32_t id, const char *interface, uint32_t version) {
         logs::log(logs::debug, "Got registry event: id={}, interface={}, version={}", id, interface, version);
         auto state = (WClientState *)data;


### PR DESCRIPTION
The `[WAYLAND]` "virtual inputs" test flakes with a SIGABRT (`listener function for opcode 0 of wl_registry is NULL`) only on the clang sanitizer variant.

Cause: in `w_get_state` the `wl_registry_listener` is a **stack local**. `wl_registry_add_listener` keeps the pointer for the registry's lifetime, but the registry outlives the function. A registry event after it returns dispatches through a dangling pointer garbage in, abort. Non-deterministic: depends on a late global + whether the stack got reused (so sanitizers hit it, others mostly do't).

Fix: make it `static const`, like every other listener in the file (e.g. `xdg_wm_base_listener`). One word.