### PR TITLE
fix(input): match the DualSense hidraw node by its HID name

### DIFF
--- a/85-wolf.rules
+++ b/85-wolf.rules
@@ -18,7 +18,9 @@ KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
 # without matching unrelated "Wolf" hardware.
 # We then (a) park them on the phantom seat9 and (b) strip the uaccess ACL. Both
 # the device's own name (ATTR, for uinput pads) and any ancestor's name (ATTRS,
-# for the uhid DualSense child devices and hidraw node) are matched.
+# for the uhid DualSense child devices) are matched. The hidraw node has no name
+# attribute in its parent chain (name lives on the sibling input device), so it
+# is matched on its parent's uevent, which carries the same name as HID_NAME.
 SUBSYSTEM=="input",  ATTR{name}=="Wolf *virtual*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
 SUBSYSTEMS=="input", ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-KERNEL=="hidraw*",   ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+KERNEL=="hidraw*",   ATTRS{uevent}=="*HID_NAME=Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"


### PR DESCRIPTION
The rule for the hidraw node came in with the input ones and uses the same ATTRS{name}=="Wolf *virtual*" form. Before that there was no hidraw rule at all. A hidraw device has no name attribute in its parent chain though. name lives on the sibling input device, so ATTRS has nothing to walk up to and the rule does not reach the node.

/dev/hidraw* for the virtual DualSense stays on ID_SEAT=seat0, so logind grants the desktop user a uaccess ACL on it. Steam on the host then reads the streamed pad and shows it connected with a battery level. The three input nodes are covered, so this is the one device still reachable.

Match the parent's uevent instead. It carries the same string as HID_NAME, so the rule keeps using the "Wolf *virtual*" glob the input rules use.

The uhid devpath is the simpler match but it is far too broad. BlueZ creates every Bluetooth HID device through uhid. On the hidraw node a real DualSense looks like the virtual one: bus 0005, vendor 054C, product 0CE6, driver playstation, same modalias. Only HID_NAME differs. With both paired at once a devpath match takes the real controller as well and strips its ACL, which breaks gyro, touchpad, LEDs and battery reporting for a real pad on the host.

udev's * spans newlines, so the trailing glob can run past the end of the HID_NAME line. The next lines are HID_PHYS, HID_UNIQ and MODALIAS. None of them can contain "virtual".

Checked with a virtual and a real DualSense connected together. The virtual node ends up on seat9 with no user ACL, the real one keeps uaccess. scripts/wolf-input-diag.sh host reports the node as reachable by the desktop user before this and root-only after.