### PR TITLE
docs(quickstart): add "Nvidia (Auto)" automated driver setup method

### DIFF
--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -58,7 +58,7 @@ Nvidia (Container Toolkit)::
 
 [WARNING]
 ====
-This **isn't recommended at the moment** as it's not as stable as the manual method. +
+This **isn't recommended at the moment** as it's not as stable as the auto or manual method. +
 You can follow https://github.com/games-on-whales/wolf/issues/152[issue #152] for updates.
 ====
 
@@ -149,6 +149,69 @@ GRUB_CMDLINE_LINUX_DEFAULT="quiet nvidia-drm.modeset=1"
 
 Then `sudo update-grub` and *reboot*.
 ====
+
+--
+Nvidia (Auto)::
++
+--
+
+Make sure that your driver version is `>= 530.30.02` then simply run `docker compose up --detach` using the following `docker-compose.yml` configuration:
+
+[source,yaml]
+....
+
+services:
+  init-nvidia-driver:
+    image: gow/nvidia-driver:latest
+    build:
+      context: https://github.com/games-on-whales/gow.git#master:/images/nvidia-driver/
+      secrets:
+        - nvidia-version
+    pull_policy: build
+    volumes:
+      - nvidia-driver-vol:/usr/nvidia.init/:rw
+
+  wolf:
+    image: ghcr.io/games-on-whales/wolf:stable
+    depends_on:
+      init-nvidia-driver:
+        condition: service_completed_successfully
+        restart: true
+    environment:
+      - "NVIDIA_DRIVER_VOLUME_NAME=${COMPOSE_PROJECT_NAME}_nvidia-driver-vol"
+    volumes:
+      - /etc/wolf/:/etc/wolf:rw
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - /dev/:/dev/:rw
+      - /run/udev:/run/udev:rw
+      - nvidia-driver-vol:/usr/nvidia:rw
+    devices:
+      - /dev/dri
+      - /dev/uinput
+      - /dev/uhid
+      - /dev/nvidia-uvm
+      - /dev/nvidia-uvm-tools
+      - /dev/nvidia-caps/nvidia-cap1
+      - /dev/nvidia-caps/nvidia-cap2
+      - /dev/nvidiactl
+      - /dev/nvidia0
+      - /dev/nvidia-modeset
+    device_cgroup_rules:
+      - 'c 13:* rmw'
+    network_mode: host
+    restart: unless-stopped
+
+volumes:
+  nvidia-driver-vol:
+
+secrets:
+  nvidia-version:
+    file: /sys/module/nvidia/version
+....
+
+If any environment dependencies have not been met or the driver initialization process failed, you should see messages in the `init-nvidia-driver` service logs; to do this, run the command `docker compose logs init-nvidia-driver`.
+
+You can find troubleshooting information on the Nvidia (Manual) tab.
 
 --
 Nvidia (Manual)::


### PR DESCRIPTION
## What

Adds a third setup method to the Quickstart guide — **Nvidia (Auto)** — documenting a fully automated Nvidia driver setup that removes the two manual steps the existing **Nvidia (Manual)** method requires: looking up the host driver version by hand, and re-creating the driver volume after every host driver upgrade.

## Changes

`docs/modules/user/pages/quickstart.adoc`:

- **New `Nvidia (Auto)` tab**, placed between `Nvidia (Container Toolkit)` and `Nvidia (Manual)`. It documents a single `docker compose up --detach` workflow:
  - an `init-nvidia-driver` service builds the `gow/nvidia-driver` image, receiving the host driver version as a Compose secret sourced from `/sys/module/nvidia/version` — so the driver in the volume always matches the running kernel module, with no manual version pinning;
  - Wolf declares `depends_on: { condition: service_completed_successfully, restart: true }`, so the volume is (re)initialized before Wolf starts and on every restart;
  - `NVIDIA_DRIVER_VOLUME_NAME` is derived from `${COMPOSE_PROJECT_NAME}`, matching the volume name Compose actually creates.
- **Troubleshooting pointer** — failed preflight checks and initialization errors surface in `docker compose logs init-nvidia-driver`; deeper troubleshooting is deferred to the existing `Nvidia (Manual)` tab rather than duplicated.
- **Warning text on the `Nvidia (Container Toolkit)` tab** updated from "not as stable as the manual method" to "not as stable as the auto or manual method", now that a second recommended path exists.

No existing setup method is changed or removed — this is purely additive.

## Related

This depends on the companion PR in the `gow` repository, which teaches the `nvidia-driver` image to read the version from a build secret and to initialize the driver volume from its entrypoint: https://github.com/games-on-whales/gow/pull/353

The Compose example documented here builds from `https://github.com/games-on-whales/gow.git#master:/images/nvidia-driver/`, so **this PR should land after games-on-whales/gow#353** — until then the documented configuration builds the pre-change image, which has neither the secret-based version detection nor the entrypoint that populates the volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
