### PR TITLE
feat: better control over motion joypads

### DIFF
--- a/docs/modules/user/pages/configuration.adoc
+++ b/docs/modules/user/pages/configuration.adoc
@@ -325,6 +325,37 @@ The available joypad types are:
 * `nintendo`
 * `ps`
 
+==== Auto-detection: UNKNOWN clients with motion get a DualSense
+
+Moonlight Android downgrades the reported controller type to `UNKNOWN` whenever the phone has sensors and the underlying pad isn't already a DualSense (see https://github.com/moonlight-stream/moonlight-android/blob/master/app/src/main/java/com/limelight/binding/input/ControllerHandler.java[`ControllerHandler.java`]) — the capability bits still advertise `GYRO` and `ACCELEROMETER`. Wolf's auto-detection treats this as the client signalling "I have motion data to give" and creates a PlayStation DualSense pad so the motion-request blocks actually fire and the gyro/accel data gets forwarded. Without this the type would fall through to Xbox and the motion would be silently dropped.
+
+Auto-detection only kicks in when there's no per-slot `controllers_override` and no per-client `motion_controller_override` (below). Both of those are explicit operator choices and win.
+
+==== Per-client `motion_controller_override`
+
+Sibling of `controllers_override`: same shape of "operator wants type X" but gated on the client actually having motion to forward. When `controllers_override[slot]` is unset, the client advertises `GYRO` / `ACCELEROMETER`, AND `motion_controller_override` is set to anything other than `auto`, Wolf creates that pad type instead of the auto-detected one. Useful to point motion-capable clients at a non-default device — for example forcing a Switch Pro pad (once the corresponding motion routing in `create_new_joypad` lands).
+
+[source,toml]
+....
+[[paired_clients]]
+# client_cert = ...
+[paired_clients.settings]
+motion_controller_override = "PS" # motion-capable clients get a DualSense
+....
+
+Available values are the same as `controllers_override` (`auto` (default) / `xbox` / `nintendo` / `ps`); `auto` defers to the auto-detection above.
+
+Precedence: per-slot `controllers_override` > per-client `motion_controller_override` > auto-detection.
+
+It is also exposed over the API:
+
+[source,bash]
+....
+curl --unix-socket /var/run/wolf/wolf.sock \
+     -X PATCH http://localhost/api/v1/clients/<client_id>/settings \
+     -d '{"settings": {"motion_controller_override": "PS"}}'
+....
+
 === Input mouse overrides
 
 You can increase and decrease the mouse acceleration and scroll speed for each paired client, ex:

--- a/src/moonlight-server/api/api.hpp
+++ b/src/moonlight-server/api/api.hpp
@@ -58,6 +58,7 @@ struct PartialClientSettings {
   std::optional<float> mouse_acceleration;
   std::optional<float> v_scroll_acceleration;
   std::optional<float> h_scroll_acceleration;
+  std::optional<wolf::config::ControllerType> motion_controller_override;
 };
 
 struct UpdateClientSettingsRequest {

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -576,8 +576,8 @@ void UnixSocketServer::endpoint_UpdateClientSettings(const HTTPRequest &req, std
           .mouse_acceleration = new_settings.mouse_acceleration.value_or(current_settings.mouse_acceleration),
           .v_scroll_acceleration = new_settings.v_scroll_acceleration.value_or(current_settings.v_scroll_acceleration),
           .h_scroll_acceleration = new_settings.h_scroll_acceleration.value_or(current_settings.h_scroll_acceleration),
-          .motion_controller_override = new_settings.motion_controller_override.value_or(
-              current_settings.motion_controller_override),
+          .motion_controller_override =
+              new_settings.motion_controller_override.value_or(current_settings.motion_controller_override),
       }};
 
   update_client_settings(this->state_->app_state->config, std::stoull(payload.client_id.value()), merged_client);

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -431,7 +431,9 @@ void UnixSocketServer::endpoint_LobbyCreate(const wolf::api::HTTPRequest &req, s
                 .v_scroll_acceleration =
                     client_settings.v_scroll_acceleration.value_or(default_client_settings.v_scroll_acceleration),
                 .h_scroll_acceleration =
-                    client_settings.h_scroll_acceleration.value_or(default_client_settings.h_scroll_acceleration)},
+                    client_settings.h_scroll_acceleration.value_or(default_client_settings.h_scroll_acceleration),
+                .motion_controller_override = client_settings.motion_controller_override.value_or(
+                    default_client_settings.motion_controller_override)},
         .runner_state_folder = event.value().runner_state_folder,
         .runner = state::get_runner(event.value().runner, this->state_->app_state->event_bus)};
     // Fire the event
