### PR TITLE
fix(hdr): complete end-to-end HDR transport

### DIFF
--- a/src/moonlight-protocol/moonlight.cpp
+++ b/src/moonlight-protocol/moonlight.cpp
@@ -47,6 +47,9 @@ XML serverinfo(bool isServerBusy,
   }
   if (support_av1) {
     codec_support |= VIDEO_FORMAT_AV1_MAIN8;
+    if (support_hdr) {
+      codec_support |= VIDEO_FORMAT_AV1_MAIN10;
+    }
   }
 
   resp.put("root.MaxLumaPixelsHEVC", std::to_string(max_luma_pixels));

--- a/src/moonlight-protocol/moonlight/control.hpp
+++ b/src/moonlight-protocol/moonlight/control.hpp
@@ -349,6 +349,12 @@ struct ControlHdrModePacket {
 
 #pragma pack(pop)
 
+static ControlHdrModePacket hdr_mode_packet(bool enabled) {
+  auto packet = ControlHdrModePacket{};
+  packet.enableHdr = enabled ? 1 : 0;
+  return packet;
+}
+
 struct ControlRumblePacket {
   ControlPacket header;
 

--- a/src/moonlight-server/control/control.cpp
+++ b/src/moonlight-server/control/control.cpp
@@ -94,6 +94,13 @@ bool encrypt_and_send(std::string_view payload,
   }
 }
 
+bool send_hdr_mode(const events::StreamSession &session, immer::box<std::shared_ptr<ENetPeer>> client, bool enabled) {
+  auto packet = moonlight::control::hdr_mode_packet(enabled);
+  std::string_view plaintext{reinterpret_cast<const char *>(&packet), sizeof(packet)};
+  logs::log(logs::debug, "[ENET] Sending HDR mode {} to session {}", enabled, session.session_id);
+  return encrypt_and_send(plaintext, session.aes_key, client);
+}
+
 std::optional<events::StreamSession> get_current_session(const enet_clients_map &connected_clients,
                                                          const state::SessionsAtoms &running_sessions,
                                                          std::string_view client_ip,
@@ -141,9 +148,11 @@ void run_control(int port,
   ENetEvent event;
 
   immer::atom<enet_clients_map> connected_clients;
+  immer::atom<immer::map<std::size_t, bool>> hdr_modes;
 
   auto stop_ev = event_bus->register_handler<immer::box<StopStreamEvent>>(
-      [&connected_clients](const immer::box<StopStreamEvent> &ev) {
+      [&connected_clients, &hdr_modes](const immer::box<StopStreamEvent> &ev) {
+        hdr_modes.update([ev](const immer::map<std::size_t, bool> &m) { return m.erase(ev->session_id); });
         auto terminate_pkt = ControlTerminatePacket{};
         std::string plaintext = {(char *)&terminate_pkt, sizeof(terminate_pkt)};
         for (auto &[peer, session] : *connected_clients.load()) {
@@ -156,22 +165,17 @@ void run_control(int port,
         logs::log(logs::debug, "[ENET] Client not found for session: {}", ev->session_id);
       });
 
-  auto hdr_mode_ev =
-      event_bus->register_handler<immer::box<HDRModeEvent>>([&connected_clients](const immer::box<HDRModeEvent> &ev) {
-        // Build the HDR_MODE control packet; metadata defaults to the BT.2020/Rec.2100
-        // values (ignored by the client when enableHdr == 0).
-        auto hdr_pkt = ControlHdrModePacket{};
-        hdr_pkt.enableHdr = ev->enable_hdr ? 1 : 0;
-        std::string plaintext = {(char *)&hdr_pkt, sizeof(hdr_pkt)};
+  auto video_ev = event_bus->register_handler<immer::box<VideoSession>>(
+      [&connected_clients, &hdr_modes](const immer::box<VideoSession> &video) {
+        hdr_modes.update(
+            [video](const immer::map<std::size_t, bool> &m) { return m.set(video->session_id, video->hdr_requested); });
+
         for (auto &[peer, session] : *connected_clients.load()) {
-          if (session->session_id == ev->session_id) {
-            immer::box<std::shared_ptr<ENetPeer>> enet_client = {to_shared_ptr(peer)};
-            encrypt_and_send(plaintext, session->aes_key, enet_client);
-            logs::log(logs::info, "[ENET] Sent HDR_MODE ({}) for session: {}", hdr_pkt.enableHdr, ev->session_id);
+          if (session->session_id == video->session_id) {
+            send_hdr_mode(*session, immer::box<std::shared_ptr<ENetPeer>>{to_shared_ptr(peer)}, video->hdr_requested);
             return;
           }
         }
-        logs::log(logs::debug, "[ENET] Client not found for HDR mode session: {}", ev->session_id);
       });
 
   while (true) {
@@ -189,6 +193,11 @@ void run_control(int port,
           });
           event_bus->fire_event(
               immer::box<ResumeStreamEvent>(ResumeStreamEvent{.session_id = client_session->session_id}));
+          if (auto hdr = hdr_modes.load()->find(client_session->session_id)) {
+            send_hdr_mode(client_session.value(),
+                          immer::box<std::shared_ptr<ENetPeer>>{to_shared_ptr(event.peer)},
+                          *hdr);
+          }
           break;
         case ENET_EVENT_TYPE_DISCONNECT:
           logs::log(logs::debug, "[ENET] disconnected client: {}:{}", client_ip, client_port);
@@ -249,7 +258,7 @@ void run_control(int port,
   }
 
   stop_ev.unregister();
-  hdr_mode_ev.unregister();
+  video_ev.unregister();
 }
 
 } // namespace control

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -145,6 +145,7 @@ struct VideoSettings {
   std::string wayland_render_node;
   std::string runner_render_node;
   std::string video_producer_buffer_caps;
+  bool hdr_output = false;
 };
 
 struct AudioSettings {
@@ -259,6 +260,7 @@ struct VideoSession {
 
   ColorRange color_range;
   ColorSpace color_space;
+  bool hdr_requested = false;
 
   std::string client_ip;
   std::array<char, 16> rtp_secret_payload;
@@ -298,16 +300,6 @@ struct ResumeStreamEvent {
 
 struct StopStreamEvent {
   std::size_t session_id;
-};
-
-/**
- * Fired when the content's HDR/SDR state changes (signalled by the producer
- * pipeline via a "wolf-hdr-state" bus message). The control thread reacts by
- * sending the Moonlight HDR_MODE control packet to the matching client.
- */
-struct HDRModeEvent {
-  std::size_t session_id;
-  bool enable_hdr;
 };
 
 struct ClientWolfUIComboEvent {
@@ -354,7 +346,6 @@ using EventBusHandlers = dp::handler_registration<immer::box<PlugDeviceEvent>,
                                                   immer::box<PauseStreamEvent>,
                                                   immer::box<ResumeStreamEvent>,
                                                   immer::box<StopStreamEvent>,
-                                                  immer::box<HDRModeEvent>,
                                                   immer::box<ClientWolfUIComboEvent>,
                                                   immer::box<RTPVideoPingEvent>,
                                                   immer::box<RTPAudioPingEvent>,
@@ -376,7 +367,6 @@ using EventBusType = dp::event_bus<immer::box<PlugDeviceEvent>,
                                    immer::box<PauseStreamEvent>,
                                    immer::box<ResumeStreamEvent>,
                                    immer::box<StopStreamEvent>,
-                                   immer::box<HDRModeEvent>,
                                    immer::box<ClientWolfUIComboEvent>,
                                    immer::box<RTPVideoPingEvent>,
                                    immer::box<RTPAudioPingEvent>,
@@ -398,7 +388,6 @@ using EventsVariant = std::variant<immer::box<PlugDeviceEvent>,
                                    immer::box<PauseStreamEvent>,
                                    immer::box<ResumeStreamEvent>,
                                    immer::box<StopStreamEvent>,
-                                   immer::box<HDRModeEvent>,
                                    immer::box<ClientWolfUIComboEvent>,
                                    immer::box<RTPVideoPingEvent>,
                                    immer::box<RTPAudioPingEvent>,

--- a/src/moonlight-server/rest/endpoints.hpp
+++ b/src/moonlight-server/rest/endpoints.hpp
@@ -78,7 +78,7 @@ void serverinfo(const std::shared_ptr<typename SimpleWeb::Server<T>::Response> &
                                    is_https,
                                    cfg->support_hevc,
                                    cfg->support_av1,
-                                   cfg->support_hdr);
+                                   state::supports_hdr(*cfg));
 
   send_xml<T>(response, SimpleWeb::StatusCode::success_ok, xml);
 }

--- a/src/moonlight-server/rtsp/commands.hpp
+++ b/src/moonlight-server/rtsp/commands.hpp
@@ -170,6 +170,25 @@ announce(const RTSP_PACKET &req, const events::StreamSession &session) {
   bool video_format_hevc = args["x-nv-vqos[0].bitStreamFormat"].value_or(0) == 1;
   bool video_format_av1 = args["x-nv-vqos[0].bitStreamFormat"].value_or(0) == 2;
   auto csc = args["x-nv-video[0].encoderCscMode"].value_or(0);
+  bool hdr_requested = args["x-nv-video[0].dynamicRangeMode"].value_or(0) == 1;
+  auto color_space = events::ColorSpace(csc >> 1);
+
+  if (hdr_requested && !session.app->base.support_hdr) {
+    logs::log(logs::warning, "[RTSP] Ignoring HDR request for an SDR-only application");
+    hdr_requested = false;
+  }
+
+  if (hdr_requested && !video_format_hevc && !video_format_av1) {
+    logs::log(logs::warning, "[RTSP] Ignoring HDR request without a 10-bit capable codec");
+    hdr_requested = false;
+  }
+
+  if (hdr_requested && color_space != events::ColorSpace::BT2020) {
+    // dynamicRangeMode is the explicit transport request. Some clients retain
+    // their SDR encoderCscMode while negotiating a 10-bit HDR codec profile.
+    logs::log(logs::info, "[RTSP] HDR requested with non-BT.2020 CSC {}; selecting BT.2020/PQ", csc);
+    color_space = events::ColorSpace::BT2020;
+  }
 
   // Video session
   moonlight::DisplayMode display = {.width = args["x-nv-video[0].clientViewportWd"].value(),
@@ -261,7 +280,8 @@ announce(const RTSP_PACKET &req, const events::StreamSession &session) {
       .slices_per_frame = args["x-nv-video[0].videoEncoderSlicesPerFrame"].value_or(1),
 
       .color_range = (csc & 0x1) ? events::ColorRange::JPEG : events::ColorRange::MPEG,
-      .color_space = events::ColorSpace(csc >> 1),
+      .color_space = color_space,
+      .hdr_requested = hdr_requested,
 
       .client_ip = session.ip,
       .rtp_secret_payload = session.rtp_secret_payload,

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -101,6 +101,7 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
                                             {.width = lobby_settings->video_settings.width,
                                              .height = lobby_settings->video_settings.height,
                                              .refreshRate = lobby_settings->video_settings.refresh_rate},
+                                            lobby_settings->video_settings.hdr_output,
                                             gst_context,
                                             on_ready,
                                             ev_bus);

--- a/src/moonlight-server/sessions/moonlight.cpp
+++ b/src/moonlight-server/sessions/moonlight.cpp
@@ -107,6 +107,7 @@ setup_moonlight_handlers(const immer::box<state::AppState> &app_state,
                                             {.width = session->display_mode.width,
                                              .height = session->display_mode.height,
                                              .refreshRate = session->display_mode.refreshRate},
+                                            session->app->base.support_hdr,
                                             gst_context,
                                             on_ready,
                                             session->event_bus);

--- a/src/moonlight-server/state/config.hpp
+++ b/src/moonlight-server/state/config.hpp
@@ -111,6 +111,24 @@ inline std::optional<immer::box<events::Profile>> get_moonlight_profile(const Co
 }
 
 /**
+ * Returns whether the encoder and at least one currently advertised Moonlight
+ * application can service an HDR connection.
+ */
+inline bool supports_hdr(const Config &cfg) {
+  if (!cfg.support_hdr)
+    return false;
+
+  auto moonlight_profile = get_moonlight_profile(cfg);
+  if (!moonlight_profile)
+    return false;
+
+  immer::vector<immer::box<events::App>> apps = moonlight_profile.value()->apps->load();
+  return std::any_of(apps.begin(), apps.end(), [](const immer::box<events::App> &app) {
+    return app->base.support_hdr;
+  });
+}
+
+/**
  * Returns the app with the given app_id (if it exists)
  */
 inline std::optional<immer::box<events::App>> get_moonlight_app_by_id(const Config &cfg, std::string_view app_id) {

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -134,6 +134,7 @@ parse_apps(const std::vector<BaseApp> &apps,
            const std::string &default_app_render_node,
            const std::string &default_gst_render_node,
            const BaseAppVideoOverride &default_video_settings,
+           bool default_support_hdr,
            const std::string &h264_video_params,
            const std::string &hevc_video_params,
            const std::string &av1_video_params,
@@ -155,6 +156,14 @@ parse_apps(const std::vector<BaseApp> &apps,
         }
         auto app_video_settings = app.video.value_or(default_video_settings);
         auto app_audio_settings = app.audio.value_or(default_audio_settings);
+        const bool support_hdr = app.support_hdr.value_or(default_support_hdr);
+        auto producer_buffer_caps =
+            app_video_settings.producer_buffer_caps.value_or(default_video_settings.producer_buffer_caps.value());
+        if (support_hdr && producer_buffer_caps.find("memory:VulkanImage") != std::string::npos) {
+          producer_buffer_caps = "video/x-raw(memory:VulkanImage), format=P010_10LE";
+        } else if (support_hdr && producer_buffer_caps.find("memory:DMABuf") != std::string::npos) {
+          producer_buffer_caps = "video/x-raw(memory:DMABuf), drm-format=P010";
+        }
 
         auto h264_gst_pipeline = fmt::format(
             "{} !\n{} !\n{} !\n{}", //
@@ -191,9 +200,9 @@ parse_apps(const std::vector<BaseApp> &apps,
         return immer::box<events::App>{
             events::App{.base = {.title = app.title,
                                  .id = generate_app_id(app),
-                                 .support_hdr = false,
+                                 .support_hdr = support_hdr,
                                  .icon_png_path = app.icon_png_path},
-                        .video_producer_buffer_caps = default_video_settings.producer_buffer_caps.value(),
+                        .video_producer_buffer_caps = producer_buffer_caps,
                         .h264_gst_pipeline = h264_gst_pipeline,
                         .hevc_gst_pipeline = hevc_gst_pipeline,
                         .av1_gst_pipeline = av1_gst_pipeline,
@@ -440,6 +449,7 @@ Config load_or_default(const std::string &source,
                                                               default_app_render_node,
                                                               default_gst_render_node,
                                                               default_base_video,
+                                                              default_gst_video_settings.hdr,
                                                               h264_video_params,
                                                               hevc_video_params,
                                                               av1_video_params,
@@ -449,13 +459,14 @@ Config load_or_default(const std::string &source,
                   }) |
                   ranges::to<ProfilesList>();
   auto profiles_atom = std::make_shared<immer::atom<ProfilesList>>(profiles);
+  const bool hardware_av1 = av1_encoder.has_value() && encoder_type(*av1_encoder) != SOFTWARE;
 
   return Config{.uuid = cfg.uuid,
                 .hostname = cfg.hostname,
                 .config_source = source,
                 .support_hevc = hevc_encoder.has_value(),
-                .support_av1 = av1_encoder.has_value() && encoder_type(*av1_encoder) != SOFTWARE,
-                .support_hdr = default_gst_video_settings.hdr && hevc_encoder.has_value(),
+                .support_av1 = hardware_av1,
+                .support_hdr = hevc_encoder.has_value() || hardware_av1,
                 .paired_clients = clients_atom,
                 .profiles = profiles_atom};
 }

--- a/src/moonlight-server/state/data-structures.hpp
+++ b/src/moonlight-server/state/data-structures.hpp
@@ -81,9 +81,8 @@ struct Config {
   std::string config_source;
   bool support_hevc;
   bool support_av1;
-  /* Advertise HEVC Main-10 (HDR10) to clients. Driven by [gstreamer.video] hdr;
-   * gates the VIDEO_FORMAT_H265_MAIN10 bit in serverinfo so Moonlight offers the
-   * HDR toggle and connects in BT2020/PQ mode. */
+  /* At least one hardware encoder can service a 10-bit HDR transport. The
+   * advertised host capability also requires a live HDR-capable app. */
   bool support_hdr;
 
   /**

--- a/src/moonlight-server/state/serialised_config.hpp
+++ b/src/moonlight-server/state/serialised_config.hpp
@@ -131,6 +131,7 @@ struct BaseApp {
   std::string title;
   std::optional<std::string> icon_png_path;
   std::optional<std::string> render_node;
+  std::optional<bool> support_hdr;
   std::optional<BaseAppVideoOverride> video;
   std::optional<BaseAppAudioOverride> audio;
   std::optional<bool> start_virtual_compositor;

--- a/src/moonlight-server/streaming/streaming.cpp
+++ b/src/moonlight-server/streaming/streaming.cpp
@@ -4,8 +4,8 @@
 #include <control/control.hpp>
 #include <core/batched_send.hpp>
 #include <gst-video-context.hpp>
-#include <gstreamer-1.0/gst/app/gstappsink.h>
-#include <gstreamer-1.0/gst/app/gstappsrc.h>
+#include <gst/app/gstappsink.h>
+#include <gst/app/gstappsrc.h>
 #include <helpers/utils.hpp>
 #include <immer/array.hpp>
 #include <immer/box.hpp>
@@ -22,11 +22,6 @@ using namespace wolf::core;
 struct GstBusData {
   std::shared_ptr<boost::promise<WaylandDisplayReady>> on_ready;
   gst_element_ptr wayland_plugin;
-  // Used to forward the producer's HDR<->SDR content-state changes to the control thread.
-  std::string session_id;
-  std::shared_ptr<events::EventBusType> event_bus;
-  // Last HDR state we forwarded; guards against re-sending HDR_MODE on no-op messages.
-  std::optional<bool> last_hdr_state;
 };
 
 gboolean structure_each(GQuark field_id, const GValue *value, gpointer user_data) {
@@ -52,29 +47,6 @@ static void application_message_handler(GstBus *bus, GstMessage *msg, gpointer d
   auto structure = gst_message_get_structure(msg);
   if (gst_structure_has_name(structure, "wayland.src")) {
     gst_structure_foreach(structure, structure_each, data);
-  } else if (gst_structure_has_name(structure, "wolf-hdr-state")) {
-    // The producer pipeline signals an HDR<->SDR content change by posting a
-    // "wolf-hdr-state" application message carrying a single "hdr" gboolean.
-    // Forward it to the control thread so it can send the Moonlight HDR_MODE packet.
-    auto bus_data = static_cast<GstBusData *>(data);
-    gboolean hdr = FALSE;
-    if (!gst_structure_get_boolean(structure, "hdr", &hdr)) {
-      logs::log(logs::warning, "[HDR] Received wolf-hdr-state message without a valid 'hdr' boolean");
-      return;
-    }
-    bool enable = hdr == TRUE;
-    if (bus_data->last_hdr_state && *bus_data->last_hdr_state == enable) {
-      return; // Only react to actual changes.
-    }
-    bus_data->last_hdr_state = enable;
-    logs::log(logs::info, "[HDR] Content switched to {} for session {}", enable ? "HDR" : "SDR", bus_data->session_id);
-    try {
-      auto session_id = std::stoull(bus_data->session_id);
-      bus_data->event_bus->fire_event(
-          immer::box<events::HDRModeEvent>(events::HDRModeEvent{.session_id = session_id, .enable_hdr = enable}));
-    } catch (const std::exception &e) {
-      logs::log(logs::warning, "[HDR] Failed to parse session id '{}': {}", bus_data->session_id, e.what());
-    }
   }
 }
 
@@ -100,37 +72,60 @@ static GstBusSyncReply bus_sync_handler(GstBus *bus, GstMessage *msg, gpointer d
   return GST_BUS_PASS;
 }
 
+std::string initial_video_colorimetry(bool hdr_requested, events::ColorSpace requested_color_space) {
+  if (hdr_requested) {
+    // HDR is a connection-level transport contract. SDR producer frames are
+    // converted into BT.2020/PQ while native PQ frames pass through.
+    return "bt2100-pq";
+  }
+
+  switch (requested_color_space) {
+  case events::ColorSpace::BT601:
+    return "bt601";
+  case events::ColorSpace::BT709:
+    return "bt709";
+  case events::ColorSpace::BT2020:
+    return "bt2020";
+  }
+  return "bt709";
+}
+
 std::pair<std::string, std::string> get_color_params(immer::box<events::VideoSession> video_session) {
   std::string color_range = (video_session->color_range == events::ColorRange::JPEG) ? "jpeg" : "mpeg2";
-  std::string color_space;
-  switch (video_session->color_space) {
-  case events::ColorSpace::BT601:
-    color_space = "bt601";
-    break;
-  case events::ColorSpace::BT709:
-    color_space = "bt709";
-    break;
-  case events::ColorSpace::BT2020:
-    color_space = "bt2020";
-    break;
+  return std::make_pair(color_range,
+                        initial_video_colorimetry(video_session->hdr_requested, video_session->color_space));
+}
+
+static void replace_all(std::string &value, std::string_view from, std::string_view to) {
+  std::size_t offset = 0;
+  while ((offset = value.find(from, offset)) != std::string::npos) {
+    value.replace(offset, from.size(), to);
+    offset += to.size();
   }
-  return std::make_pair(color_range, color_space);
+}
+
+std::string prepare_video_pipeline(std::string pipeline, bool hdr_requested) {
+  if (hdr_requested) {
+    replace_all(pipeline, "format=NV12", "format=P010_10LE");
+    replace_all(pipeline, "profile=main,", "profile=main-10,");
+  }
+  return pipeline;
 }
 
 void start_video_producer(const std::string &session_id,
                           const std::string &buffer_format,
                           const std::string &render_node,
                           const wolf::core::virtual_display::DisplayMode &display_mode,
+                          bool hdr_capable,
                           std::shared_ptr<immer::atom<gst_video_context::gst_context_ptr>> video_context,
                           std::shared_ptr<boost::promise<WaylandDisplayReady>> on_ready,
                           std::shared_ptr<events::EventBusType> event_bus) {
   // The native Vulkan zero-copy path needs the source in Vulkan mode so it emits NV12
   // memory:VulkanImage (selected when the negotiated producer caps are VulkanImage).
   std::string vulkan_prop = buffer_format.find("VulkanImage") != std::string::npos ? " vulkan=true" : "";
-  // A P010 producer format selects the 10-bit / HDR path: tell the source to emit
-  // BT.2020 PQ-tagged frames (mastering-display + content-light metadata) so the
-  // downstream vulkanh265enc produces an HDR10 Main-10 stream.
-  std::string hdr_prop = buffer_format.find("P010") != std::string::npos ? " hdr=true" : "";
+  // HDR is an application/producer capability, not an inference from the
+  // selected allocation format.
+  std::string hdr_prop = hdr_capable ? " hdr=true" : "";
   auto pipeline = fmt::format(
       "waylanddisplaysrc name=wolf_wayland_source render_node={render_node}{vulkan_prop}{hdr_prop} ! "
       "{buffer_format}, width={width}, height={height}, framerate={fps}/1 ! \n"    //
@@ -144,10 +139,8 @@ void start_video_producer(const std::string &session_id,
       fmt::arg("height", display_mode.height),
       fmt::arg("fps", display_mode.refreshRate));
   logs::log(logs::debug, "[GSTREAMER] Starting video producer: {}", pipeline);
-  auto bus_data_ptr = std::make_shared<GstBusData>(GstBusData{.on_ready = std::move(on_ready),
-                                                              .wayland_plugin = nullptr,
-                                                              .session_id = session_id,
-                                                              .event_bus = event_bus});
+  auto bus_data_ptr =
+      std::make_shared<GstBusData>(GstBusData{.on_ready = std::move(on_ready), .wayland_plugin = nullptr});
   std::shared_ptr<NeedContextData> ctx_data_ptr =
       std::make_shared<NeedContextData>(NeedContextData{.device_path = render_node, .gst_context = video_context});
   run_pipeline(pipeline, [=](auto pipeline) {
@@ -419,8 +412,9 @@ void start_streaming_video(immer::box<events::VideoSession> video_session,
                            std::shared_ptr<udp::socket> video_socket) {
   auto [color_range, color_space] = get_color_params(video_session);
 
+  auto pipeline_template = prepare_video_pipeline(video_session->gst_pipeline, video_session->hdr_requested);
   auto pipeline = fmt::format(
-      fmt::runtime(video_session->gst_pipeline),
+      fmt::runtime(pipeline_template),
       fmt::arg("session_id", video_session->session_id),
       fmt::arg("width", video_session->display_mode.width),
       fmt::arg("height", video_session->display_mode.height),

--- a/src/moonlight-server/streaming/streaming.hpp
+++ b/src/moonlight-server/streaming/streaming.hpp
@@ -7,8 +7,8 @@
 #include <gst-plugin/gstrtpmoonlightpay_audio.hpp>
 #include <gst-plugin/gstrtpmoonlightpay_video.hpp>
 #include <gst-plugin/video.hpp>
+#include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
-#include <gstreamer-1.0/gst/app/gstappsrc.h>
 #include <immer/box.hpp>
 #include <memory>
 #include <moonlight/fec.hpp>
@@ -34,6 +34,7 @@ void start_video_producer(const std::string &session_id,
                           const std::string &buffer_format,
                           const std::string &render_node,
                           const wolf::core::virtual_display::DisplayMode &display_mode,
+                          bool hdr_capable,
                           std::shared_ptr<immer::atom<gst_video_context::gst_context_ptr>> video_context,
                           std::shared_ptr<boost::promise<WaylandDisplayReady>> on_ready,
                           std::shared_ptr<events::EventBusType> event_bus);
@@ -50,6 +51,9 @@ void start_streaming_video(immer::box<events::VideoSession> video_session,
                            unsigned short client_port,
                            std::shared_ptr<immer::atom<gst_video_context::gst_context_ptr>> video_context,
                            std::shared_ptr<udp::socket> video_socket);
+
+std::string initial_video_colorimetry(bool hdr_requested, events::ColorSpace requested_color_space);
+std::string prepare_video_pipeline(std::string pipeline, bool hdr_requested);
 
 void start_streaming_audio(immer::box<events::AudioSession> audio_session,
                            const std::shared_ptr<events::EventBusType> &event_bus,

--- a/tests/assets/config.test.toml
+++ b/tests/assets/config.test.toml
@@ -28,6 +28,7 @@ id = "moonlight-profile-id"
 title = "Firefox"
 start_virtual_compositor = true
 icon_png_path = "firefox.png"
+support_hdr = true
 
 [profiles.apps.runner]
 type = "docker"

--- a/tests/testControl.cpp
+++ b/tests/testControl.cpp
@@ -89,3 +89,15 @@ TEST_CASE("control joypad input packets") {
   REQUIRE(input_data->active_gamepad_mask == 1);
   REQUIRE(pressed_btns & pkts::CONTROLLER_BTN::A);
 }
+
+TEST_CASE("HDR mode control packet carries BT.2020 mastering metadata") {
+  auto packet = hdr_mode_packet(true);
+
+  REQUIRE(packet.header.type == pkts::HDR_MODE);
+  REQUIRE(packet.header.length == sizeof(packet) - sizeof(ControlPacket));
+  REQUIRE(packet.enableHdr == 1);
+  REQUIRE(packet.metadata.displayPrimaries[0].x == 35400);
+  REQUIRE(packet.metadata.whitePoint.x == 15635);
+  REQUIRE(packet.metadata.maxDisplayLuminance == 1000);
+  REQUIRE(sizeof(packet) == sizeof(ControlPacket) + 1 + sizeof(SS_HDR_METADATA));
+}

--- a/tests/testMoonlight.cpp
+++ b/tests/testMoonlight.cpp
@@ -37,6 +37,7 @@ TEST_CASE("LocalState load TOML", "[LocalState]") {
     auto first_app = apps.at(0);
     REQUIRE_THAT(first_app->base.title, Equals("Firefox"));
     REQUIRE_THAT(first_app->base.id, Equals("304556286"));
+    REQUIRE(first_app->base.support_hdr);
     REQUIRE_THAT(first_app->base.icon_png_path.value(), Equals("firefox.png"));
     auto default_video_source = "interpipesrc name=interpipesrc_{}_video";
     REQUIRE_THAT(first_app->h264_gst_pipeline,
@@ -53,6 +54,7 @@ TEST_CASE("LocalState load TOML", "[LocalState]") {
     auto second_app = apps.at(1);
     REQUIRE_THAT(second_app->base.title, Equals("Test ball"));
     REQUIRE_THAT(second_app->base.id, Equals("378473508"));
+    REQUIRE_FALSE(second_app->base.support_hdr);
     REQUIRE(second_app->base.icon_png_path.has_value() == false);
     REQUIRE_THAT(second_app->h264_gst_pipeline,
                  Equals("override DEFAULT SOURCE !\ndefault !\nh264_pipeline !\nvideo_sink"));
@@ -221,6 +223,66 @@ TEST_CASE("Mocked serverinfo", "[MoonlightProtocol]") {
             "</root>");
     REQUIRE(result.get<bool>("root.PairStatus") == true);
   }
+
+  SECTION("server_info advertises AV1 Main10 for an HDR-capable host") {
+    auto result = serverinfo(false,
+                             0,
+                             0,
+                             1,
+                             cfg.uuid,
+                             cfg.hostname,
+                             "AA:BB:CC:DD",
+                             "192.168.1.1",
+                             displayModes,
+                             true,
+                             false,
+                             true,
+                             true);
+
+    REQUIRE(result.get<int>("root.ServerCodecModeSupport") == 196609);
+  }
+}
+
+TEST_CASE("HDR video pipeline selects a 10-bit encoder path", "[Streaming][HDR]") {
+  auto pipeline = "vapostproc ! video/x-raw(memory:VAMemory), format=NV12, colorimetry={color_space} ! "
+                  "vah265enc ! video/x-h265, profile=main, stream-format=byte-stream";
+
+  auto hdr = streaming::prepare_video_pipeline(pipeline, true);
+  REQUIRE_THAT(hdr, Catch::Matchers::ContainsSubstring("format=P010_10LE"));
+  REQUIRE_THAT(hdr, Catch::Matchers::ContainsSubstring("profile=main-10"));
+  REQUIRE(streaming::prepare_video_pipeline(pipeline, false) == pipeline);
+}
+
+TEST_CASE("HDR transport remains PQ while SDR producer frames are converted", "[Streaming][HDR]") {
+  REQUIRE(streaming::initial_video_colorimetry(true, events::ColorSpace::BT2020) == "bt2100-pq");
+  REQUIRE(streaming::initial_video_colorimetry(true, events::ColorSpace::BT709) == "bt2100-pq");
+  REQUIRE(streaming::initial_video_colorimetry(false, events::ColorSpace::BT601) == "bt601");
+  REQUIRE(streaming::initial_video_colorimetry(false, events::ColorSpace::BT709) == "bt709");
+  REQUIRE(streaming::initial_video_colorimetry(false, events::ColorSpace::BT2020) == "bt2020");
+}
+
+TEST_CASE("HDR host capability requires an encoder and a live HDR application", "[LocalState][HDR]") {
+  auto apps =
+      std::make_shared<immer::atom<immer::vector<immer::box<events::App>>>>(immer::vector<immer::box<events::App>>{
+          events::App{.base = moonlight::App{.title = "SDR", .support_hdr = false}},
+      });
+  auto profiles = std::make_shared<immer::atom<state::ProfilesList>>(state::ProfilesList{events::Profile{
+      .id = std::string{events::MOONLIGHT_PROFILE_ID},
+      .name = "Moonlight",
+      .icon_png_path = "",
+      .apps = apps,
+  }});
+  auto cfg = state::Config{.support_hdr = false, .profiles = profiles};
+
+  REQUIRE_FALSE(state::supports_hdr(cfg));
+
+  cfg.support_hdr = true;
+  REQUIRE_FALSE(state::supports_hdr(cfg));
+
+  apps->update([](auto current) {
+    return current.push_back(events::App{.base = moonlight::App{.title = "HDR", .support_hdr = true}});
+  });
+  REQUIRE(state::supports_hdr(cfg));
 }
 
 // Stuff generated from Moonlight

--- a/tests/testRTSP.cpp
+++ b/tests/testRTSP.cpp
@@ -250,9 +250,10 @@ state::SessionsAtoms test_init_state() {
   events::StreamSession session = {.display_mode = {1920, 1080, 60},
                                    .audio_channel_count = 2,
                                    .event_bus = std::make_shared<events::EventBusType>(),
-                                   .app = std::make_shared<events::App>(events::App{.base = {},
+                                   .app = std::make_shared<events::App>(events::App{.base = {.support_hdr = true},
                                                                                     .h264_gst_pipeline = "",
                                                                                     .hevc_gst_pipeline = "",
+                                                                                    .av1_gst_pipeline = "",
                                                                                     .opus_gst_pipeline = "",
                                                                                     .runner = nullptr}),
                                    .aes_key = crypto::hex_to_str("9d804e47a6aa6624b7d4b502b32cc522", true),
@@ -375,6 +376,10 @@ TEST_CASE("Commands (Payload matching)", "[RTSP]") {
   }
 
   SECTION("ANNOUNCE control") {
+    std::optional<events::VideoSession> announced_video;
+    auto video_handler = state->load()->operator[](0).event_bus->register_handler<immer::box<events::VideoSession>>(
+        [&announced_video](const immer::box<events::VideoSession> &video) { announced_video = *video; });
+
     // This is a very long message, it'll kick the recursion in receive_message()
     wolf_client->run("ANNOUNCE streamid=control/13/0 RTSP/1.0\n"
                      "CSeq: 6\n"
@@ -409,8 +414,8 @@ TEST_CASE("Commands (Payload matching)", "[RTSP]") {
                      "a=x-nv-general.enableRecoveryMode:0 \n"
                      "a=x-nv-video[0].videoEncoderSlicesPerFrame:1 \n"
                      "a=x-nv-clientSupportHevc:0 \n"
-                     "a=x-nv-vqos[0].bitStreamFormat:0 \n"
-                     "a=x-nv-video[0].dynamicRangeMode:0 \n"
+                     "a=x-nv-vqos[0].bitStreamFormat:1 \n"
+                     "a=x-nv-video[0].dynamicRangeMode:1 \n"
                      "a=x-nv-video[0].maxNumReferenceFrames:1 \n"
                      "a=x-nv-video[0].clientRefreshRateX100:0 \n"
                      "a=x-nv-audio.surround.numChannels:2 \n"
@@ -418,7 +423,9 @@ TEST_CASE("Commands (Payload matching)", "[RTSP]") {
                      "a=x-nv-audio.surround.enable:0 \n"
                      "a=x-nv-audio.surround.AudioQuality:0 \n"
                      "a=x-nv-aqos.packetDuration:5 \n"
-                     "a=x-nv-video[0].encoderCscMode:0 \n"
+                     // dynamicRangeMode is authoritative even when a client
+                     // retains an SDR encoderCscMode during negotiation.
+                     "a=x-nv-video[0].encoderCscMode:2 \n"
                      "t=0 0\n"
                      "m=video 47998 \n"sv,
                      [](std::optional<RTSP_PACKET> response) {
@@ -426,6 +433,11 @@ TEST_CASE("Commands (Payload matching)", "[RTSP]") {
                        REQUIRE(response.value().response.status_code == 200);
                        REQUIRE(response.value().seq_number == 6);
                      });
+
+    REQUIRE(announced_video.has_value());
+    REQUIRE(announced_video->hdr_requested);
+    REQUIRE(announced_video->color_space == events::ColorSpace::BT2020);
+    video_handler.unregister();
   }
 
   SECTION("Non valid payload") {


### PR DESCRIPTION
## Summary

This completes Wolf's end-to-end HDR transport path: capability advertisement, Moonlight negotiation, control-channel activation, producer configuration, 10-bit encoder selection, and per-frame color handling.

## Root cause

Wolf previously mixed the connection-level HDR transport contract with the producer's frame-level SDR/PQ state. That allowed producer transitions to toggle Moonlight HDR mode after connection, while clients requesting HDR through `dynamicRangeMode=1` could retain a stale SDR `encoderCscMode`. AV1 Main10 was also omitted from host capability advertisement, and hardware HDR capability was not constrained by the applications currently exposed to Moonlight.

## Fix

- Treat `dynamicRangeMode` as the authoritative HDR request and normalize HDR sessions to BT.2020/PQ.
- Keep the negotiated Moonlight HDR transport stable for the connection lifetime.
- Preserve per-frame SDR conversion and native PQ handling inside the GStreamer pipeline without renegotiating the client transport.
- Send and replay the Moonlight HDR mode packet for the negotiated video session.
- Advertise AV1 Main10 when AV1 and HDR are both supported.
- Promote HDR VulkanImage and DMA-BUF producer caps to P010 and select Main10 encoder profiles.
- Add per-app `support_hdr` configuration and advertise host HDR only when both the encoder and a currently exposed application support it.
- Honor application-specific producer caps.
- Use the standard GStreamer app-header include layout required by the Vulkan build.

## Result

HDR-capable applications negotiate stable HEVC Main10 or AV1 Main10 BT.2020/PQ streams. SDR-only applications are not advertised as HDR-capable, while SDR frames presented during an HDR session are converted by the media pipeline without changing the negotiated transport.

## Validation

- Linux production target built against GStreamer 1.28.4 with the Vulkan encoder path enabled.
- HDR and AV1 transport: 18 assertions.
- RTSP negotiation: 144 assertions.
- Application and capability state: 49 assertions.
