### PR TITLE
Fix modifier keys being instantly released when clients send side-specific VK codes

### DIFF
--- a/src/moonlight-protocol/moonlight/control.hpp
+++ b/src/moonlight-protocol/moonlight/control.hpp
@@ -110,8 +110,15 @@ enum KEYBOARD_MODIFIERS : char {
 enum MOONLIGHT_MODIFIERS : short {
   M_SHIFT = 0x10,
   M_CTRL = 0x11,
+  M_MENU = 0x12,
   M_ALT = 0xA4,
-  M_META = 0x5B
+  M_META = 0x5B,
+  M_LSHIFT = 0xA0,
+  M_RSHIFT = 0xA1,
+  M_LCTRL = 0xA2,
+  M_RCTRL = 0xA3,
+  M_RALT = 0xA5,
+  M_RMETA = 0x5C
 };
 
 // make sure these structs are allocated in 1-byte blocks so the data aligns

--- a/src/moonlight-server/control/input_handler.cpp
+++ b/src/moonlight-server/control/input_handler.cpp
@@ -366,6 +366,28 @@ void mouse_h_scroll(const MOUSE_HSCROLL_PACKET &pkt, events::StreamSession &sess
   }
 }
 
+static char modifier_bit(short moonlight_key) {
+  switch (moonlight_key) {
+  case M_SHIFT:
+  case M_LSHIFT:
+  case M_RSHIFT:
+    return KEYBOARD_MODIFIERS::SHIFT;
+  case M_CTRL:
+  case M_LCTRL:
+  case M_RCTRL:
+    return KEYBOARD_MODIFIERS::CTRL;
+  case M_MENU:
+  case M_ALT:
+  case M_RALT:
+    return KEYBOARD_MODIFIERS::ALT;
+  case M_META:
+  case M_RMETA:
+    return KEYBOARD_MODIFIERS::META;
+  default:
+    return KEYBOARD_MODIFIERS::NONE;
+  }
+}
+
 void keyboard_key(const KEYBOARD_PACKET &pkt, events::StreamSession &session) {
   // moonlight always sets the high bit; not sure why but mask it off here
   short moonlight_key = (short)boost::endian::little_to_native(pkt.key_code) & (short)0x7fff;
@@ -375,13 +397,22 @@ void keyboard_key(const KEYBOARD_PACKET &pkt, events::StreamSession &session) {
     return;
   }
 
+  const char key_mod = modifier_bit(moonlight_key);
+  char held = 0;
+  if (key_mod != KEYBOARD_MODIFIERS::NONE) {
+    held = session.held_modifiers->update(
+        [&](char h) -> char { return pkt.type == KEY_PRESS ? (h | key_mod) : (h & ~key_mod); });
+  } else {
+    held = session.held_modifiers->load();
+  }
+
   if (pkt.type == KEY_PRESS) {
     int wolf_ui_combo_pressed = 0;
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && moonlight_key != M_SHIFT)
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && !(key_mod & KEYBOARD_MODIFIERS::SHIFT))
       wolf_ui_combo_pressed++;
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && moonlight_key != M_CTRL)
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && !(key_mod & KEYBOARD_MODIFIERS::CTRL))
       wolf_ui_combo_pressed++;
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && moonlight_key != M_ALT)
+    if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && !(key_mod & KEYBOARD_MODIFIERS::ALT))
       wolf_ui_combo_pressed++;
 
     // CTRL + ALT + SHIFT + W
@@ -395,32 +426,34 @@ void keyboard_key(const KEYBOARD_PACKET &pkt, events::StreamSession &session) {
             keyboard.release(M_ALT);
           },
           session.keyboard->value());
