### PR TITLE
fix(api): keep start_audio_server when deserialising an App

### DIFF
--- a/src/moonlight-server/events/reflectors.hpp
+++ b/src/moonlight-server/events/reflectors.hpp
@@ -85,6 +85,7 @@ template <> struct Reflector<events::App> {
         .render_node = app.render_node,
         .opus_gst_pipeline = app.opus_gst_pipeline,
         .start_virtual_compositor = app.start_virtual_compositor,
+        .start_audio_server = app.start_audio_server,
         .runner = runner,
     };
   }


### PR DESCRIPTION
`Reflector<events::App>::to()` rebuilt the `events::App` without
`start_audio_server`, so aggregate initialisation left it `false`. Every app
created through `POST /api/v1/apps/add` therefore had its audio server disabled,
no matter what the request said: the session came up with a virtual compositor
but no `virtual_sink_<session_id>`, in-app streams fell back to `auto_null` and
Moonlight got silence.

`from()` in the same file copies the field, and `configTOML.cpp` reads
(`value_or(true)`) and writes it, so apps defined in `config.toml` behaved
correctly — which is why the API *reported* `false` rather than omitting the key,
and why this was easy to miss.

The `start_virtual_compositor` line right above shows the intended shape; this
adds the matching assignment for the audio flag.

Details, reproduction and the user-visible symptoms are in #465.

Fixes #465