### PR TITLE
feat(vulkan): wolf:vulkan image (native Vulkan NV12 encode) + Fedora switch

### DIFF
--- a/.ci-rebuild-trigger
+++ b/.ci-rebuild-trigger
@@ -1,0 +1,1 @@
+rebuild wolf:vulkan on gst-wayland-display:vulkan base with LINEAR encode-src workaround (1118de2)

--- a/.devcontainer/dev-setup.sh
+++ b/.devcontainer/dev-setup.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 set -e
-export DEBIAN_FRONTEND=noninteractive
 
-apt-get update
+# The devcontainer is built on the Fedora wolf-builder stage, so use dnf.
 
 # Install debugger
-apt-get install -y gdb
+dnf install -y gdb
 
 # Install wayland-protocols
-apt-get install -y wayland-protocols
+dnf install -y wayland-protocols-devel
 
 # Build and install nvtop
-apt-get install -y libdrm-dev libsystemd-dev libncurses5-dev libncursesw5-dev
+dnf install -y libdrm-devel systemd-devel ncurses-devel
 cd /tmp/
 git clone https://github.com/Syllo/nvtop.git
 mkdir -p nvtop/build && cd nvtop/build

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,13 +7,15 @@
   },
   "postStartCommand": "bash $(pwd)/.devcontainer/dev-setup.sh",
   "features": {
-    "ghcr.io/nils-geistmann/devcontainers-features/zsh:0": {
-      "plugins": [
-        "git",
-        "zsh-autosuggestions",
-        "history",
-        "docker"
-      ]
+    // common-utils is distro-aware (apt/dnf/microdnf/yum/apk), so it installs
+    // zsh + oh-my-zsh on the Fedora wolf-builder base. The previous
+    // nils-geistmann/zsh feature was apt-only and broke when the image moved
+    // off Ubuntu.
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "installOhMyZsh": true,
+      "configureZshAsDefaultShell": true,
+      "username": "root"
     },
     // Doesn't work on ubuntu oracular
     //    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -131,6 +131,25 @@ jobs:
           cache-from: ${{ steps.prep.outputs.cache_from }}
           cache-to: ${{ steps.prep.outputs.cache_to }}
 
+      # Native-Vulkan variant: built on ghcr.io/<owner>/gst-wayland-display:vulkan
+      # (patched GStreamer 1.28.4 vulkan-video + the plugin), published as wolf:vulkan.
+      # The gst-Vulkan + plugin build happens once in gst-wayland-display:vulkan; here
+      # we only compile Wolf on top. See docker/wolf.vulkan.Dockerfile.
+      - name: Build Wolf (Vulkan)
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          file: docker/wolf.vulkan.Dockerfile
+          push: ${{ steps.prep.outputs.push }}
+          tags: ghcr.io/${{ github.repository_owner }}/wolf:vulkan
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/gst-wayland-display:vulkan
+            IMAGE_SOURCE=${{ steps.prep.outputs.github_server_url }}/${{ github.repository }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/wolf:vulkan-buildcache
+          cache-to: ${{ steps.prep.outputs.push == 'true' && format('type=registry,ref=ghcr.io/{0}/wolf:vulkan-buildcache,mode=max', github.repository_owner) || '' }}
+
   test_devcontainer:
     runs-on: ubuntu-latest
     needs: buildx

--- a/docker/gpu-drivers.Dockerfile
+++ b/docker/gpu-drivers.Dockerfile
@@ -1,29 +1,26 @@
-ARG BASE_IMAGE=ghcr.io/games-on-whales/base-app:edge
+ARG BASE_IMAGE=ghcr.io/games-on-whales/base-app:fedora
 FROM $BASE_IMAGE
-ENV DEBIAN_FRONTEND=noninteractive
-ENV BUILD_ARCHITECTURE=amd64
-ENV DEB_BUILD_OPTIONS=noddebs
 
-# Intel (Quick Synk) specific:
-# - libmfx Provides MSDK runtime (libmfxhw64.so.1) for 11th Gen Rocket Lake and older
-# - libmfx-gen1.2 Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
-ARG REQUIRED_PACKAGES="va-driver-all intel-media-va-driver-non-free \
-                       libmfx-gen1.2 libigfxcmrt7 \
-                       libva-drm2 libva-x11-2 libvpl2"
+# Intel VA-API / QSV drivers and VPL runtime
+# intel-media-driver lives in RPM Fusion free on Fedora (not in the base repos),
+# so enable it first; libvpl and mesa-va-drivers come from the main repos.
+ARG REQUIRED_PACKAGES="libva libva-utils \
+                       intel-media-driver \
+                       libvpl \
+                       mesa-va-drivers"
 
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    $REQUIRED_PACKAGES && \
-    rm -rf /var/lib/apt/lists/*
+RUN dnf install -y \
+      https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm && \
+    dnf install -y --skip-unavailable $REQUIRED_PACKAGES && \
+    dnf clean all
 
-# libmfx is not available in Ubuntu 25.04 so we are building from sources (see: https://github.com/games-on-whales/wolf/issues/221)
+# libmfx is not available in Fedora so we build from sources (see: https://github.com/games-on-whales/wolf/issues/221)
 RUN <<_BUILD_LIBMFX
     #!/bin/bash
     set -e
 
-    apt-get update -y
-    apt-get install -y curl git build-essential cmake pkg-config \
-                       libdrm-dev libva-dev libx11-dev libx11-xcb-dev libxcb-present-dev libxcb-dri3-dev
+    dnf install -y curl git gcc gcc-c++ cmake pkg-config \
+                   libdrm-devel libva-devel libX11-devel libxcb-devel libXext-devel
 
     cd /tmp
     git clone https://github.com/Intel-Media-SDK/MediaSDK msdk
@@ -33,6 +30,8 @@ RUN <<_BUILD_LIBMFX
 
     # Patch to fix compilation error on modern gcc
     curl -fsSL https://patch-diff.githubusercontent.com/raw/Intel-Media-SDK/MediaSDK/pull/3005.patch | git apply -
+    grep -q "#include <cstdint>" samples/sample_vpp/src/sample_vpp_frc_adv.cpp || \
+      sed -i "/#include <algorithm>/a #include <cstdint>" samples/sample_vpp/src/sample_vpp_frc_adv.cpp
 
     mkdir build
     cd build
@@ -46,8 +45,8 @@ RUN <<_BUILD_LIBMFX
     ldconfig
 
     # Cleanup
-    apt-get remove -y --purge curl git build-essential cmake pkg-config
-    rm -rf /var/lib/apt/lists/* /tmp/*
+    dnf clean all
+    rm -rf /tmp/*
 _BUILD_LIBMFX
 
 # Adding missing libnvrtc.so and libnvrtc-bulletins.so for Nvidia
@@ -56,9 +55,7 @@ RUN <<_ADD_NVRTC
     #!/bin/bash
     set -e
 
-    #Extra deps
-    apt-get update -y
-    apt-get install -y unzip curl
+    dnf install -y unzip curl
 
     cd /tmp
     curl -fsSL -o nvidia_cuda_nvrtc_linux_x86_64.whl "https://developer.download.nvidia.com/compute/redist/nvidia-cuda-nvrtc/nvidia_cuda_nvrtc-11.0.221-cp36-cp36m-linux_x86_64.whl"
@@ -74,9 +71,8 @@ RUN <<_ADD_NVRTC
     echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
 
     # Cleanup
-    apt-get remove -y --purge unzip curl
-    rm -rf /var/lib/apt/lists/*
+    dnf clean all
 _ADD_NVRTC
 
 LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
-LABEL org.opencontainers.image.description="A base image with all the required GPU drivers"
+LABEL org.opencontainers.image.description="A base image with all the required GPU drivers (Fedora)"

--- a/docker/gstreamer.Dockerfile
+++ b/docker/gstreamer.Dockerfile
@@ -1,8 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/games-on-whales/gpu-drivers:2025.05
 FROM $BASE_IMAGE AS builder
-ENV DEBIAN_FRONTEND=noninteractive
-ENV BUILD_ARCHITECTURE=amd64
-ENV DEB_BUILD_OPTIONS=noddebs
 
 ARG GSTREAMER_VERSION=1.26.7
 ENV GSTREAMER_VERSION=$GSTREAMER_VERSION
@@ -10,45 +7,28 @@ ENV GSTREAMER_VERSION=$GSTREAMER_VERSION
 ENV SOURCE_PATH=/sources/
 WORKDIR $SOURCE_PATH
 
-COPY <<-EOT $SOURCE_PATH/gstreamer.control
-Section: misc
-Priority: optional
-Standards-Version: 3.9.2
-Package: gstreamer-wolf
-Version: $GSTREAMER_VERSION
-Depends: libc6, libcap2, libcap2-bin, libdw1, libglib2.0-0, libunwind8,
-          zlib1g, libdrm2, libva2, libpulse0, libxdamage1, libx265-215, libopus0,
-          libegl1, libgl1, libgles2, libudev1, libva-drm2, libva-wayland2, libva-x11-2, libva2,
-          libwayland-client0, libx11-6, libx11-xcb1,  libxrandr2, libvpl2, libzxing3, libopenexr-3-1-30, librsvg2-2, libwebp7,
-          libcairo2, libcairo-gobject2, libjpeg8, libopenjp2-7, liblcms2-2, libzbar0, libaom3, libsoup-2.4-1, libopengl0,
-          libgbm1, libglx0, libgl1, libgudev-1.0-0
-Provides: gstreamer, libgstreamer1.0-0
-Description: Manually built from git
-EOT
-
 RUN <<_GSTREAMER_INSTALL
     #!/bin/bash
     set -e
 
     DEV_PACKAGES=" \
-        build-essential ninja-build gcc meson cmake ccache bison equivs \
-        ca-certificates git libllvm15 \
-        flex libx265-dev libopus-dev nasm libzxing-dev libzbar-dev libdrm-dev libva-dev \
-        libvpl-dev libunwind8 libcap2-bin \
-        libx11-dev libx11-xcb-dev libxfixes-dev libxdamage-dev libwayland-dev wayland-protocols libpulse-dev libglib2.0-dev \
-        libopenjp2-7-dev liblcms2-dev libcairo2-dev libcairo-gobject2 libwebp7 librsvg2-dev libaom-dev \
-        libharfbuzz-dev libpango1.0-dev libsoup-2.4-1 libopengl-dev libgbm-dev libegl-dev \
-        libglu1-mesa-dev freeglut3-dev mesa-common-dev libgl1-mesa-dev libgles-dev libgl-dev libglx-dev libgudev-1.0-dev
+        gcc gcc-c++ ninja-build meson cmake ccache bison libatomic \
+        ca-certificates git \
+        flex x265-devel opus-devel nasm zxing-cpp-devel zbar-devel libdrm-devel libva-devel \
+        libvpl-devel libunwind libcap \
+        libX11-devel libxcb-devel libXfixes-devel libXdamage-devel wayland-devel wayland-protocols-devel pulseaudio-libs-devel glib2-devel \
+        openjpeg2-devel lcms2-devel cairo-devel cairo-gobject-devel libwebp librsvg2-devel libaom-devel \
+        harfbuzz-devel pango-devel libsoup-devel libglvnd-devel mesa-libgbm-devel mesa-libEGL-devel \
+        mesa-libGLU-devel freeglut-devel mesa-libGL-devel mesa-libGLES-devel libgudev-devel
         "
-    apt-get update -y
-    apt-get install -y --no-install-recommends $DEV_PACKAGES
+    dnf install -y $DEV_PACKAGES
 
     # Build gstreamer
     git clone https://gitlab.freedesktop.org/gstreamer/gstreamer.git $SOURCE_PATH/gstreamer
     cd ${SOURCE_PATH}/gstreamer
     git checkout $GSTREAMER_VERSION
     git submodule update --recursive --remote
-    # see the list of possible options here: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/meson_options.txt \
+    # see the list of possible options here: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/blob/main/meson_options.txt
     meson setup \
         --buildtype=release \
         --strip \
@@ -84,10 +64,6 @@ RUN <<_GSTREAMER_INSTALL
     meson compile -C build
     meson install -C build
 
-    # fake install, this way we'll keep runtime dependencies and we can safely delete all the additional packages
-    equivs-build $SOURCE_PATH/gstreamer.control
-    dpkg -i gstreamer-wolf_${GSTREAMER_VERSION}_all.deb
-
     # Add GstInterpipe
     git clone https://github.com/games-on-whales/gst-interpipe.git $SOURCE_PATH/gst-interpipe
     cd $SOURCE_PATH/gst-interpipe
@@ -96,17 +72,12 @@ RUN <<_GSTREAMER_INSTALL
     meson install -C build
 
     # Final cleanup stage
-    apt-mark auto $DEV_PACKAGES
-    apt-get autoremove -y --purge
-    # We can now safely delete the gstreamer repo + build folder
-    rm -rf  \
-    $SOURCE_PATH \
-    /var/lib/apt/lists/*
+    dnf clean all
+    rm -rf $SOURCE_PATH
 _GSTREAMER_INSTALL
 
 LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
-LABEL org.opencontainers.image.description="GStreamer: https://gstreamer.freedesktop.org/"
-
+LABEL org.opencontainers.image.description="GStreamer: https://gstreamer.freedesktop.org/ (Fedora)"
 
 ENTRYPOINT []
 CMD ["/usr/local/bin/gst-inspect-1.0"]

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -2,10 +2,7 @@ ARG BASE_IMAGE=ghcr.io/games-on-whales/gstreamer:1.26.7
 ########################################################
 FROM $BASE_IMAGE AS wolf-builder
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+RUN dnf install -y \
     curl \
     ca-certificates \
     ninja-build \
@@ -14,19 +11,21 @@ RUN apt-get update -y && \
     ccache \
     git \
     clang \
-    build-essential \
-    libboost-thread-dev libboost-locale-dev libboost-filesystem-dev libboost-log-dev libboost-stacktrace-dev libboost-container-dev libboost-json-dev \
-    libwayland-dev libwayland-server0 libinput-dev libxkbcommon-dev libgbm-dev \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libevdev-dev \
-    libpulse-dev \
-    libunwind-dev \
-    libudev-dev \
-    libdrm-dev \
-    libpci-dev \
-    libglib2.0-dev libegl-dev libgles-dev libopengl-dev \
-    && rm -rf /var/lib/apt/lists/*
+    gcc-c++ \
+    glibc-static \
+    libstdc++-static \
+    boost-devel \
+    wayland-devel libinput-devel libxkbcommon-devel mesa-libgbm-devel \
+    libcurl-devel \
+    openssl-devel \
+    libevdev-devel \
+    pulseaudio-libs-devel \
+    libunwind-devel \
+    systemd-devel \
+    libdrm-devel \
+    pciutils-devel \
+    glib2-devel mesa-libEGL-devel mesa-libGLES-devel libglvnd-devel \
+    && dnf clean all
 
 ## Install Rust in order to build our custom compositor
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -73,28 +72,25 @@ RUN --mount=type=cache,target=/cache/ccache \
 
 ########################################################
 FROM $BASE_IMAGE AS runner
-ENV DEBIAN_FRONTEND=noninteractive
 
 # Wolf runtime dependencies
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+RUN dnf install -y \
     ca-certificates \
-    libssl3 \
-    libicu76 \
-    libevdev2 \
-    libudev1 \
-    libcurl4 \
-    libdrm2 \
-    libpci3 \
-    libunwind8 \
-    && rm -rf /var/lib/apt/lists/*
+    openssl-libs \
+    libicu \
+    libevdev \
+    systemd-libs \
+    libcurl \
+    libdrm \
+    pciutils-libs \
+    libunwind \
+    && dnf clean all
 
 # gst-plugin-wayland runtime dependencies
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    libwayland-server0 libinput10 libxkbcommon0 libgbm1 \
-    libglvnd0 libgl1 libglx0 libegl1 libgles2 xwayland hwdata \
-    && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y \
+    libwayland-server libinput libxkbcommon mesa-libgbm \
+    libglvnd mesa-libGL mesa-libEGL mesa-libGLES xorg-x11-server-Xwayland hwdata \
+    && dnf clean all
 
 # Embedded PulseAudio: Wolf runs its own PulseAudio server inside this container
 # (supervised by supervisord, see startup.sh + supervisord.conf) so audio is
@@ -102,17 +98,33 @@ RUN apt-get update -y && \
 # sidecar container and its startup race. supervisord starts PA before Wolf,
 # restarts it if it dies, and stops both cleanly on container shutdown.
 # pulseaudio-utils ships pactl, handy for debugging audio from inside the container.
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+# The Fedora base ships pipewire-pulseaudio (the PipeWire PA-compat shim), which
+# conflicts with the real pulseaudio daemon supervisord drives; --allowerasing
+# swaps it out. Wolf runs its own PulseAudio server, so the shim isn't needed.
+RUN dnf install -y --allowerasing \
     pulseaudio pulseaudio-utils supervisor \
-    && rm -rf /var/lib/apt/lists/*
+    && dnf clean all
 
 COPY docker/supervisord.conf /etc/supervisord.conf
 
 ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
-# Copying out our custom compositor from the build stage
+# Copying out our custom compositor from the build stage. The gst-wayland-display
+# C API is statically linked into wolf, so the plugin artefacts (.so/.a/.pc) in
+# GST_PLUGIN_PATH are all the runtime needs.
 COPY --from=wolf-builder /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/* $GST_PLUGIN_PATH
-COPY --from=wolf-builder /usr/local/lib/liblibgstwaylanddisplay* /usr/local/lib/
+
+# Bundle the exact libicu the builder linked wolf against, so a builder/runner
+# layer-cache skew can't produce a wolf binary that can't resolve its own
+# libicuuc soname at runtime.
+COPY --from=wolf-builder /usr/lib64/libicu*.so.* /usr/lib64/
+
+# The gstreamer base (built with meson on Fedora) installs its shared libs to
+# /usr/local/lib64, including libgstcuda-1.0.so.0 -- which our nvcodec-enabled
+# gst-wayland-display plugin links against. That directory is not on the default
+# runtime linker search path, so without this gst-inspect can't dlopen the
+# plugin (libgstcuda-1.0.so.0: cannot open shared object file). Register it and
+# rebuild the ld.so cache so the compositor plugin resolves at runtime.
+RUN echo /usr/local/lib64 > /etc/ld.so.conf.d/gstreamer-local.conf && ldconfig
 
 WORKDIR /wolf
 
@@ -162,7 +174,7 @@ EXPOSE 48100/udp
 EXPOSE 48200/udp
 
 LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
-LABEL org.opencontainers.image.description="Wolf: stream virtual desktops and games in Docker"
+LABEL org.opencontainers.image.description="Wolf: stream virtual desktops and games in Docker (Fedora)"
 
 # See GOW/base-app
 COPY --chmod=777 docker/startup.sh /opt/gow/startup-app.sh

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -1,0 +1,120 @@
+# wolf:vulkan
+#
+# Wolf built on top of the native-Vulkan GStreamer stack. Unlike docker/wolf.Dockerfile
+# (which builds on the stock gstreamer image and clones+cinstalls the plugin itself),
+# this variant is FROM ghcr.io/games-on-whales/gst-wayland-display:vulkan, which already
+# carries patched GStreamer 1.28.4 (Vulkan video encode + the vulkanh264enc DPB-pool
+# patch) under /opt/gst AND the gst-wayland-display plugin installed there. So we only
+# compile Wolf on top — no gst build, no plugin clone. See that image's docker/vulkan.Dockerfile.
+ARG BASE_IMAGE=ghcr.io/games-on-whales/gst-wayland-display:vulkan
+########################################################
+FROM $BASE_IMAGE AS wolf-builder
+
+# Wolf's own build dependencies. The gst toolchain (gcc, cmake, ninja, clang, the
+# gst -devel headers in /opt/gst) already comes from the base image; here we add the
+# libraries Wolf links that the gst image doesn't carry.
+RUN dnf install -y \
+    ccache \
+    boost-devel \
+    libevdev-devel \
+    pulseaudio-libs-devel \
+    libcurl-devel \
+    pciutils-devel \
+    glibc-static \
+    libstdc++-static \
+    && dnf clean all
+
+# gst (incl. the gst-wayland-display .pc/.a/.so) is under /opt/gst; the base image
+# already exports PKG_CONFIG_PATH / GST_PLUGIN_PATH / LD_LIBRARY_PATH for it, so
+# Wolf's CMake finds gstreamer-1.0 and the statically-linked gstwaylanddisplay there.
+COPY . /wolf/
+WORKDIR /wolf
+
+ENV CCACHE_DIR=/cache/ccache
+ENV CMAKE_BUILD_DIR=/cache/cmake-build
+RUN --mount=type=cache,target=/cache/ccache \
+    cmake -B$CMAKE_BUILD_DIR \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_CXX_EXTENSIONS=OFF \
+    -DCMAKE_CXX_FLAGS="-Wno-missing-template-arg-list-after-template-kw" \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBoost_USE_STATIC_LIBS=ON \
+    -DBUILD_FAKE_UDEV_CLI=ON \
+    -DBUILD_TESTING=OFF \
+    -G Ninja && \
+    ninja -C $CMAKE_BUILD_DIR wolf && \
+    ninja -C $CMAKE_BUILD_DIR fake-udev && \
+    cp $CMAKE_BUILD_DIR/src/moonlight-server/wolf /wolf/wolf && \
+    cp $CMAKE_BUILD_DIR/src/fake-udev/fake-udev /wolf/fake-udev
+
+########################################################
+FROM $BASE_IMAGE AS runner
+
+# Wolf runtime dependencies (gst + the plugin + freeworld RADV mesa already in the base)
+RUN dnf install -y \
+    ca-certificates openssl-libs libicu libevdev systemd-libs libcurl libdrm \
+    pciutils-libs libunwind \
+    libwayland-server libinput libxkbcommon mesa-libgbm \
+    libglvnd mesa-libGL mesa-libEGL mesa-libGLES xorg-x11-server-Xwayland hwdata \
+    && dnf clean all
+
+# Embedded PulseAudio (supervised by supervisord, see startup.sh + supervisord.conf):
+# Wolf runs its own PA server so audio is up as soon as Wolf boots, no external
+# sidecar. The Fedora base ships pipewire-pulseaudio (a PA-compat shim) which
+# conflicts with the real daemon; --allowerasing swaps it out.
+RUN dnf install -y --allowerasing \
+    pulseaudio pulseaudio-utils supervisor \
+    && dnf clean all
+
+COPY docker/supervisord.conf /etc/supervisord.conf
+
+# The plugin + gst live under /opt/gst in the base image (GST_PLUGIN_PATH and
+# LD_LIBRARY_PATH are already exported there); register /opt/gst/lib64 with the
+# dynamic linker so wolf and gst-inspect resolve the gstreamer .so's at runtime.
+RUN echo /opt/gst/lib64 > /etc/ld.so.conf.d/gst-vulkan.conf && ldconfig
+
+WORKDIR /wolf
+ENV WOLF_CFG_FOLDER=/etc/wolf/cfg
+
+COPY --from=wolf-builder /wolf/wolf /wolf/wolf
+COPY --from=wolf-builder /wolf/fake-udev /wolf/fake-udev
+
+ENV GST_GL_API=gles2 \
+    GST_GL_PLATFORM=egl \
+    GST_GL_WINDOW=surfaceless \
+    WOLF_USE_ZERO_COPY=TRUE \
+    WOLF_LOG_LEVEL=INFO \
+    WOLF_CFG_FILE=$WOLF_CFG_FOLDER/config.toml \
+    WOLF_PRIVATE_KEY_FILE=$WOLF_CFG_FOLDER/key.pem \
+    WOLF_PRIVATE_CERT_FILE=$WOLF_CFG_FOLDER/cert.pem \
+    WOLF_PULSE_IMAGE=ghcr.io/games-on-whales/pulseaudio:master \
+    WOLF_RENDER_NODE=/dev/dri/renderD128 \
+    WOLF_STOP_CONTAINER_ON_EXIT=TRUE \
+    WOLF_DOCKER_SOCKET=/var/run/docker.sock \
+    WOLF_DEFAULT_RUN_UID=1000 \
+    WOLF_DEFAULT_RUN_GID=1000 \
+    RUST_BACKTRACE=full \
+    RUST_LOG=WARN \
+    HOST_APPS_STATE_FOLDER=/etc/wolf \
+    GST_DEBUG=2 \
+    PUID=0 \
+    PGID=0 \
+    UNAME="root"
+
+VOLUME /run/user/wolf/
+ENV XDG_RUNTIME_DIR=/run/user/wolf
+
+# HTTPS / HTTP / Control / RTSP / Video / Audio
+EXPOSE 47984/tcp
+EXPOSE 47989/tcp
+EXPOSE 47999/udp
+EXPOSE 48010/tcp
+EXPOSE 48100/udp
+EXPOSE 48200/udp
+
+LABEL org.opencontainers.image.source="https://github.com/games-on-whales/wolf/"
+LABEL org.opencontainers.image.description="Wolf with native Vulkan NV12 encode (Fedora + GStreamer 1.28.4 vulkan-video)"
+
+COPY --chmod=777 docker/startup.sh /opt/gow/startup-app.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -84,6 +84,15 @@ RUN echo /opt/gst/lib64 > /etc/ld.so.conf.d/gst-vulkan.conf && ldconfig
 WORKDIR /wolf
 ENV WOLF_CFG_FOLDER=/etc/wolf/cfg
 
+# Disable the lavapipe (llvmpipe) Vulkan ICD process-wide. On mixed-GPU / software-fallback
+# hosts the Vulkan loader otherwise dlopen()s lavapipe during vkCreateInstance (both the
+# producer's modifier query AND the vulkanh26x encoder's gst.vulkan.instance), and its libLLVM
+# static init collides with the libLLVM already loaded by the mesa GLES renderer -> LLVM
+# "option registered more than once" -> abort/std::terminate. lavapipe can't do Vulkan video
+# encode anyway. Set at the image level (not just the producer's plugin_init) so it covers the
+# encoder's instance regardless of plugin load order. Honour an explicit override at run time.
+ENV VK_LOADER_DRIVERS_DISABLE="*lvp_icd*"
+
 COPY --from=wolf-builder /wolf/wolf /wolf/wolf
 COPY --from=wolf-builder /wolf/fake-udev /wolf/fake-udev
 

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y \
 # Cache-bust: force a clean recompile on the freshly-published base
 # (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
 # vulkanh265enc.patch). Bump the value to invalidate the build cache.
-ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-3-compositor-align
+ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-4-sdr-tonemap
 RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
 
 COPY . /wolf/

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y \
 # Cache-bust: force a clean recompile on the freshly-published base
 # (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
 # vulkanh265enc.patch). Bump the value to invalidate the build cache.
-ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-8-pqpass
+ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-9-dynamic
 RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
 
 COPY . /wolf/

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y \
 # Cache-bust: force a clean recompile on the freshly-published base
 # (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
 # vulkanh265enc.patch). Bump the value to invalidate the build cache.
-ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-6-spike
+ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-7-cm-import
 RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
 
 COPY . /wolf/

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y \
 # Cache-bust: force a clean recompile on the freshly-published base
 # (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
 # vulkanh265enc.patch). Bump the value to invalidate the build cache.
-ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-5-ref-white-knob
+ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-6-spike
 RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
 
 COPY . /wolf/

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y \
 # Cache-bust: force a clean recompile on the freshly-published base
 # (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
 # vulkanh265enc.patch). Bump the value to invalidate the build cache.
-ARG WOLF_VULKAN_CACHEBUST=2026-06-28-hdr-2-handshake
+ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-3-compositor-align
 RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
 
 COPY . /wolf/

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -27,6 +27,13 @@ RUN dnf install -y \
 # gst (incl. the gst-wayland-display .pc/.a/.so) is under /opt/gst; the base image
 # already exports PKG_CONFIG_PATH / GST_PLUGIN_PATH / LD_LIBRARY_PATH for it, so
 # Wolf's CMake finds gstreamer-1.0 and the statically-linked gstwaylanddisplay there.
+
+# Cache-bust: force a clean recompile on the freshly-published base
+# (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
+# vulkanh265enc.patch). Bump the value to invalidate the build cache.
+ARG WOLF_VULKAN_CACHEBUST=2026-06-28-hdr-1
+RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
+
 COPY . /wolf/
 WORKDIR /wolf
 

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y \
 # Cache-bust: force a clean recompile on the freshly-published base
 # (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
 # vulkanh265enc.patch). Bump the value to invalidate the build cache.
-ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-4-sdr-tonemap
+ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-5-ref-white-knob
 RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
 
 COPY . /wolf/

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y \
 # Cache-bust: force a clean recompile on the freshly-published base
 # (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
 # vulkanh265enc.patch). Bump the value to invalidate the build cache.
-ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-7-cm-import
+ARG WOLF_VULKAN_CACHEBUST=2026-06-29-hdr-8-pqpass
 RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
 
 COPY . /wolf/

--- a/docker/wolf.vulkan.Dockerfile
+++ b/docker/wolf.vulkan.Dockerfile
@@ -31,7 +31,7 @@ RUN dnf install -y \
 # Cache-bust: force a clean recompile on the freshly-published base
 # (gst-wayland-display:vulkan carrying the producer P010+HDR + encoder HDR SEI +
 # vulkanh265enc.patch). Bump the value to invalidate the build cache.
-ARG WOLF_VULKAN_CACHEBUST=2026-06-28-hdr-1
+ARG WOLF_VULKAN_CACHEBUST=2026-06-28-hdr-2-handshake
 RUN echo "rebuild on fresh base: ${WOLF_VULKAN_CACHEBUST}"
 
 COPY . /wolf/

--- a/docs/modules/user/pages/configuration.adoc
+++ b/docs/modules/user/pages/configuration.adoc
@@ -43,6 +43,18 @@ Wolf is configured via a TOML config file and some additional optional ENV varia
 |5000
 |The time in milliseconds to wait for the Wayland socket to appear before starting the stream runner
 
+|WOLF_VULKAN_QUALITY
+|0
+|`vulkanh264enc` quality/speed preset (0 = fastest) used by the Vulkan H.264 encoder. Only applies when the `vulkan` H.264 encoder is selected.
+
+|WOLF_VULKAN_REF_FRAMES
+|1
+|Number of reference frames for the Vulkan H.264 encoder. 1 is recommended for low-latency streaming.
+
+|WOLF_VULKAN_B_FRAMES
+|0
+|Number of B-frames for the Vulkan H.264 encoder. 0 avoids reorder latency for live streaming.
+
 |WOLF_DOCKER_SOCKET
 |/var/run/docker.sock
 |The full path to the docker socket, doesn't support tcp (yet)

--- a/src/moonlight-protocol/moonlight.cpp
+++ b/src/moonlight-protocol/moonlight.cpp
@@ -22,7 +22,8 @@ XML serverinfo(bool isServerBusy,
                const immer::array<DisplayMode> &display_modes,
                int pair_status,
                bool support_hevc,
-               bool support_av1) {
+               bool support_av1,
+               bool support_hdr) {
   XML resp;
 
   resp.put("root.<xmlattr>.status_code", 200);
@@ -37,6 +38,12 @@ XML serverinfo(bool isServerBusy,
   if (support_hevc) {
     max_luma_pixels = 1869449984;
     codec_support |= VIDEO_FORMAT_H265;
+    // Advertise HEVC Main-10 so Moonlight offers the HDR toggle and, when enabled,
+    // connects in BT2020/PQ mode (sending encoderCscMode -> BT2020). Without this bit
+    // the client never requests HDR and would mis-decode the host's PQ Main-10 stream.
+    if (support_hdr) {
+      codec_support |= VIDEO_FORMAT_H265_MAIN10;
+    }
   }
   if (support_av1) {
     codec_support |= VIDEO_FORMAT_AV1_MAIN8;

--- a/src/moonlight-protocol/moonlight/control.hpp
+++ b/src/moonlight-protocol/moonlight/control.hpp
@@ -309,6 +309,46 @@ struct ControlTerminatePacket {
   std::uint32_t reason = TERMINATE_REASON_GRACEFULL;
 };
 
+// The HDR mode packet carries a tightly-packed payload (1-byte flag immediately
+// followed by the 26-byte metadata blob, no padding) that must match the
+// Sunshine / moonlight-common-c wire layout, so force 1-byte packing here.
+#pragma pack(push, 1)
+
+/**
+ * HDR static metadata, mirrors the Sunshine / moonlight-common-c SS_HDR_METADATA layout.
+ *
+ * displayPrimaries and whitePoint are CIE 1931 xy chromaticity coordinates scaled
+ * by 50000 (i.e. units of 0.00002). The defaults below are the BT.2020 / Rec.2100
+ * values matching the mastering-display + content-light metadata emitted by the
+ * gst-wayland-display encoder caps:
+ *   HDR_MASTERING "35400:14600:8500:39850:6550:2300:15635:16450:10000000:1"
+ *   HDR_CLL       "1000:400"
+ * The gst mastering string is ordered R G B WP maxLum minLum, which maps 1:1 onto
+ * displayPrimaries[0..2] (R, G, B) and whitePoint here. The gst luminances are in
+ * 0.0001-nit units: max 10000000 -> 1000 nits, min 1 -> 1 (kept in 0.0001-nit units).
+ */
+struct SS_HDR_METADATA {
+  struct {
+    std::uint16_t x, y;
+  } displayPrimaries[3] = {{35400, 14600}, {8500, 39850}, {6550, 2300}}; // R, G, B  (coords * 50000)
+  struct {
+    std::uint16_t x, y;
+  } whitePoint = {15635, 16450};                 // D65 (coords * 50000)
+  std::uint16_t maxDisplayLuminance = 1000;      // nits
+  std::uint16_t minDisplayLuminance = 1;         // 0.0001-nit units (0.0001 nit)
+  std::uint16_t maxContentLightLevel = 1000;     // MaxCLL, nits
+  std::uint16_t maxFrameAverageLightLevel = 400; // MaxFALL, nits
+  std::uint16_t maxFullFrameLuminance = 0;       // nits (SDR reference white; ignored by clients)
+};
+
+struct ControlHdrModePacket {
+  ControlPacket header = {.type = pkts::HDR_MODE, .length = sizeof(std::uint8_t) + sizeof(SS_HDR_METADATA)};
+  std::uint8_t enableHdr = 0; // 0 = SDR, 1 = HDR; metadata is ignored by clients when 0
+  SS_HDR_METADATA metadata;
+};
+
+#pragma pack(pop)
+
 struct ControlRumblePacket {
   ControlPacket header;
 

--- a/src/moonlight-protocol/moonlight/protocol.hpp
+++ b/src/moonlight-protocol/moonlight/protocol.hpp
@@ -41,7 +41,8 @@ XML serverinfo(bool isServerBusy,
                const immer::array<DisplayMode> &display_modes,
                int pair_status,
                bool support_hevc,
-               bool support_av1);
+               bool support_av1,
+               bool support_hdr = false);
 
 /**
  * @brief Step 2: PAIR a new client

--- a/src/moonlight-server/control/control.cpp
+++ b/src/moonlight-server/control/control.cpp
@@ -156,6 +156,24 @@ void run_control(int port,
         logs::log(logs::debug, "[ENET] Client not found for session: {}", ev->session_id);
       });
 
+  auto hdr_mode_ev =
+      event_bus->register_handler<immer::box<HDRModeEvent>>([&connected_clients](const immer::box<HDRModeEvent> &ev) {
+        // Build the HDR_MODE control packet; metadata defaults to the BT.2020/Rec.2100
+        // values (ignored by the client when enableHdr == 0).
+        auto hdr_pkt = ControlHdrModePacket{};
+        hdr_pkt.enableHdr = ev->enable_hdr ? 1 : 0;
+        std::string plaintext = {(char *)&hdr_pkt, sizeof(hdr_pkt)};
+        for (auto &[peer, session] : *connected_clients.load()) {
+          if (session->session_id == ev->session_id) {
+            immer::box<std::shared_ptr<ENetPeer>> enet_client = {to_shared_ptr(peer)};
+            encrypt_and_send(plaintext, session->aes_key, enet_client);
+            logs::log(logs::info, "[ENET] Sent HDR_MODE ({}) for session: {}", hdr_pkt.enableHdr, ev->session_id);
+            return;
+          }
+        }
+        logs::log(logs::debug, "[ENET] Client not found for HDR mode session: {}", ev->session_id);
+      });
+
   while (true) {
     if (enet_host_service(host.get(), &event, timeout.count()) > 0) {
       auto [client_ip, client_port] = get_ip((sockaddr *)&event.peer->address.address);
@@ -231,6 +249,7 @@ void run_control(int port,
   }
 
   stop_ev.unregister();
+  hdr_mode_ev.unregister();
 }
 
 } // namespace control

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -300,6 +300,16 @@ struct StopStreamEvent {
   std::size_t session_id;
 };
 
+/**
+ * Fired when the content's HDR/SDR state changes (signalled by the producer
+ * pipeline via a "wolf-hdr-state" bus message). The control thread reacts by
+ * sending the Moonlight HDR_MODE control packet to the matching client.
+ */
+struct HDRModeEvent {
+  std::size_t session_id;
+  bool enable_hdr;
+};
+
 struct ClientWolfUIComboEvent {
   std::size_t session_id;
 };
@@ -344,6 +354,7 @@ using EventBusHandlers = dp::handler_registration<immer::box<PlugDeviceEvent>,
                                                   immer::box<PauseStreamEvent>,
                                                   immer::box<ResumeStreamEvent>,
                                                   immer::box<StopStreamEvent>,
+                                                  immer::box<HDRModeEvent>,
                                                   immer::box<ClientWolfUIComboEvent>,
                                                   immer::box<RTPVideoPingEvent>,
                                                   immer::box<RTPAudioPingEvent>,
@@ -365,6 +376,7 @@ using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<PauseStreamEvent>,
                                    immer::box<ResumeStreamEvent>,
                                    immer::box<StopStreamEvent>,
+                                   immer::box<HDRModeEvent>,
                                    immer::box<ClientWolfUIComboEvent>,
                                    immer::box<RTPVideoPingEvent>,
                                    immer::box<RTPAudioPingEvent>,
@@ -386,6 +398,7 @@ using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<PauseStreamEvent>,
                                    immer::box<ResumeStreamEvent>,
                                    immer::box<StopStreamEvent>,
+                                   immer::box<HDRModeEvent>,
                                    immer::box<ClientWolfUIComboEvent>,
                                    immer::box<RTPVideoPingEvent>,
                                    immer::box<RTPAudioPingEvent>,

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -381,6 +381,19 @@ auto create_run_session(const SimpleWeb::CaseInsensitiveMultimap &headers,
                                          state->config->support_hevc,
                                          state->config->support_av1};
 
+  // The Vulkan zero-copy producer renders the virtual compositor at this resolution,
+  // and the Vulkan encoder requires 64px CTB alignment (see rtsp/commands.hpp, which
+  // rounds the *encoder* dimension up). The compositor is created HERE, at /launch,
+  // before RTSP, so it must be rounded too -- otherwise the producer fills only the
+  // requested rows while the encoder reads full 64px CTBs, leaving the extra rows
+  // uninitialised (a green bar along the bottom edge). Scoped to the Vulkan producer;
+  // the client scales the slightly-larger frame back into its viewport.
+  if (run_app.video_producer_buffer_caps.find("VulkanImage") != std::string::npos) {
+    auto round_up_64 = [](int v) { return (v + 63) & ~63; };
+    display_mode.width = round_up_64(display_mode.width);
+    display_mode.height = round_up_64(display_mode.height);
+  }
+
   auto surround_info = std::stoi(get_header(headers, "surroundAudioInfo").value_or("196610"));
   int channelCount = surround_info & (0xffff /* last 16 bits */);
 

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -77,7 +77,8 @@ void serverinfo(const std::shared_ptr<typename SimpleWeb::Server<T>::Response> &
                                    host->display_modes,
                                    is_https,
                                    cfg->support_hevc,
-                                   cfg->support_av1);
+                                   cfg->support_av1,
+                                   cfg->support_hdr);
 
   send_xml<T>(response, SimpleWeb::StatusCode::success_ok, xml);
 }