+      session.held_modifiers->store(0);
       session.event_bus->fire_event(
           immer::box<events::ClientWolfUIComboEvent>{events::ClientWolfUIComboEvent{.session_id = session.session_id}});
       return;
     }
 
     // Press the virtual modifiers
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && moonlight_key != M_SHIFT)
+    const char virtual_mods = pkt.modifiers & ~held & ~key_mod;
+    if (virtual_mods & KEYBOARD_MODIFIERS::SHIFT)
       std::visit([](auto &keyboard) { keyboard.press(M_SHIFT); }, session.keyboard->value());
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && moonlight_key != M_CTRL)
+    if (virtual_mods & KEYBOARD_MODIFIERS::CTRL)
       std::visit([](auto &keyboard) { keyboard.press(M_CTRL); }, session.keyboard->value());
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && moonlight_key != M_ALT)
+    if (virtual_mods & KEYBOARD_MODIFIERS::ALT)
       std::visit([](auto &keyboard) { keyboard.press(M_ALT); }, session.keyboard->value());
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::META && moonlight_key != M_META)
+    if (virtual_mods & KEYBOARD_MODIFIERS::META)
       std::visit([](auto &keyboard) { keyboard.press(M_META); }, session.keyboard->value());
 
     // Press the actual key
     std::visit([moonlight_key](auto &keyboard) { keyboard.press(moonlight_key); }, session.keyboard->value());
 
     // Release the virtual modifiers
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::SHIFT && moonlight_key != M_SHIFT)
+    if (virtual_mods & KEYBOARD_MODIFIERS::SHIFT)
       std::visit([](auto &keyboard) { keyboard.release(M_SHIFT); }, session.keyboard->value());
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::CTRL && moonlight_key != M_CTRL)
+    if (virtual_mods & KEYBOARD_MODIFIERS::CTRL)
       std::visit([](auto &keyboard) { keyboard.release(M_CTRL); }, session.keyboard->value());
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::ALT && moonlight_key != M_ALT)
+    if (virtual_mods & KEYBOARD_MODIFIERS::ALT)
       std::visit([](auto &keyboard) { keyboard.release(M_ALT); }, session.keyboard->value());
-    if (pkt.modifiers & KEYBOARD_MODIFIERS::META && moonlight_key != M_META)
+    if (virtual_mods & KEYBOARD_MODIFIERS::META)
       std::visit([](auto &keyboard) { keyboard.release(M_META); }, session.keyboard->value());
 
   } else {

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -455,6 +455,12 @@ struct StreamSession {
 
   std::shared_ptr<immer::atom<JoypadList>> joypads = std::make_shared<immer::atom<JoypadList>>();
 
+  /**
+   * Bitmask (KEYBOARD_MODIFIERS) of the modifier keys the client is currently physically holding.
+   * Used to avoid synthesizing a virtual press/release around keys the client already holds down.
+   */
+  std::shared_ptr<immer::atom<char>> held_modifiers = std::make_shared<immer::atom<char>>();
+
   std::shared_ptr<std::optional<input::PenTablet>> pen_tablet =
       std::make_shared<std::optional<input::PenTablet>>(); /* Optional, will be set on first use */
 };


### PR DESCRIPTION
## Problem
  
`keyboard_key()` synthesizes "virtual modifiers" around every `KEY_PRESS`: it presses the modifiers reported in the packet flags, presses the actual key, then immediately releases those modifiers. The guards that skip this dance when the pressed key *is* the modifier itself only compare against the generic Windows VK codes (`M_SHIFT = 0x10`, `M_CTRL = 0x11`), but clients (e.g. moonlight-qt) send the side-specific codes (`VK_LSHIFT = 0xA0`, `VK_LCONTROL = 0xA2`, ...).

As a result:

- Pressing and holding Shift/Ctrl produces a key press immediately followed by a synthetic release (a ~0 ms pulse), so applications never see the key as held.
- While a modifier is physically held, every other keypress carries the modifier flag and re-triggers the press/release dance, releasing a key the client is still holding.

Typical symptoms: hold-modifier actions in games don't work (e.g. Shift to sprint) and key-binding screens don't detect Shift/Ctrl, while text capitalization keeps working (the modifier state bit is briefly set around each letter). Alt is unaffected only by luck, since `M_ALT` happens to be defined as the side-specific code (`0xA4`). This is likely the root cause of games-on-whales/gow#299.

## Fix

- Add the side-specific modifier VK codes to `MOONLIGHT_MODIFIERS` and recognize both families through a `modifier_bit()` helper.
- Track per session which modifiers the client is physically holding, from the modifier keys' own press/release packets. 
- Synthesize the virtual modifier press/release only for modifiers reported in the packet flags that the client is *not* physically holding. This preserves the original purpose of the dance (state drift, e.g. a modifier already held before the stream started) while never interfering with keys the client actually holds.

Note: the bug can go unnoticed on sessions using uinput virtual devices, because inputtino periodically re-presses the keys it still tracks as held (`cur_press_keys`), so the wrongly released modifier comes back down after a few milliseconds. Sessions using the Wayland virtual keyboard have no such  keep-alive, so the modifier stays released.