@@ -574,6 +576,8 @@ void UnixSocketServer::endpoint_UpdateClientSettings(const HTTPRequest &req, std
           .mouse_acceleration = new_settings.mouse_acceleration.value_or(current_settings.mouse_acceleration),
           .v_scroll_acceleration = new_settings.v_scroll_acceleration.value_or(current_settings.v_scroll_acceleration),
           .h_scroll_acceleration = new_settings.h_scroll_acceleration.value_or(current_settings.h_scroll_acceleration),
+          .motion_controller_override = new_settings.motion_controller_override.value_or(
+              current_settings.motion_controller_override),
       }};
 
   update_client_settings(this->state_->app_state->config, std::stoull(payload.client_id.value()), merged_client);

--- a/src/moonlight-server/control/input_handler.cpp
+++ b/src/moonlight-server/control/input_handler.cpp
@@ -59,19 +59,43 @@ std::shared_ptr<events::JoypadTypes> create_new_joypad(const events::StreamSessi
   auto final_type = controllers_override.size() > controller_number ? controllers_override[controller_number]
                                                                     : wolf::config::ControllerType::AUTO;
   if (final_type == wolf::config::ControllerType::AUTO) {
-    switch (requested_type) {
-    case XBOX:
-      final_type = wolf::config::ControllerType::XBOX;
-      break;
-    case PS:
-      final_type = wolf::config::ControllerType::PS;
-      break;
-    case NINTENDO:
-      final_type = wolf::config::ControllerType::NINTENDO;
-      break;
-    default:
-      final_type = wolf::config::ControllerType::AUTO;
-      break;
+    // Motion-gated per-client override. When this slot has no
+    // `controllers_override`, the client advertises GYRO or
+    // ACCELEROMETER, AND `motion_controller_override` is set to a
+    // specific type, route to that type. Sibling to
+    // `controllers_override` (unconditional force, per-slot), but
+    // gated on the client actually having motion to forward so
+    // non-motion clients are unaffected.
+    if ((capabilities & (ACCELEROMETER | GYRO)) &&
+        session.client_settings->motion_controller_override != wolf::config::ControllerType::AUTO) {
+      final_type = session.client_settings->motion_controller_override;
+    } else {
+      switch (requested_type) {
+      case XBOX:
+        final_type = wolf::config::ControllerType::XBOX;
+        break;
+      case PS:
+        final_type = wolf::config::ControllerType::PS;
+        break;
+      case NINTENDO:
+        final_type = wolf::config::ControllerType::NINTENDO;
+        break;
+      default:
+        // Client reported UNKNOWN. If it advertises GYRO or
+        // ACCELEROMETER (typically a phone with built-in sensors
+        // overlaying any underlying pad — see
+        // moonlight-android ControllerHandler.java:3148) promote to
+        // PS so the motion-request blocks below actually fire and the
+        // gyro/accel data the client is ready to send gets requested
+        // and forwarded. Without this it stays AUTO → XBOX and the
+        // motion is silently dropped.
+        if (capabilities & (ACCELEROMETER | GYRO)) {
+          final_type = wolf::config::ControllerType::PS;
+        } else {
+          final_type = wolf::config::ControllerType::AUTO;
+        }
+        break;
+      }
     }
   }
   switch (final_type) {

--- a/src/moonlight-server/state/serialised_config.hpp
+++ b/src/moonlight-server/state/serialised_config.hpp
@@ -29,6 +29,16 @@ struct ClientSettings {
   float v_scroll_acceleration = 1.0;
   /* (horizontal scroll) Values above 1.0 will make it faster, between 0.0 and 1.0 will make it slower */
   float h_scroll_acceleration = 1.0;
+  /* Motion-capable virtual pad override. When `controllers_override[slot]`
+   * is unset, the client advertises GYRO/ACCELEROMETER, AND this is
+   * anything other than `AUTO`, Wolf creates this controller type
+   * instead of the auto-detected one. `AUTO` (default) defers to the
+   * auto-detection logic (which promotes UNKNOWN-with-motion clients
+   * to PS so motion routes — see `create_new_joypad` in
+   * control/input_handler.cpp). Sibling to `controllers_override`:
+   * same shape of "operator wants type X" but gated on the client
+   * actually having motion to forward. */
+  ControllerType motion_controller_override = ControllerType::AUTO;
 };
 
 struct PairedClient {

--- a/tests/testWolfAPI.cpp
+++ b/tests/testWolfAPI.cpp
@@ -143,7 +143,8 @@ TEST_CASE("Pair APIs", "[API]") {
                       "\"controllers_override\":[\"PS\"],"
                       "\"mouse_acceleration\":2.5,"
                       "\"v_scroll_acceleration\":1.5,"
-                      "\"h_scroll_acceleration\":10.199999809265137}}]}"));
+                      "\"h_scroll_acceleration\":10.199999809265137,"
+                      "\"motion_controller_override\":\"AUTO\"}}]}"));
 
   auto pair_promise = std::make_shared<boost::promise<std::string>>();
 


### PR DESCRIPTION
## Problem

Wolf trusts the controller type the Moonlight client reports. For phone clients that's often wrong: `moonlight-common-c` (used by all Moonlight clients) advertises `GYRO`/`ACCELEROMETER` capability whenever the phone has sensors enabled, but Moonlight Android specifically downgrades the **reported type** to `UNKNOWN` whenever the phone has sensors and the underlying pad isn't already a DualSense:

```java
// moonlight-android/app/src/main/java/com/limelight/binding/input/ControllerHandler.java#L3148
if (type != MoonBridge.LI_CTYPE_PS && sensorManager != null) {
    // Override the detected controller type if we're emulating motion sensors
    reportedType = MoonBridge.LI_CTYPE_UNKNOWN;
}
```

Wolf's default for UNKNOWN is the Xbox virtual pad. The motion-request blocks (`if (capabilities & GYRO|ACCELEROMETER && final_type == PS)`) only fire for PS pads — so the gyro/accel data the client is ready to send is silently dropped.

## Fix

Two related changes, bundled:

### 1. Auto-detect (always on, no config)

When the client reports `controller_type=UNKNOWN` AND advertises `GYRO` or `ACCELEROMETER`, Wolf creates a PS5/DualSense pad instead of falling through to Xbox. The motion blocks then fire and the gyro data is forwarded end-to-end. Stock Moonlight Android with any non-PS pad on any phone with sensors enabled now gets motion routed out of the box.

The promotion is unconditional because Moonlight Android itself shows an in-game toast ("Gamepad type may be changed due to motion sensor emulation") when the user enables motion — the client-side already signals the type change is expected.

### 2. Per-client `motion_controller_override` setting

A new optional `motion_controller_override: ControllerType` field on `ClientSettings` (default `AUTO`). Sibling of `controllers_override`: same shape of "operator wants type X" but gated on the client actually having motion to forward. When `controllers_override[slot]` is unset, the client advertises `GYRO`/`ACCELEROMETER`, AND `motion_controller_override != AUTO`, Wolf forces that pad type instead of the auto-detected one.

```
PATCH /api/v1/clients/<id>/settings  { "motion_controller_override": "PS" }
```

Same plumbing as `controllers_override` — added to `PartialClientSettings`, threaded through both the lobby-create and client-settings-update endpoints.

Useful for "every motion-capable connection from this client should land on device X" preferences. Forward-compatible with PR #385's Switch Pro work — once those motion-gates extend beyond `PS`, `motion_controller_override = "NINTENDO"` will route motion to a Switch Pro pad.

## Precedence

```
controllers_override[slot]   (per-slot)    ← highest, wins everything
        ↓ unset
motion_controller_override   (per-client)  ← forces type if motion advertised AND != AUTO
        ↓ AUTO
auto-detection                              ← UNKNOWN+motion → PS, else honour client's reported type
```

## Compatibility

Existing clients with `motion_controller_override` unset keep their behaviour for explicit XBOX/PS/NINTENDO. The only behaviour change is for UNKNOWN-with-motion clients, which previously got Xbox+no-motion and now get DualSense+motion — universally an improvement for the affected users (everyone on Moonlight Android with a non-DS pad + sensors enabled).

## Documented

In `docs/modules/user/pages/configuration.adoc` under "Override the default joypad mapping" — two new sub-sections covering the auto-detection and `motion_controller_override`.

## Verified

End-to-end on a Pixel 7 running stock Moonlight Android with an Xbox pad attached: client reports UNKNOWN with `GYRO|ACCELEROMETER`, Wolf creates a DualSense, and gyro/accel events arrive at the virtual pad — no config needed. With `motion_controller_override="XBOX"` set on the same client, Wolf creates an Xbox pad instead.
