### PR TITLE
fix(input): DualSense battery always reads low in Steam

### DIFF
--- a/src/moonlight-protocol/moonlight/control.hpp
+++ b/src/moonlight-protocol/moonlight/control.hpp
@@ -266,7 +266,9 @@ enum MOTION_TYPE : uint8_t {
 
 constexpr uint8_t BATTERY_PERCENTAGE_UNKNOWN = 0xFF;
 
-enum BATTERY_STATE : unsigned short {
+// One byte on the wire -- must stay uint8_t, otherwise it eats the following battery_percentage
+// byte in CONTROLLER_BATTERY_PACKET and the percentage is always read as the trailing zero (0%).
+enum BATTERY_STATE : uint8_t {
   BATTERY_STATE_UNKNOWN = 0x0,
   BATTERY_NOT_PRESENT = 0x1,
   BATTERY_DISCHARGHING = 0x2,


### PR DESCRIPTION
The emulated DualSense reports a near empty battery regardless of the real charge on the client's controller. Steam and games read that value off the pad, so in the session the controller shows as low. This is the battery the session app reads, not the host.

battery_state in CONTROLLER_BATTERY_PACKET is a 2 byte enum (unsigned short), but the field is one byte on the wire. The struct is packed, so the second byte overlaps battery_percentage and it always reads the trailing zero. set_battery() then gets 0 and sets the pad to empty.

The other one byte enums in this header (MOTION_TYPE, TOUCH_EVENT_TYPE) are uint8_t. BATTERY_STATE should be too. It has been unsigned short since the virtual inputs were split out of Moonlight, and the value only matters on the PS5 pad when the client reports battery, so the misparse stayed hidden.