### PR TITLE
Add a generic per-app properties map

### DIFF
--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -4,6 +4,7 @@
 #define BOOST_THREAD_PROVIDES_FUTURE
 #include <boost/thread.hpp>
 #include <boost/thread/future.hpp>
+#include <map>
 #include <core/audio.hpp>
 #include <core/input.hpp>
 #include <core/virtual-display.hpp>
@@ -74,6 +75,8 @@ struct App {
   std::string opus_gst_pipeline;
   bool start_virtual_compositor;
   bool start_audio_server;
+  /** App-specific settings wolf passes through verbatim; interpreted by the app runner. */
+  std::map<std::string, std::string> properties;
   std::shared_ptr<Runner> runner;
 };
 

--- a/src/moonlight-server/events/reflectors.hpp
+++ b/src/moonlight-server/events/reflectors.hpp
@@ -4,6 +4,7 @@
 #include "state/data-structures.hpp"
 
 #include <events/events.hpp>
+#include <map>
 #include <rfl.hpp>
 #include <rfl/parsing/Parser.hpp>
 #include <state/serialised_config.hpp>
@@ -57,6 +58,7 @@ template <> struct Reflector<events::App> {
     std::string opus_gst_pipeline;
     bool start_virtual_compositor;
     bool start_audio_server;
+    std::map<std::string, std::string> properties;
     Reflector<events::Runner>::ReflType runner;
   };
 
@@ -72,6 +74,7 @@ template <> struct Reflector<events::App> {
             .opus_gst_pipeline = v.opus_gst_pipeline,
             .start_virtual_compositor = v.start_virtual_compositor,
             .start_audio_server = v.start_audio_server,
+            .properties = v.properties,
             .runner = v.runner->serialize()};
   }
 
@@ -85,6 +88,7 @@ template <> struct Reflector<events::App> {
         .render_node = app.render_node,
         .opus_gst_pipeline = app.opus_gst_pipeline,
         .start_virtual_compositor = app.start_virtual_compositor,
+        .properties = app.properties,
         .runner = runner,
     };
   }

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -199,6 +199,7 @@ parse_apps(const std::vector<BaseApp> &apps,
                         .opus_gst_pipeline = opus_gst_pipeline,
                         .start_virtual_compositor = app.start_virtual_compositor.value_or(true),
                         .start_audio_server = app.start_audio_server.value_or(true),
+                        .properties = app.properties.value_or(std::map<std::string, std::string>{}),
                         .runner = get_runner(app.runner, ev_bus)}};
       }) |                                                  //
       ranges::to<immer::vector<immer::box<events::App>>>(); //
@@ -488,6 +489,9 @@ void update_profiles(const Config &cfg, const ProfilesList &profiles) {
                                                 .render_node = app->render_node,
                                                 .start_virtual_compositor = app->start_virtual_compositor,
                                                 .start_audio_server = app->start_audio_server,
+                                                .properties = app->properties.empty()
+                                                                  ? std::nullopt
+                                                                  : std::make_optional(app->properties),
                                                 .runner = app->runner->serialize()};
                                }) | //
                                ranges::to_vector,

--- a/src/moonlight-server/state/serialised_config.hpp
+++ b/src/moonlight-server/state/serialised_config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <helpers/utils.hpp>
+#include <map>
 #include <rfl.hpp>
 #include <string>
 
@@ -124,6 +125,12 @@ struct BaseApp {
   std::optional<BaseAppAudioOverride> audio;
   std::optional<bool> start_virtual_compositor;
   std::optional<bool> start_audio_server;
+  /**
+   * Free-form, app-specific settings that wolf itself does not interpret — the app
+   * image / runner does (e.g. "steam_library_dirs"). Kept generic so new app types
+   * need no schema changes here.
+   */
+  std::optional<std::map<std::string, std::string>> properties;
   rfl::TaggedUnion<"type", AppCMD, AppDocker> runner =
       AppCMD{}; // We have to provide a default or rfl::DefaultIfMissing will fail
 };


### PR DESCRIPTION
**Draft — a generic per-app `properties` map so wolf can carry app-specific settings without per-app schema changes.**

## What
Apps gain an optional `properties: map<string, string>` that wolf itself does **not** interpret — the app image / runner does (e.g. `steam_library_dirs`, emulator firmware paths). It flows end-to-end:

`BaseApp` (TOML config) → `events::App` (runtime) → `Reflector<App>` (socket API `/api/v1/apps`), and round-trips back to TOML on save.

## Why
External tooling (custom launchers / web UIs over the socket API) and app-specific runners need somewhere to attach settings meaningful only to a particular app, without growing wolf's core schema for each one. A generic string map keeps wolf agnostic while the app side interprets its own keys.

```toml
[[profiles.apps]]
title = "Steam"

[profiles.apps.properties]
steam_library_dirs = "/mnt/ssd/steam:/mnt/nas/steam"
```

## Notes
- Optional + defaults to empty → no behaviour change for existing configs.
- An empty map round-trips to *absent* (no empty TOML table is written back).
- First of a small series of hooks (this, plus client-settings policy fields) that let an external launcher/UI drive wolf entirely over the socket API.
