### PR TITLE
fix(lobby): deliver device unplug events to the lobby container

### DIFF
--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -313,10 +313,10 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
         immer::vector<events::Lobby> lobbies = app_state->lobbies->load();
         if (auto lobby = state::get_lobby_by_connected_session(lobbies, unplug_device_event->session_id)) {
           logs::log(logs::debug, "[LOBBY] Unplug device for session {}", unplug_device_event->session_id);
-          app_state->event_bus->fire_event(
+          app_state->event_bus->fire_event(immer::box<events::UnplugDeviceEvent>{
               events::UnplugDeviceEvent{.session_id = lobby->id,
                                         .udev_events = unplug_device_event->udev_events,
-                                        .udev_hw_db_entries = unplug_device_event->udev_hw_db_entries});
+                                        .udev_hw_db_entries = unplug_device_event->udev_hw_db_entries}});
         }
       }));
 

--- a/tests/testWolfAPI.cpp
+++ b/tests/testWolfAPI.cpp
@@ -495,6 +495,48 @@ TEST_CASE("Session APIs without app_id or client_id", "[API]") {
   REQUIRE(sessions2.sessions.size() == 1);
 }
 
+// A device unplugged while its session is inside a lobby must be relayed to the lobby's runner.
+TEST_CASE("Lobby relays a device unplug to its runner", "[API]") {
+  auto event_bus = std::make_shared<events::EventBusType>();
+  auto running_sessions = std::make_shared<immer::atom<immer::vector<events::StreamSession>>>();
+  auto config = immer::box<state::Config>(state::load_or_default("config.test.toml", event_bus, running_sessions));
+  auto app_state = immer::box<state::AppState>(state::AppState{
+      .config = config,
+      .pairing_cache = std::make_shared<immer::atom<immer::map<std::string, state::PairCache>>>(),
+      .pairing_atom = std::make_shared<immer::atom<immer::map<std::string, immer::box<events::PairSignal>>>>(),
+      .event_bus = event_bus,
+      .lobbies = std::make_shared<immer::atom<immer::vector<events::Lobby>>>(),
+      .running_sessions = running_sessions});
+
+  // A lobby with one connected Moonlight session, added straight to state (no compositor).
+  const std::string lobby_id = "lobby-under-test";
+  const std::string moonlight_session_id = "1234";
+  events::Lobby lobby{.id = lobby_id,
+                      .name = "test_lobby",
+                      .started_by_profile_id = "test_profile",
+                      .multi_user = false,
+                      .stop_when_everyone_leaves = false};
+  lobby.connected_sessions->update([&](const immer::vector<immer::box<std::string>> &connected) {
+    return connected.push_back(immer::box<std::string>{moonlight_session_id});
+  });
+  app_state->lobbies->update([&](const immer::vector<events::Lobby> &lobbies) { return lobbies.push_back(lobby); });
+
+  auto lobbies_handlers = sessions::setup_lobbies_handlers(app_state, api_runtime_dir(), {});
+
+  int relayed_to_lobby = 0;
+  auto observer = event_bus->register_handler<immer::box<events::UnplugDeviceEvent>>(
+      [&](const immer::box<events::UnplugDeviceEvent> &ev) {
+        if (ev->session_id == lobby_id) {
+          relayed_to_lobby++;
+        }
+      });
+
+  event_bus->fire_event(
+      immer::box<events::UnplugDeviceEvent>{events::UnplugDeviceEvent{.session_id = moonlight_session_id}});
+
+  REQUIRE(relayed_to_lobby == 1);
+}
+
 TEST_CASE("Lobbies APIs", "[API]") {
   auto event_bus = std::make_shared<events::EventBusType>();
   auto running_sessions = std::make_shared<immer::atom<immer::vector<events::StreamSession>>>();


### PR DESCRIPTION
## Problem

Hot-plugging a controller (disconnect then reconnect) while a Moonlight session is inside a lobby app (e.g. Steam) doesn't reach the app — the reconnected pad never shows up. A plain Wolf-UI session is fine; it only breaks once the session has joined a lobby.

## Cause

The lobby's `UnplugDeviceEvent` handler re-fires the event to the lobby's runner as a **bare** `events::UnplugDeviceEvent`:

```cpp
app_state->event_bus->fire_event(
    events::UnplugDeviceEvent{.session_id = lobby->id, ...});
```

Every handler registers for `immer::box<events::UnplugDeviceEvent>`, and `dp::event_bus` keys handlers by `typeid(EventType)`. So the unboxed event matches no handler and is silently dropped — the lobby container never receives the remove.

The stale device node then makes the next replug fail at `mknod ... File exists`, and since the plug command is `mknod ... && fake-udev`, the `&&`-chained ADD uevent never fires, so the app never sees the reconnect.

The sibling paths (plug relay, join, leave) all box the event; this one didn't — it has been this way since lobbies were introduced.

## Fix

Box the relayed event, matching the other paths. Includes a regression test that drives the relay through `setup_lobbies_handlers` (no compositor required).