### PR TITLE
fix: serialize the RTSP handshake per client IP (same-NAT clients)

### DIFF
--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -16,6 +16,7 @@
 #include <rest/helpers.hpp>
 #include <rest/rest.hpp>
 #include <rtp/udp-ping.hpp>
+#include <rtsp/rtsp_handshake.hpp>
 #include <state/config.hpp>
 #include <state/sessions.hpp>
 #include <state/utils.hpp>
@@ -419,6 +420,11 @@ void launch(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
   state->running_sessions->update(
       [new_session](const immer::vector<events::StreamSession> &ses_v) { return ses_v.push_back(*new_session); });
 
+  // Couple this launch with the RTSP handshake that follows it: claim the RTSP
+  // window for this client IP so a concurrent same-NAT launch waits and the two
+  // RTSP handshakes don't get crossed (see rtsp/rtsp_handshake.hpp).
+  rtsp::RtspHandshake::instance().begin(new_session->session_id, client_ip);
+
   auto rtsp_ip = get_rtsp_ip_string(get_host_ip<SimpleWeb::HTTPS>(request, state), *new_session);
   auto xml = moonlight::launch_success(rtsp_ip, std::to_string(get_port(state::RTSP_SETUP_PORT)));
   send_xml<SimpleWeb::HTTPS>(response, SimpleWeb::StatusCode::success_ok, xml);
@@ -447,6 +453,9 @@ void resume(const std::shared_ptr<typename SimpleWeb::Server<SimpleWeb::HTTPS>::
     state->running_sessions->update([&old_session, new_session](const immer::vector<events::StreamSession> ses_v) {
       return state::remove_session(ses_v, old_session.value()).push_back(*new_session);
     });
+
+    // Same RTSP-handshake coupling as launch() (see rtsp/rtsp_handshake.hpp).
+    rtsp::RtspHandshake::instance().begin(new_session->session_id, client_ip);
 
     auto rtsp_ip = get_rtsp_ip_string(get_host_ip<SimpleWeb::HTTPS>(request, state), *new_session);
     auto xml = moonlight::launch_resume(rtsp_ip, std::to_string(get_port(state::RTSP_SETUP_PORT)));

--- a/src/moonlight-server/rtsp/net.hpp
+++ b/src/moonlight-server/rtsp/net.hpp
@@ -6,6 +6,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/shared_ptr.hpp>
 #include <rtsp/commands.hpp>
+#include <rtsp/rtsp_handshake.hpp>
 #include <state/sessions.hpp>
 #include <string_view>
 #include <thread>
@@ -69,13 +70,44 @@ public:
     if (auto host = packet.options.find("Host"); host != packet.options.end()) {
       host_option = host->second;
     }
+    // 1. Exact match on the per-session fake IP (in the URI or the Host header).
     for (const events::StreamSession &session : sessions) {
       if (session.rtsp_fake_ip == packet.request.uri.ip || host_option == session.rtsp_fake_ip) {
         logs::log(logs::debug, "[RTSP] found session by matching payload: {}", session.rtsp_fake_ip);
         return session;
-      } else if ((host_option == "0.0.0.0" || host_option.empty()) && session.ip == user_ip) {
-        logs::log(logs::debug, "[RTSP] found session by matching IP: {}", session.ip);
-        return session;
+      }
+    }
+    // 2. Ambiguous `Host: 0.0.0.0` (moonlight below the HQ-audio threshold): the
+    // client doesn't tell us which session it means, so resolve it through the
+    // launch->RTSP coupling — the session that currently owns the RTSP handshake
+    // window for this source IP (see rtsp_handshake.hpp). Every packet of a live
+    // handshake lands here while that window is open.
+    if (host_option == "0.0.0.0" || host_option.empty()) {
+      const std::string ip{user_ip};
+      if (auto active = RtspHandshake::instance().active_session(ip)) {
+        for (const events::StreamSession &session : sessions) {
+          if (session.session_id == *active) {
+            logs::log(logs::debug, "[RTSP] resolved session {} via the RTSP handshake window", *active);
+            return session;
+          }
+        }
+      }
+      // No open window (an established session sending a stray ambiguous packet,
+      // or a handshake that outran the safety timeout): fall back to the source
+      // IP, but only when it's unambiguous — exactly one session on this IP. With
+      // two same-IP sessions the window above is the only correct demux, so we
+      // never guess between them here.
+      std::optional<events::StreamSession> unique;
+      std::size_t matches = 0;
+      for (const events::StreamSession &session : sessions) {
+        if (session.ip == user_ip) {
+          unique = session;
+          ++matches;
+        }
+      }
+      if (matches == 1) {
+        logs::log(logs::debug, "[RTSP] found session by matching IP: {}", unique->ip);
+        return unique;
       }
     }
     return std::nullopt;
@@ -108,6 +140,11 @@ public:
       if (parsed_msg) {
         auto session = get_session(self->stream_sessions->load(), parsed_msg.value(), user_ip);
         if (session) {
+          // The RTSP handshake ends at PLAY: close this session's window so a
+          // same-IP launch waiting on it can proceed (see rtsp_handshake.hpp).
+          if (parsed_msg->request.cmd == "PLAY") {
+            RtspHandshake::instance().complete(session->session_id);
+          }
           auto response = commands::message_handler(parsed_msg.value(), session.value());
           self->send_message(response, [self](auto bytes) { self->close(); });
         } else {

--- a/src/moonlight-server/rtsp/rtsp_handshake.hpp
+++ b/src/moonlight-server/rtsp/rtsp_handshake.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace rtsp {
+
+/**
+ * Couples an HTTPS launch/resume with the RTSP handshake that follows it, so
+ * two Moonlight clients behind the same NAT don't get their RTSP sessions
+ * crossed.
+ *
+ * Background: below the high-quality-audio threshold moonlight-common-c sends
+ * RTSP with `Host: 0.0.0.0`, which makes Wolf's RTSP demux fall back to
+ * source-IP matching. For two clients sharing one public IP that matches both
+ * to whichever session is first in the list, swapping their AES keys.
+ *
+ * Fix (the model Sunshine uses): after a launch/resume there is always an RTSP
+ * handshake from that same client. We give the launching client an exclusive
+ * RTSP "window" for its IP; while the window is open every ambiguous RTSP
+ * packet from that IP resolves to its session. A *concurrent* launch from the
+ * same IP blocks until the window closes, so the two handshakes never overlap.
+ * The very first launch never blocks (the client only opens the RTSP
+ * connection after it gets the launch response).
+ *
+ * The window starts wide (the client may take a moment to connect) and shrinks
+ * to a short grace once the first RTSP packet is seen — long enough to cover
+ * the rest of that client's OPTIONS/DESCRIBE/SETUP/PLAY burst.
+ */
+class RtspHandshake {
+public:
+  static RtspHandshake &instance() {
+    static RtspHandshake gate;
+    return gate;
+  }
+
+  /**
+   * Claim the RTSP window for `client_ip`. Returns immediately when no other
+   * session from the same IP is mid-handshake; otherwise blocks (up to
+   * MAX_WAIT) until that one's window closes. Call right before replying to
+   * /launch or /resume.
+   */
+  void begin(std::size_t session_id, const std::string &client_ip) {
+    std::unique_lock<std::mutex> lk(mtx_);
+    const auto give_up = clock::now() + MAX_WAIT;
+    for (auto it = pending_.find(client_ip); it != pending_.end() && clock::now() < it->second.window_end;
+         it = pending_.find(client_ip)) {
+      if (clock::now() >= give_up) {
+        break; // don't block a launch forever if the previous client vanished
+      }
+      cv_.wait_until(lk, std::min(it->second.window_end, give_up));
+    }
+    pending_[client_ip] = Pending{.session_id = session_id, .window_end = clock::now() + INITIAL};
+  }
+
+  /**
+   * The session that currently owns the RTSP window for `client_ip`, if any.
+   * Used by the RTSP demux to resolve `Host: 0.0.0.0` packets. The window stays
+   * open for the *whole* handshake: it is closed by complete() on the RTSP PLAY,
+   * or by the INITIAL safety timeout if the client never finishes. (An earlier
+   * "close on first packet" was too eager — a later SETUP escaped the window and
+   * fell back to the wrong session, handing the client the other one's secret.)
+   */
+  std::optional<std::size_t> active_session(const std::string &client_ip) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    auto it = pending_.find(client_ip);
+    if (it == pending_.end() || clock::now() >= it->second.window_end) {
+      return std::nullopt;
+    }
+    return it->second.session_id;
+  }
+
+  /**
+   * Close the RTSP window for a session once its handshake is done (called on
+   * the RTSP PLAY), so a same-IP launch waiting on it can proceed immediately.
+   */
+  void complete(std::size_t session_id) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    for (auto it = pending_.begin(); it != pending_.end(); ++it) {
+      if (it->second.session_id == session_id) {
+        pending_.erase(it);
+        cv_.notify_all();
+        return;
+      }
+    }
+  }
+
+private:
+  using clock = std::chrono::steady_clock;
+  struct Pending {
+    std::size_t session_id;
+    clock::time_point window_end;
+  };
+
+  std::mutex mtx_;
+  std::condition_variable cv_;
+  std::map<std::string, Pending> pending_; // keyed by client IP
+
+  // Safety cap: how long a window stays open if the client never sends PLAY
+  // (e.g. it connected the HTTPS launch but never started the RTSP handshake).
+  static constexpr std::chrono::milliseconds INITIAL{10000};
+  // Hard cap on how long a concurrent same-IP launch will block waiting for the
+  // in-flight one's handshake to finish.
+  static constexpr std::chrono::milliseconds MAX_WAIT{11000};
+};
+
+} // namespace rtsp


### PR DESCRIPTION
Wolf gives each session a random **fake IP** in the launch response and expects the client to echo it back as the RTSP `Host`/URI — that's how it tells concurrent sessions apart. But below the high-quality-audio threshold `moonlight-common-c` sends `Host: 0.0.0.0` and drops it, and there is no other per-session identifier in the RTSP handshake (the `Session` header is a constant). So two clients behind the same NAT both arrive as `0.0.0.0` from the same source IP, Wolf routes both to the first session, and their AES keys and ENET secrets get swapped — video corrupts and one client's input lands in the other's session.

Since the client can't reliably tell us which session it is, this couples each HTTPS launch/resume with the RTSP handshake that follows it: the launching client owns an exclusive RTSP window for its source IP, held until the handshake finishes (RTSP `PLAY`). While the window is open, ambiguous `0.0.0.0` packets from that IP resolve to that session; a concurrent same-IP launch waits until the window closes, so two handshakes never overlap.

```
client                                    Wolf
  |  HTTPS /launch (or /resume)             |
  |----------------------------------------→|  create session S
  |                                         |  open RTSP window:  srcIP → S
  |  200 (rtsp setup port)                  |
  |←----------------------------------------|
  |                                         |
  |  RTSP OPTIONS→DESCRIBE→SETUP(a/v/ctrl)   |
  |      →ANNOUNCE       (Host: 0.0.0.0)     |
  |----------------------------------------→|  window open → every packet → S
  |←----------------------------------------|  (SETUP control hands back S's ENET secret)
  |                                         |
  |  RTSP PLAY                              |
  |----------------------------------------→|  resolve → S, then close S's window
  |←----------------------------------------|
  |                                         |
  | === video/audio (UDP) + input (ENET), demuxed per session by that secret ===
```

A second **distinct** client on the same NAT that launches mid-handshake blocks at its own `/launch` until the first window closes, so the two handshakes are serialized and never resolve to each other.

Clients that *do* echo the fake IP (above the threshold) are still matched directly by it — the window only covers the `0.0.0.0` case.