--- a/src/moonlight-server/rtsp/commands.hpp
+++ b/src/moonlight-server/rtsp/commands.hpp
@@ -194,15 +194,19 @@ announce(const RTSP_PACKET &req, const events::StreamSession &session) {
   // block when a dimension isn't a multiple of the 64px CTB (every standard
   // height: 1080/720/2160). Round the stream up to whole CTBs so the encoder
   // only sees full blocks; the client scales the slightly-larger frame back to
-  // its viewport. Scoped to the vulkanh265enc pipeline so other encoders (which
-  // handle partial blocks fine) keep their exact requested resolution.
-  if (gst_pipeline.find("vulkanh265enc") != std::string::npos) {
+  // its viewport. This MUST match the compositor rounding applied at /launch for
+  // the Vulkan producer (rest/endpoints.hpp) -- the producer fills the compositor
+  // resolution, so an unrounded encoder would read uninitialised rows (green bar).
+  // Applied to both Vulkan encoders (h264 is CTB-immune but still shares the rounded
+  // Vulkan compositor, so its encode dimension has to agree).
+  if (gst_pipeline.find("vulkanh265enc") != std::string::npos ||
+      gst_pipeline.find("vulkanh264enc") != std::string::npos) {
     auto round_up_64 = [](int v) { return (v + 63) & ~63; };
     auto aligned_w = round_up_64(display.width);
     auto aligned_h = round_up_64(display.height);
     if (aligned_w != display.width || aligned_h != display.height) {
       logs::log(logs::info,
-                "[RTSP] vulkanh265enc: rounding {}x{} up to {}x{} (64px CTB alignment)",
+                "[RTSP] vulkan encoder: rounding {}x{} up to {}x{} (64px CTB alignment)",
                 display.width,
                 display.height,
                 aligned_w,

--- a/src/moonlight-server/rtsp/commands.hpp
+++ b/src/moonlight-server/rtsp/commands.hpp
@@ -190,6 +190,28 @@ announce(const RTSP_PACKET &req, const events::StreamSession &session) {
     gst_pipeline = session.app->h264_gst_pipeline;
   }
 
+  // RADV's Vulkan HEVC encoder corrupts the bottom/right partial coding-tree
+  // block when a dimension isn't a multiple of the 64px CTB (every standard
+  // height: 1080/720/2160). Round the stream up to whole CTBs so the encoder
+  // only sees full blocks; the client scales the slightly-larger frame back to
+  // its viewport. Scoped to the vulkanh265enc pipeline so other encoders (which
+  // handle partial blocks fine) keep their exact requested resolution.
+  if (gst_pipeline.find("vulkanh265enc") != std::string::npos) {
+    auto round_up_64 = [](int v) { return (v + 63) & ~63; };
+    auto aligned_w = round_up_64(display.width);
+    auto aligned_h = round_up_64(display.height);
+    if (aligned_w != display.width || aligned_h != display.height) {
+      logs::log(logs::info,
+                "[RTSP] vulkanh265enc: rounding {}x{} up to {}x{} (64px CTB alignment)",
+                display.width,
+                display.height,
+                aligned_w,
+                aligned_h);
+      display.width = aligned_w;
+      display.height = aligned_h;
+    }
+  }
+
   auto audio_channels = args["x-nv-audio.surround.numChannels"].value_or(session.audio_channel_count);
   auto fec_percentage = 20; // TODO: setting?
 

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -41,6 +41,8 @@ static Encoder encoder_type(const GstEncoder &settings) {
     return QUICKSYNC;
   case (utils::hash("applemedia")):
     return APPLE;
+  case (utils::hash("vulkan")):
+    return VULKAN;
   case (utils::hash("x264")):
   case (utils::hash("x265")):
   case (utils::hash("aom")):
@@ -301,7 +303,12 @@ Config load_or_default(const std::string &source,
   if (use_zero_copy) {
     switch (video_encoder) {
     case NVIDIA: {
-      default_base_video.producer_buffer_caps = "video/x-raw(memory:CUDAMemory)";
+      // Carry an NV12 DMABuf over the interpipe and import it into CUDA in the
+      // consumer (dmabuftocuda, see nvcodec video_params_zero_copy). A CUDAMemory
+      // buffer can't cross the interpipe -- it's tied to a CUDA context/stream the
+      // per-client encoder pipeline doesn't share -- so the producer must hand off
+      // the context-free dmabuf, exactly like the VAAPI path below.
+      default_base_video.producer_buffer_caps = "video/x-raw(memory:DMABuf), drm-format=NV12";
       break;
     }
     case VAAPI:
@@ -324,6 +331,14 @@ Config load_or_default(const std::string &source,
         default_base_video.producer_buffer_caps =
             fmt::format("video/x-raw(memory:DMABuf), drm-format={{{}}}", utils::join(gst_caps, ","));
       }
+      break;
+    }
+    case VULKAN: {
+      // Native Vulkan Video zero-copy: the producer (waylanddisplaysrc vulkan=true) emits an
+      // NV12 memory:VulkanImage that crosses the interpipe on a shared GstVulkanDevice (shared
+      // via the producer's bus_sync_handler / NeedContextData). vulkanh264enc consumes it
+      // directly -- no upload/convert.
+      default_base_video.producer_buffer_caps = "video/x-raw(memory:VulkanImage), format=NV12";
       break;
     }
     default: {

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -1,3 +1,4 @@
+#include <cstdlib>
 #include <events/events.hpp>
 #include <events/reflectors.hpp>
 #include <fstream>
@@ -351,6 +352,23 @@ Config load_or_default(const std::string &source,
             use_zero_copy ? "zero copy" : "legacy",
             get_vendor_name(vendor),
             default_gst_render_node);
+
+  bool using_vulkan_encoder = encoder_type(*h264_encoder) == VULKAN ||
+                              (hevc_encoder && encoder_type(*hevc_encoder) == VULKAN) ||
+                              (av1_encoder && encoder_type(*av1_encoder) == VULKAN);
+  if (vendor == GPU_VENDOR::AMD && using_vulkan_encoder) {
+    // The Vulkan Video encoder runs inside this process, so RADV's low-latency encode mode (Mesa 26.1+) has to be
+    // enabled on Wolf's own environment. Don't override a RADV_PERFTEST that the user already set.
+    if (!utils::get_env("RADV_PERFTEST")) {
+      setenv("RADV_PERFTEST", "lowlatencyenc", 0);
+      logs::log(logs::info,
+                "AMD GPU with a Vulkan Video encoder detected, enabling RADV_PERFTEST=lowlatencyenc for low-latency "
+                "encoding (requires Mesa 26.1+, silently ignored on older Mesa). Set RADV_PERFTEST yourself to "
+                "override this.");
+    } else {
+      logs::log(logs::debug, "RADV_PERFTEST already set ({}), leaving it as-is", utils::get_env("RADV_PERFTEST"));
+    }
+  }
 
   default_base_video.h264_encoder = h264_encoder.value().encoder_pipeline;
   if (hevc_encoder) {

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -342,10 +342,9 @@ Config load_or_default(const std::string &source,
       // [gstreamer.video] hdr = true selects the 10-bit P010 producer format, which
       // (via the hdr=true producer prop and vulkanh265enc's Main-10 + HDR10 SEI path)
       // yields an HDR10 stream. Default 8-bit NV12 so SDR clients aren't mis-signaled.
-      default_base_video.producer_buffer_caps =
-          default_gst_video_settings.hdr
-              ? "video/x-raw(memory:VulkanImage), format=P010_10LE"
-              : "video/x-raw(memory:VulkanImage), format=NV12";
+      default_base_video.producer_buffer_caps = default_gst_video_settings.hdr
+                                                    ? "video/x-raw(memory:VulkanImage), format=P010_10LE"
+                                                    : "video/x-raw(memory:VulkanImage), format=NV12";
       break;
     }
     default: {

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -339,7 +339,13 @@ Config load_or_default(const std::string &source,
       // NV12 memory:VulkanImage that crosses the interpipe on a shared GstVulkanDevice (shared
       // via the producer's bus_sync_handler / NeedContextData). vulkanh264enc consumes it
       // directly -- no upload/convert.
-      default_base_video.producer_buffer_caps = "video/x-raw(memory:VulkanImage), format=NV12";
+      // WOLF_HDR=TRUE selects the 10-bit P010 producer format, which (via the hdr=true
+      // producer prop and vulkanh265enc's Main-10 + HDR10 SEI path) yields an HDR10 stream.
+      // Default stays 8-bit NV12 so SDR clients are never mis-signaled as HDR.
+      default_base_video.producer_buffer_caps =
+          utils::get_env("WOLF_HDR", "") == std::string("TRUE")
+              ? "video/x-raw(memory:VulkanImage), format=P010_10LE"
+              : "video/x-raw(memory:VulkanImage), format=NV12";
       break;
     }
     default: {

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -375,6 +375,13 @@ Config load_or_default(const std::string &source,
     }
   }
 
+  if (default_gst_video_settings.hdr) {
+    // Plumb the SDR reference-white level to the producer's BT.2020/PQ shader (a
+    // specialization constant) so SDR content is tone-mapped to the configured nits
+    // instead of being stretched to PQ peak. Read by waylanddisplaysrc at converter build.
+    setenv("WOLF_SDR_REFERENCE_WHITE", std::to_string(default_gst_video_settings.sdr_reference_white).c_str(), 1);
+  }
+
   default_base_video.h264_encoder = h264_encoder.value().encoder_pipeline;
   if (hevc_encoder) {
     auto hevc_pipeline = hevc_encoder.value().encoder_pipeline;

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -339,11 +339,11 @@ Config load_or_default(const std::string &source,
       // NV12 memory:VulkanImage that crosses the interpipe on a shared GstVulkanDevice (shared
       // via the producer's bus_sync_handler / NeedContextData). vulkanh264enc consumes it
       // directly -- no upload/convert.
-      // WOLF_HDR=TRUE selects the 10-bit P010 producer format, which (via the hdr=true
-      // producer prop and vulkanh265enc's Main-10 + HDR10 SEI path) yields an HDR10 stream.
-      // Default stays 8-bit NV12 so SDR clients are never mis-signaled as HDR.
+      // [gstreamer.video] hdr = true selects the 10-bit P010 producer format, which
+      // (via the hdr=true producer prop and vulkanh265enc's Main-10 + HDR10 SEI path)
+      // yields an HDR10 stream. Default 8-bit NV12 so SDR clients aren't mis-signaled.
       default_base_video.producer_buffer_caps =
-          utils::get_env("WOLF_HDR", "") == std::string("TRUE")
+          default_gst_video_settings.hdr
               ? "video/x-raw(memory:VulkanImage), format=P010_10LE"
               : "video/x-raw(memory:VulkanImage), format=NV12";
       break;

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -377,7 +377,14 @@ Config load_or_default(const std::string &source,
 
   default_base_video.h264_encoder = h264_encoder.value().encoder_pipeline;
   if (hevc_encoder) {
-    default_base_video.hevc_encoder = hevc_encoder.value().encoder_pipeline;
+    auto hevc_pipeline = hevc_encoder.value().encoder_pipeline;
+    if (default_gst_video_settings.hdr && encoder_type(*hevc_encoder) == VULKAN) {
+      // The 10-bit P010 producer makes vulkanh265enc emit Main-10; the downstream
+      // capsfilter must allow it. An 8-bit `profile=main` constraint rejects the
+      // P010 input with "No valid profile found" -> not-negotiated -> no video.
+      hevc_pipeline = std::regex_replace(hevc_pipeline, std::regex("profile=main,"), "profile=main-10,");
+    }
+    default_base_video.hevc_encoder = hevc_pipeline;
   } else {
     logs::log(logs::warning, "Unable to find an HEVC encoder, disabling it");
   }
@@ -441,6 +448,7 @@ Config load_or_default(const std::string &source,
                 .config_source = source,
                 .support_hevc = hevc_encoder.has_value(),
                 .support_av1 = av1_encoder.has_value() && encoder_type(*av1_encoder) != SOFTWARE,
+                .support_hdr = default_gst_video_settings.hdr && hevc_encoder.has_value(),
                 .paired_clients = clients_atom,
                 .profiles = profiles_atom};
 }

--- a/src/moonlight-server/state/data-structures.hpp
+++ b/src/moonlight-server/state/data-structures.hpp
@@ -81,6 +81,10 @@ struct Config {
   std::string config_source;
   bool support_hevc;
   bool support_av1;
+  /* Advertise HEVC Main-10 (HDR10) to clients. Driven by [gstreamer.video] hdr;
+   * gates the VIDEO_FORMAT_H265_MAIN10 bit in serverinfo so Moonlight offers the
+   * HDR toggle and connects in BT2020/PQ mode. */
+  bool support_hdr;
 
   /**
    * Mutable, paired_clients will be loaded up on startup

--- a/src/moonlight-server/state/data-structures.hpp
+++ b/src/moonlight-server/state/data-structures.hpp
@@ -68,6 +68,7 @@ enum Encoder {
   QUICKSYNC,
   SOFTWARE,
   APPLE,
+  VULKAN,
   UNKNOWN
 };
 

--- a/src/moonlight-server/state/default/config.include.toml
+++ b/src/moonlight-server/state/default/config.include.toml
@@ -340,8 +340,14 @@ video/x-raw(memory:CUDAMemory), width={width}, height={height}, \
 chroma-site={color_range}, format=NV12, colorimetry={color_space}, pixel-aspect-ratio=1/1\
 """
 
+# Zero-copy carries an NV12 DMABuf over the interpipe (a CUDAMemory buffer can't
+# cross the interpipe boundary -- it's bound to a CUDA context/stream the consumer
+# pipeline doesn't share). dmabuftocuda imports that DMABuf into CUDA here in the
+# consumer (via EGLImage, no system-memory copy), where the encoder's CUDA context
+# is available; cudaupload can't (it has no DMABuf sink caps).
 video_params_zero_copy = """
-cudaupload !
+queue !
+dmabuftocuda !
 cudaconvertscale add-borders=true !
 video/x-raw(memory:CUDAMemory),format=NV12, width={width}, height={height}, pixel-aspect-ratio=1/1
 """
@@ -443,6 +449,26 @@ encoder_pipeline = """
 nvh264enc preset=low-latency-hq zerolatency=true gop-size=0 rc-mode=cbr-ld-hq bitrate={bitrate} vbv-buffer-size={vbv_buffer_size} aud=false !
 h264parse !
 video/x-h264, profile=main, stream-format=byte-stream\
+"""
+
+# Native Vulkan Video zero-copy encode (waylanddisplaysrc vulkan=true emits NV12 memory:VulkanImage).
+# Tunables come from WOLF_VULKAN_QUALITY / _REF_FRAMES / _B_FRAMES (defaults: low-latency streaming
+# preset = fastest quality, single reference, no B-frames -> full VCN throughput). Note: HEVC/AV1
+# Vulkan encode are not yet exposed by Mesa/RADV, so only H.264 is provided here.
+[[gstreamer.video.h264_encoders]]
+plugin_name = "vulkan"
+check_elements = ["vulkanh264enc"]
+encoder_pipeline = """
+vulkanh264enc aud=false quality={vk_quality} num-ref-frames={vk_ref_frames} b-frames={vk_b_frames} bitrate={bitrate} rate-control=cbr min-qp=20 idr-period=1024 !
+h264parse !
+video/x-h264, profile=main, stream-format=byte-stream\
+"""
+# The producer (waylanddisplaysrc vulkan=true) already emits NV12 memory:VulkanImage at the
+# session resolution/framerate, so the zero-copy path needs no videoscale/videoconvert/videorate
+# -- those are CPU elements that cannot negotiate the VulkanImage memory feature (the default
+# zero-copy params would inject them and fail with not-negotiated). Just a decoupling queue.
+video_params_zero_copy = """
+queue\
 """
 
 [[gstreamer.video.h264_encoders]]

--- a/src/moonlight-server/state/default/config.include.toml
+++ b/src/moonlight-server/state/default/config.include.toml
@@ -380,6 +380,26 @@ video/x-raw(memory:VAMemory), format=NV12, width={width}, height={height}, pixel
 # HEVC encoders
 # Order here matters: Wolf will try them in order and pick the first one that's not failing
 ###
+# Native Vulkan Video zero-copy HEVC encode (waylanddisplaysrc vulkan=true emits NV12/P010
+# memory:VulkanImage). Unlike the nvcodec/va entries below there is NO `profile=main` capsfilter,
+# so the 10-bit P010 Main-10 HDR path negotiates. Tunables come from WOLF_VULKAN_QUALITY /
+# _REF_FRAMES / _B_FRAMES. Works on NVIDIA (RTX 50-series VCN/Vulkan video encode); Mesa/RADV
+# does not expose HEVC Vulkan encode yet, so check_elements gates it out and Wolf falls through
+# to nvcodec/va. Listed first so the zero-copy HDR path is preferred where available.
+[[gstreamer.video.hevc_encoders]]
+plugin_name = "vulkan"
+check_elements = ["vulkanh265enc"]
+encoder_pipeline = """
+vulkanh265enc aud=false quality={vk_quality} num-ref-frames={vk_ref_frames} b-frames={vk_b_frames} bitrate={bitrate} rate-control=cqp min-qp=20 idr-period=1024 !
+h265parse !
+video/x-h265, stream-format=byte-stream\
+"""
+# Producer already emits the VulkanImage at session resolution/framerate, so the zero-copy path
+# is just a decoupling queue (convert/scale elements can't negotiate the VulkanImage memory feature).
+video_params_zero_copy = """
+queue\
+"""
+
 [[gstreamer.video.hevc_encoders]]
 plugin_name = "nvcodec"
 check_elements = ["nvh265enc", "cudaconvertscale", "cudaupload"]
@@ -453,8 +473,8 @@ video/x-h264, profile=main, stream-format=byte-stream\
 
 # Native Vulkan Video zero-copy encode (waylanddisplaysrc vulkan=true emits NV12 memory:VulkanImage).
 # Tunables come from WOLF_VULKAN_QUALITY / _REF_FRAMES / _B_FRAMES (defaults: low-latency streaming
-# preset = fastest quality, single reference, no B-frames -> full VCN throughput). Note: HEVC/AV1
-# Vulkan encode are not yet exposed by Mesa/RADV, so only H.264 is provided here.
+# preset = fastest quality, single reference, no B-frames -> full VCN throughput). Note: AV1
+# Vulkan encode is not yet exposed by Mesa/RADV; HEVC is provided in the hevc_encoders section above.
 [[gstreamer.video.h264_encoders]]
 plugin_name = "vulkan"
 check_elements = ["vulkanh264enc"]

--- a/src/moonlight-server/state/default/config.v7.toml
+++ b/src/moonlight-server/state/default/config.v7.toml
@@ -339,8 +339,14 @@ video/x-raw(memory:CUDAMemory), width={width}, height={height}, \
 chroma-site={color_range}, format=NV12, colorimetry={color_space}, pixel-aspect-ratio=1/1\
 """
 
+# Zero-copy carries an NV12 DMABuf over the interpipe (a CUDAMemory buffer can't
+# cross the interpipe boundary -- it's bound to a CUDA context/stream the consumer
+# pipeline doesn't share). dmabuftocuda imports that DMABuf into CUDA here in the
+# consumer (via EGLImage, no system-memory copy), where the encoder's CUDA context
+# is available; cudaupload can't (it has no DMABuf sink caps).
 video_params_zero_copy = """
-cudaupload !
+queue !
+dmabuftocuda !
 cudaconvertscale add-borders=true !
 video/x-raw(memory:CUDAMemory),format=NV12, width={width}, height={height}, pixel-aspect-ratio=1/1
 """
@@ -442,6 +448,26 @@ encoder_pipeline = """
 nvh264enc preset=low-latency-hq zerolatency=true gop-size=0 rc-mode=cbr-ld-hq bitrate={bitrate} vbv-buffer-size={vbv_buffer_size} aud=false !
 h264parse !
 video/x-h264, profile=main, stream-format=byte-stream\
+"""
+
+# Native Vulkan Video zero-copy encode (waylanddisplaysrc vulkan=true emits NV12 memory:VulkanImage).
+# Tunables come from WOLF_VULKAN_QUALITY / _REF_FRAMES / _B_FRAMES (defaults: low-latency streaming
+# preset = fastest quality, single reference, no B-frames -> full VCN throughput). Note: HEVC/AV1
+# Vulkan encode are not yet exposed by Mesa/RADV, so only H.264 is provided here.
+[[gstreamer.video.h264_encoders]]
+plugin_name = "vulkan"
+check_elements = ["vulkanh264enc"]
+encoder_pipeline = """
+vulkanh264enc aud=false quality={vk_quality} num-ref-frames={vk_ref_frames} b-frames={vk_b_frames} bitrate={bitrate} rate-control=cbr min-qp=20 idr-period=1024 !
+h264parse !
+video/x-h264, profile=main, stream-format=byte-stream\
+"""
+# The producer (waylanddisplaysrc vulkan=true) already emits NV12 memory:VulkanImage at the
+# session resolution/framerate, so the zero-copy path needs no videoscale/videoconvert/videorate
+# -- those are CPU elements that cannot negotiate the VulkanImage memory feature (the default
+# zero-copy params would inject them and fail with not-negotiated). Just a decoupling queue.
+video_params_zero_copy = """
+queue\
 """
 
 [[gstreamer.video.h264_encoders]]

--- a/src/moonlight-server/state/default/config.v7.toml
+++ b/src/moonlight-server/state/default/config.v7.toml
@@ -379,6 +379,26 @@ video/x-raw(memory:VAMemory), format=NV12, width={width}, height={height}, pixel
 # HEVC encoders
 # Order here matters: Wolf will try them in order and pick the first one that's not failing
 ###
+# Native Vulkan Video zero-copy HEVC encode (waylanddisplaysrc vulkan=true emits NV12/P010
+# memory:VulkanImage). Unlike the nvcodec/va entries below there is NO `profile=main` capsfilter,
+# so the 10-bit P010 Main-10 HDR path negotiates. Tunables come from WOLF_VULKAN_QUALITY /
+# _REF_FRAMES / _B_FRAMES. Works on NVIDIA (RTX 50-series VCN/Vulkan video encode); Mesa/RADV
+# does not expose HEVC Vulkan encode yet, so check_elements gates it out and Wolf falls through
+# to nvcodec/va. Listed first so the zero-copy HDR path is preferred where available.
+[[gstreamer.video.hevc_encoders]]
+plugin_name = "vulkan"
+check_elements = ["vulkanh265enc"]
+encoder_pipeline = """
+vulkanh265enc aud=false quality={vk_quality} num-ref-frames={vk_ref_frames} b-frames={vk_b_frames} bitrate={bitrate} rate-control=cqp min-qp=20 idr-period=1024 !
+h265parse !
+video/x-h265, stream-format=byte-stream\
+"""
+# Producer already emits the VulkanImage at session resolution/framerate, so the zero-copy path
+# is just a decoupling queue (convert/scale elements can't negotiate the VulkanImage memory feature).
+video_params_zero_copy = """
+queue\
+"""
+
 [[gstreamer.video.hevc_encoders]]
 plugin_name = "nvcodec"
 check_elements = ["nvh265enc", "cudaconvertscale", "cudaupload"]
@@ -452,8 +472,8 @@ video/x-h264, profile=main, stream-format=byte-stream\
 
 # Native Vulkan Video zero-copy encode (waylanddisplaysrc vulkan=true emits NV12 memory:VulkanImage).
 # Tunables come from WOLF_VULKAN_QUALITY / _REF_FRAMES / _B_FRAMES (defaults: low-latency streaming
-# preset = fastest quality, single reference, no B-frames -> full VCN throughput). Note: HEVC/AV1
-# Vulkan encode are not yet exposed by Mesa/RADV, so only H.264 is provided here.
+# preset = fastest quality, single reference, no B-frames -> full VCN throughput). Note: AV1
+# Vulkan encode is not yet exposed by Mesa/RADV; HEVC is provided in the hevc_encoders section above.
 [[gstreamer.video.h264_encoders]]
 plugin_name = "vulkan"
 check_elements = ["vulkanh264enc"]

--- a/src/moonlight-server/state/serialised_config.hpp
+++ b/src/moonlight-server/state/serialised_config.hpp
@@ -65,6 +65,11 @@ struct GstVideoCfg {
   std::string default_sink;
   std::map<std::string, GstEncoderDefault> defaults;
 
+  // When true, the native Vulkan zero-copy HEVC path uses a 10-bit P010 producer
+  // format with BT.2020/PQ tagging, so vulkanh265enc emits an HDR10 Main-10 stream.
+  // Default false (8-bit SDR NV12) so SDR clients are never mis-signaled as HDR.
+  bool hdr = false;
+
   std::vector<GstEncoder> av1_encoders;
   std::vector<GstEncoder> hevc_encoders;
   std::vector<GstEncoder> h264_encoders;

--- a/src/moonlight-server/state/serialised_config.hpp
+++ b/src/moonlight-server/state/serialised_config.hpp
@@ -70,6 +70,12 @@ struct GstVideoCfg {
   // Default false (8-bit SDR NV12) so SDR clients are never mis-signaled as HDR.
   bool hdr = false;
 
+  // SDR diffuse-white level in nits when hdr=true. The desktop/SDR content is tone-mapped
+  // into the PQ container with this as 100% white (BT.2408 graphics white = 203). Lower it
+  // for a dimmer desktop, raise it for a brighter one. Plumbed to the producer's BT.2020/PQ
+  // shader via the WOLF_SDR_REFERENCE_WHITE env; only affects the HDR (P010/PQ) path.
+  double sdr_reference_white = 203.0;
+
   std::vector<GstEncoder> av1_encoders;
   std::vector<GstEncoder> hevc_encoders;
   std::vector<GstEncoder> h264_encoders;

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -102,17 +102,18 @@ void start_video_producer(const std::string &session_id,
   // BT.2020 PQ-tagged frames (mastering-display + content-light metadata) so the
   // downstream vulkanh265enc produces an HDR10 Main-10 stream.
   std::string hdr_prop = buffer_format.find("P010") != std::string::npos ? " hdr=true" : "";
-  auto pipeline = fmt::format("waylanddisplaysrc name=wolf_wayland_source render_node={render_node}{vulkan_prop}{hdr_prop} ! "
-                              "{buffer_format}, width={width}, height={height}, framerate={fps}/1 ! \n"    //
-                              "interpipesink sync=true async=false name={session_id}_video max-buffers=1", //
-                              fmt::arg("vulkan_prop", vulkan_prop),
-                              fmt::arg("hdr_prop", hdr_prop),
-                              fmt::arg("buffer_format", buffer_format),
-                              fmt::arg("render_node", render_node),
-                              fmt::arg("session_id", session_id),
-                              fmt::arg("width", display_mode.width),
-                              fmt::arg("height", display_mode.height),
-                              fmt::arg("fps", display_mode.refreshRate));
+  auto pipeline = fmt::format(
+      "waylanddisplaysrc name=wolf_wayland_source render_node={render_node}{vulkan_prop}{hdr_prop} ! "
+      "{buffer_format}, width={width}, height={height}, framerate={fps}/1 ! \n"    //
+      "interpipesink sync=true async=false name={session_id}_video max-buffers=1", //
+      fmt::arg("vulkan_prop", vulkan_prop),
+      fmt::arg("hdr_prop", hdr_prop),
+      fmt::arg("buffer_format", buffer_format),
+      fmt::arg("render_node", render_node),
+      fmt::arg("session_id", session_id),
+      fmt::arg("width", display_mode.width),
+      fmt::arg("height", display_mode.height),
+      fmt::arg("fps", display_mode.refreshRate));
   logs::log(logs::debug, "[GSTREAMER] Starting video producer: {}", pipeline);
   auto bus_data_ptr =
       std::make_shared<GstBusData>(GstBusData{.on_ready = std::move(on_ready), .wayland_plugin = nullptr});

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -10,6 +10,7 @@
 #include <immer/array.hpp>
 #include <immer/box.hpp>
 #include <memory>
+#include <optional>
 #include <streaming/streaming.hpp>
 #include <thread>
 
@@ -21,6 +22,11 @@ using namespace wolf::core;
 struct GstBusData {
   std::shared_ptr<boost::promise<WaylandDisplayReady>> on_ready;
   gst_element_ptr wayland_plugin;
+  // Used to forward the producer's HDR<->SDR content-state changes to the control thread.
+  std::string session_id;
+  std::shared_ptr<events::EventBusType> event_bus;
+  // Last HDR state we forwarded; guards against re-sending HDR_MODE on no-op messages.
+  std::optional<bool> last_hdr_state;
 };
 
 gboolean structure_each(GQuark field_id, const GValue *value, gpointer user_data) {
@@ -46,6 +52,29 @@ static void application_message_handler(GstBus *bus, GstMessage *msg, gpointer d
   auto structure = gst_message_get_structure(msg);
   if (gst_structure_has_name(structure, "wayland.src")) {
     gst_structure_foreach(structure, structure_each, data);
+  } else if (gst_structure_has_name(structure, "wolf-hdr-state")) {
+    // The producer pipeline signals an HDR<->SDR content change by posting a
+    // "wolf-hdr-state" application message carrying a single "hdr" gboolean.
+    // Forward it to the control thread so it can send the Moonlight HDR_MODE packet.
+    auto bus_data = static_cast<GstBusData *>(data);
+    gboolean hdr = FALSE;
+    if (!gst_structure_get_boolean(structure, "hdr", &hdr)) {
+      logs::log(logs::warning, "[HDR] Received wolf-hdr-state message without a valid 'hdr' boolean");
+      return;
+    }
+    bool enable = hdr == TRUE;
+    if (bus_data->last_hdr_state && *bus_data->last_hdr_state == enable) {
+      return; // Only react to actual changes.
+    }
+    bus_data->last_hdr_state = enable;
+    logs::log(logs::info, "[HDR] Content switched to {} for session {}", enable ? "HDR" : "SDR", bus_data->session_id);
+    try {
+      auto session_id = std::stoull(bus_data->session_id);
+      bus_data->event_bus->fire_event(
+          immer::box<events::HDRModeEvent>(events::HDRModeEvent{.session_id = session_id, .enable_hdr = enable}));
+    } catch (const std::exception &e) {
+      logs::log(logs::warning, "[HDR] Failed to parse session id '{}': {}", bus_data->session_id, e.what());
+    }
   }
 }
 
@@ -115,8 +144,10 @@ void start_video_producer(const std::string &session_id,
       fmt::arg("height", display_mode.height),
       fmt::arg("fps", display_mode.refreshRate));
   logs::log(logs::debug, "[GSTREAMER] Starting video producer: {}", pipeline);
-  auto bus_data_ptr =
-      std::make_shared<GstBusData>(GstBusData{.on_ready = std::move(on_ready), .wayland_plugin = nullptr});
+  auto bus_data_ptr = std::make_shared<GstBusData>(GstBusData{.on_ready = std::move(on_ready),
+                                                              .wayland_plugin = nullptr,
+                                                              .session_id = session_id,
+                                                              .event_bus = event_bus});
   std::shared_ptr<NeedContextData> ctx_data_ptr =
       std::make_shared<NeedContextData>(NeedContextData{.device_path = render_node, .gst_context = video_context});
   run_pipeline(pipeline, [=](auto pipeline) {

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -95,9 +95,13 @@ void start_video_producer(const std::string &session_id,
                           std::shared_ptr<immer::atom<gst_video_context::gst_context_ptr>> video_context,
                           std::shared_ptr<boost::promise<WaylandDisplayReady>> on_ready,
                           std::shared_ptr<events::EventBusType> event_bus) {
-  auto pipeline = fmt::format("waylanddisplaysrc name=wolf_wayland_source render_node={render_node} ! "
+  // The native Vulkan zero-copy path needs the source in Vulkan mode so it emits NV12
+  // memory:VulkanImage (selected when the negotiated producer caps are VulkanImage).
+  std::string vulkan_prop = buffer_format.find("VulkanImage") != std::string::npos ? " vulkan=true" : "";
+  auto pipeline = fmt::format("waylanddisplaysrc name=wolf_wayland_source render_node={render_node}{vulkan_prop} ! "
                               "{buffer_format}, width={width}, height={height}, framerate={fps}/1 ! \n"    //
                               "interpipesink sync=true async=false name={session_id}_video max-buffers=1", //
+                              fmt::arg("vulkan_prop", vulkan_prop),
                               fmt::arg("buffer_format", buffer_format),
                               fmt::arg("render_node", render_node),
                               fmt::arg("session_id", session_id),
@@ -392,6 +396,11 @@ void start_streaming_video(immer::box<events::VideoSession> video_session,
       fmt::arg("min_required_fec_packets", video_session->min_required_fec_packets),
       fmt::arg("slices_per_frame", video_session->slices_per_frame),
       fmt::arg("vbv_buffer_size", video_session->bitrate_kbps / video_session->display_mode.refreshRate),
+      // Vulkan encoder tunables (defaults = low-latency streaming preset: fastest quality,
+      // single reference, no B-frames -> full VCN throughput). Override per-deployment via env.
+      fmt::arg("vk_quality", utils::get_env("WOLF_VULKAN_QUALITY", "0")),
+      fmt::arg("vk_ref_frames", utils::get_env("WOLF_VULKAN_REF_FRAMES", "1")),
+      fmt::arg("vk_b_frames", utils::get_env("WOLF_VULKAN_B_FRAMES", "0")),
       fmt::arg("color_space", color_space),
       fmt::arg("color_range", color_range),
       fmt::arg("host_port", video_session->port));

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -98,10 +98,15 @@ void start_video_producer(const std::string &session_id,
   // The native Vulkan zero-copy path needs the source in Vulkan mode so it emits NV12
   // memory:VulkanImage (selected when the negotiated producer caps are VulkanImage).
   std::string vulkan_prop = buffer_format.find("VulkanImage") != std::string::npos ? " vulkan=true" : "";
-  auto pipeline = fmt::format("waylanddisplaysrc name=wolf_wayland_source render_node={render_node}{vulkan_prop} ! "
+  // A P010 producer format selects the 10-bit / HDR path: tell the source to emit
+  // BT.2020 PQ-tagged frames (mastering-display + content-light metadata) so the
+  // downstream vulkanh265enc produces an HDR10 Main-10 stream.
+  std::string hdr_prop = buffer_format.find("P010") != std::string::npos ? " hdr=true" : "";
+  auto pipeline = fmt::format("waylanddisplaysrc name=wolf_wayland_source render_node={render_node}{vulkan_prop}{hdr_prop} ! "
                               "{buffer_format}, width={width}, height={height}, framerate={fps}/1 ! \n"    //
                               "interpipesink sync=true async=false name={session_id}_video max-buffers=1", //
                               fmt::arg("vulkan_prop", vulkan_prop),
+                              fmt::arg("hdr_prop", hdr_prop),
                               fmt::arg("buffer_format", buffer_format),
                               fmt::arg("render_node", render_node),
                               fmt::arg("session_id", session_id),


### PR DESCRIPTION
> **Draft.** Builds and publishes a `wolf:vulkan` image with native Vulkan NV12 H.264 encode, on a Fedora base. Pairs with games-on-whales/gst-wayland-display#37, which publishes the `gst-wayland-display:vulkan` base image this builds FROM.

## What this adds

**1. Native Vulkan NV12 H.264 encode** (`feat(vulkan)`)
A `VULKAN` encoder type wired through config/streaming: a `vulkanh264enc` `h264_encoders` block, `producer_buffer_caps = video/x-raw(memory:VulkanImage), format=NV12`, and `video_params_zero_copy = "queue"` so the encoder consumes the producer's NV12 `VulkanImage` directly (no `videoscale`/`videoconvert`/`videorate`, which can't negotiate the `memory:VulkanImage` feature). `waylanddisplaysrc vulkan=true` is set when the buffer caps ask for VulkanImage. Tunables: `WOLF_VULKAN_QUALITY` / `_REF_FRAMES` / `_B_FRAMES` (defaults tuned for low-latency: `quality=0 num-ref-frames=1 b-frames=0`).

**2. `wolf:vulkan` image** (`ci`)
`docker/wolf.vulkan.Dockerfile` is `FROM ghcr.io/games-on-whales/gst-wayland-display:vulkan` — which already carries patched GStreamer 1.28.4 (vulkan-video + the `vulkanh264enc` DPB-pool patch) and the plugin under `/opt/gst`. So the heavy gst-Vulkan + plugin build happens once in that image; here we only compile Wolf on top. A `Build Wolf (Vulkan)` step in `docker-build.yml` publishes `ghcr.io/<owner>/wolf:vulkan`.

**3. Fedora image switch** (`feat(fedora)`)
Moved here from #431 per request. `gpu-drivers`, `gstreamer` and `wolf` images build on Fedora (`base-app:fedora`) instead of Ubuntu/apt. Wolf runs its own PulseAudio under supervisord (the Fedora base ships a conflicting `pipewire-pulseaudio` shim, swapped with `--allowerasing`), with graceful SIGINT shutdown to match `stopsignal=INT`.

## Relationship to other PRs
- **games-on-whales/gst-wayland-display#37** — publishes `gst-wayland-display:vulkan`, the base image this builds FROM.
- **#431** — keeps the smoke-test harness + Wayland resolution tests; the Fedora switch was moved out of it into this PR.

## Status / testing
Hardware-validated end-to-end on an AMD RX 7900 XTX (RADV + RPM Fusion freeworld mesa): `waylanddisplaysrc → NV12 VulkanImage → vulkanh264enc → Moonlight` streams real content. Draft pending CI image builds and broader GPU validation.
