### PR TITLE
Per-client profile access in ClientSettings

### DIFF
--- a/src/moonlight-server/api/api.hpp
+++ b/src/moonlight-server/api/api.hpp
@@ -59,6 +59,8 @@ struct PartialClientSettings {
   std::optional<float> v_scroll_acceleration;
   std::optional<float> h_scroll_acceleration;
   std::optional<wolf::config::ControllerType> motion_controller_override;
+  std::optional<std::vector<std::string>> allowed_profiles;
+  std::optional<bool> show_coop_games;
 };
 
 struct UpdateClientSettingsRequest {

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -433,7 +433,10 @@ void UnixSocketServer::endpoint_LobbyCreate(const wolf::api::HTTPRequest &req, s
                 .h_scroll_acceleration =
                     client_settings.h_scroll_acceleration.value_or(default_client_settings.h_scroll_acceleration),
                 .motion_controller_override = client_settings.motion_controller_override.value_or(
-                    default_client_settings.motion_controller_override)},
+                    default_client_settings.motion_controller_override),
+                .allowed_profiles = client_settings.allowed_profiles.value_or(default_client_settings.allowed_profiles),
+                .show_coop_games =
+                    client_settings.show_coop_games.value_or(default_client_settings.show_coop_games)},
         .runner_state_folder = event.value().runner_state_folder,
         .runner = state::get_runner(event.value().runner, this->state_->app_state->event_bus)};
     // Fire the event
@@ -578,6 +581,8 @@ void UnixSocketServer::endpoint_UpdateClientSettings(const HTTPRequest &req, std
           .h_scroll_acceleration = new_settings.h_scroll_acceleration.value_or(current_settings.h_scroll_acceleration),
           .motion_controller_override =
               new_settings.motion_controller_override.value_or(current_settings.motion_controller_override),
+          .allowed_profiles = new_settings.allowed_profiles.value_or(current_settings.allowed_profiles),
+          .show_coop_games = new_settings.show_coop_games.value_or(current_settings.show_coop_games),
       }};
 
   update_client_settings(this->state_->app_state->config, std::stoull(payload.client_id.value()), merged_client);

--- a/src/moonlight-server/state/serialised_config.hpp
+++ b/src/moonlight-server/state/serialised_config.hpp
@@ -39,6 +39,12 @@ struct ClientSettings {
    * same shape of "operator wants type X" but gated on the client
    * actually having motion to forward. */
   ControllerType motion_controller_override = ControllerType::AUTO;
+  /* Profile IDs this client may see and launch. Empty (default) = unrestricted
+   * (all profiles). Lets a shared host scope which clients see which profiles. */
+  std::vector<std::string> allowed_profiles = {};
+  /* Whether this client may see and join other clients' co-op (multi-user)
+   * lobbies. Default true. */
+  bool show_coop_games = true;
 };
 
 struct PairedClient {


### PR DESCRIPTION
Adds per-client access control to `ClientSettings` — the existing home for client-specific config (`run_uid`, `controllers_override`, `motion_controller_override`, …).

## What
- `allowed_profiles: vector<string>` — profile IDs a client may see and launch. Empty (default) = unrestricted (all profiles).
- `show_coop_games: bool` (default `true`) — whether a client may see and join other clients' co-op (multi-user) lobbies.

Both are settable over the socket API through `PartialClientSettings` (the update-client-settings endpoint) and flow through create-lobby, exactly like the existing per-client fields. They show up in the clients response too.

## Why
On a shared / multi-tenant host, different clients should see different sets of profiles, and co-op visibility is naturally per-client. `ClientSettings` is already where per-client policy lives, so this slots in with no new mechanism. Defaults preserve today's behaviour (all profiles visible, co-op visible).

This lets an external UI that drives Wolf over the socket read a client's `allowed_profiles` / `show_coop_games` and filter what it shows — without Wolf needing to know anything about that UI.

Draft pending CI.
