### PR TITLE
feat(input): fake-uinput shim for Steam Input in containers

### DIFF
--- a/85-wolf.rules
+++ b/85-wolf.rules
@@ -22,3 +22,13 @@ KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
 SUBSYSTEM=="input",  ATTR{name}=="Wolf *virtual*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
 SUBSYSTEMS=="input", ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
 KERNEL=="hidraw*",   ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+
+# Devices an app creates for itself inside a session container through the
+# fake-uinput shim (Steam Input makes its own pad that way). They reach the host
+# kernel and leak to the host seat like those above, but the name rules cannot
+# catch them: the app picks the name, and Steam's is "Microsoft X-Box 360 pad".
+# Renaming would break SDL's button mapping, which is looked up by name, so the
+# shim stamps phys instead and we match on that.
+# See https://games-on-whales.github.io/wolf/stable/dev/fake-uinput.html
+SUBSYSTEM=="input",  ATTR{phys}=="wolf-fake-uinput/*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+SUBSYSTEMS=="input", ATTRS{phys}=="wolf-fake-uinput/*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ add_subdirectory(src/gst-video-context)
 
 if (UNIX AND NOT APPLE)
     add_subdirectory(src/fake-udev)
+    add_subdirectory(src/fake-uinput)
 endif ()
 
 option(BUILD_MOONLIGHT "Build Moonlight server" ON)

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -21,6 +21,12 @@ export GST_GL_DRM_DEVICE=${GST_GL_DRM_DEVICE:-$WOLF_ENCODER_NODE}
 export WOLF_DOCKER_FAKE_UDEV_PATH=${WOLF_DOCKER_FAKE_UDEV_PATH:-$HOST_APPS_STATE_FOLDER/fake-udev}
 cp /wolf/fake-udev $WOLF_DOCKER_FAKE_UDEV_PATH
 
+# Publish the fake-uinput shim libs (64- and 32-bit) to the state folder so Wolf can auto-mount
+# them into session containers (see sessions/common.cpp). Mirrors the fake-udev copy above.
+mkdir -p "$HOST_APPS_STATE_FOLDER/fake-uinput/lib64" "$HOST_APPS_STATE_FOLDER/fake-uinput/lib32"
+cp /wolf/libfake-uinput.so    "$HOST_APPS_STATE_FOLDER/fake-uinput/lib64/libfake-uinput.so"
+cp /wolf/libfake-uinput-32.so "$HOST_APPS_STATE_FOLDER/fake-uinput/lib32/libfake-uinput.so"
+
 # Run PulseAudio and Wolf side by side under supervisord. PulseAudio lives
 # inside the Wolf container instead of the legacy "WolfPulseAudio" sidecar:
 # supervisord starts PA first, restarts it if it dies, and stops both cleanly

--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -67,9 +67,16 @@ RUN --mount=type=cache,target=/cache/ccache \
     -G Ninja && \
     ninja -C $CMAKE_BUILD_DIR wolf && \
     ninja -C $CMAKE_BUILD_DIR fake-udev && \
+    ninja -C $CMAKE_BUILD_DIR fake_uinput && \
     # We have to copy out the built executables because this will only be available inside the buildkit cache
     cp $CMAKE_BUILD_DIR/src/moonlight-server/wolf /wolf/wolf && \
-    cp $CMAKE_BUILD_DIR/src/fake-udev/fake-udev /wolf/fake-udev
+    cp $CMAKE_BUILD_DIR/src/fake-udev/fake-udev /wolf/fake-udev && \
+    cp $CMAKE_BUILD_DIR/src/fake-uinput/libfake-uinput.so /wolf/libfake-uinput.so
+
+# Build the 32-bit fake-uinput shim too: Steam's client is 32-bit and LD_PRELOADs into that process.
+# The shim has no dependencies beyond libc/libdl/libstdc++, so a direct multilib compile is enough.
+RUN apt-get update && apt-get install -y --no-install-recommends g++-multilib && \
+    g++ -m32 -shared -fPIC -O2 -std=c++17 -o /wolf/libfake-uinput-32.so /wolf/src/fake-uinput/fake-uinput.cpp
 
 ########################################################
 FROM $BASE_IMAGE AS runner
@@ -120,6 +127,8 @@ ENV WOLF_CFG_FOLDER=/etc/wolf/cfg
 
 COPY --from=wolf-builder /wolf/wolf /wolf/wolf
 COPY --from=wolf-builder /wolf/fake-udev /wolf/fake-udev
+COPY --from=wolf-builder /wolf/libfake-uinput.so /wolf/libfake-uinput.so
+COPY --from=wolf-builder /wolf/libfake-uinput-32.so /wolf/libfake-uinput-32.so
 
 ENV GST_GL_API=gles2 \
     GST_GL_PLATFORM=egl \

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -20,6 +20,7 @@
 ** xref:dev:gstreamer.adoc[]
 ** xref:dev:wayland.adoc[]
 ** xref:dev:fake-udev.adoc[]
+** xref:dev:fake-uinput.adoc[]
 
 ** xref:protocols:index.adoc[]
 *** xref:protocols:http-pairing.adoc[]

--- a/docs/modules/dev/pages/fake-uinput.adoc
+++ b/docs/modules/dev/pages/fake-uinput.adoc
@@ -1,0 +1,87 @@
+= Faking uinput in Docker
+
+xref:fake-udev.adoc[fake-udev] lets Wolf hot-plug the virtual devices _it_ creates into a running
+container. Here we want the opposite: to let an application _inside_ a container create its own
+`uinput` devices. The usual case is
+https://partner.steamgames.com/doc/features/steam_controller/steam_input_gamepad_emulation_bestpractices[Steam Input],
+which grabs a controller and re-exposes a remapped virtual pad through `/dev/uinput`.
+
+== The problem
+
+Our session containers are unprivileged: `/dev` is a fresh `tmpfs`, the container lives in its own
+network namespace, and it isn't granted the capabilities to create device nodes. So when an app opens
+`/dev/uinput` and issues `UI_DEV_CREATE`:
+
+* there is no `/dev/uinput` in the container to begin with; and
+* even if there were, the node the kernel creates would never show up in the container's `tmpfs`
+  `/dev`, and no udev event would reach the container's network namespace footnote:[The very same
+  reasons xref:fake-udev.adoc[fake-udev] has to exist.].
+
+== Let Wolf do the privileged part
+
+The idea is to keep the container unprivileged and let Wolf, on the host, do the bits that actually
+need privilege, reusing the machinery it already has for its own virtual pads.
+
+An app opts in by setting `WOLF_FAKE_UINPUT=1` in its runner `env` footnote:[An env var rather than a
+dedicated field on purpose: it is one of the few runner fields that round-trips faithfully through
+every client (including wolf-ui, which rebuilds the runner from a typed model and would drop an
+unknown field), and it matches how `GOW_REQUIRED_DEVICES` and `RUN_SWAY` are already configured.].
+For those apps Wolf injects a small `LD_PRELOAD` shim (`src/fake-uinput`) that intercepts only
+`ioctl(fd, UI_DEV_CREATE)` and `UI_DEV_DESTROY`; everything else is passed straight through. On
+create the shim resolves the new device's sysfs name (`UI_GET_SYSNAME`) and tells Wolf about it over
+the control socket.
+
+.The endpoints the shim calls
+[source]
+....
+POST /api/v1/runtime/plug-udev-device     {"session_id": ..., "sysfs_name": "input42"}
+POST /api/v1/runtime/unplug-udev-device   {"session_id": ..., "sysfs_name": "input42"}
+....
+
+Wolf reads the device from sysfs and hands it to the same code path it uses for its own pads: `mknod`
+the node into the right container and broadcast the udev event through fake-udev. The container is
+given the real `/dev/uinput` so the app can create the device, but Wolf does everything else, so no
+`CAP_MKNOD` and no `/dev/input` bind-mount.
+
+[plantuml,format=svg]
+....
+title: Steam Input creating a pad inside a container
+autonumber
+
+participant App as "App (Steam)"
+participant Shim as "fake-uinput shim"
+participant uinput as "/dev/uinput (host kernel)"
+participant Wolf as Wolf
+participant Runner as "docker runner"
+
+App->uinput: open + UI_DEV_CREATE
+Shim->uinput: (passthrough) real device created on host
+Shim->Wolf: POST plug-udev-device {session_id, sysfs_name}
+Wolf->Runner: PlugDeviceEvent
+Runner->App: mknod node in container + fake-udev "add"
+App->App: game opens /dev/input/eventX
+....
+
+The relevant code is `src/fake-uinput` (the shim), `api/fake_uinput.hpp` (sysfs -> `PlugDeviceEvent`),
+and the injection in `sessions/common.cpp`.
+
+== Security
+
+Handing a container the host's real `/dev/uinput` is a deliberate trade-off: a process in the
+container creates devices in the *host* kernel, so a virtual keyboard or pointer created this way
+appears on the host and could inject input into the host session footnote:[The escape vector raised
+upstream in https://github.com/games-on-whales/wolf/issues/81[#81].]. It is opt-in per app
+(`WOLF_FAKE_UINPUT=1`) and off by default, which bounds the exposure to apps the operator has
+explicitly enabled.
+
+Those devices are kept off the host's `seat0` the same way Wolf's own virtual devices are. The name
+rules in `85-wolf.rules` cannot match them: the app picks the device name, and Steam Input calls its
+pad `Microsoft X-Box 360 pad`. Renaming it would break SDL, which looks controllers up by name to
+choose a button mapping. Instead the shim sets `phys` to `wolf-fake-uinput/0` (a `UI_SET_PHYS` before
+the `UI_DEV_CREATE` it is already intercepting), and `85-wolf.rules` matches on that, parking the
+device on the dead `seat9` and stripping its `uaccess` ACL.
+
+That covers devices the shim knows about. A process in the container still holds the real `/dev/uinput`
+and could create a device by some other route, so this is a narrowing rather than a boundary. The fully
+isolated alternative, never exposing the real device and emulating `uinput` end to end (e.g. over CUSE),
+is heavier; this change trades that for a small, dependency-free implementation.

--- a/src/fake-uinput/CMakeLists.txt
+++ b/src/fake-uinput/CMakeLists.txt
@@ -1,0 +1,18 @@
+# fake-uinput: LD_PRELOAD shim that lets containerized apps (e.g. Steam Input) create uinput
+# devices in an unprivileged Wolf session container. It intercepts ioctl(UI_DEV_CREATE/DESTROY)
+# and notifies Wolf over the control socket; Wolf performs the privileged mknod + fake-udev.
+# Structure mirrors src/fake-udev. Build 64-bit here; the 32-bit variant is built directly in the
+# Dockerfile (Steam's client is 32-bit) since the shim has no dependencies beyond libc/libdl.
+option(BUILD_FAKE_UINPUT "Build fake-uinput shim library" ON)
+if (BUILD_FAKE_UINPUT)
+    message(STATUS "Building fake-uinput")
+
+    add_library(fake_uinput SHARED fake-uinput.cpp)
+    add_library(fake-uinput::lib ALIAS fake_uinput)
+
+    target_compile_features(fake_uinput PRIVATE cxx_std_17)
+    target_link_libraries(fake_uinput PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(fake_uinput PROPERTIES OUTPUT_NAME "fake-uinput")
+    # The 32-bit build is produced directly in docker/wolf.Dockerfile with `g++ -m32` (the shim is a
+    # single dependency-free TU) rather than via a multilib CMake toolchain, to keep this build simple.
+endif ()

--- a/src/fake-uinput/fake-uinput.cpp
+++ b/src/fake-uinput/fake-uinput.cpp
@@ -2,12 +2,12 @@
 // unprivileged session containers -- the typical case being Steam Input. It hooks only
 // ioctl(UI_DEV_CREATE / UI_DEV_DESTROY); everything else passes straight through, so Wolf's own
 // virtual controllers are untouched. It does no privileged work itself: on create/destroy it
-// notifies Wolf over the control socket (HTTP over the AF_UNIX socket at $WOLF_SOCKET_PATH), and
+// notifies Wolf over the AF_UNIX socket at $WOLF_FAKE_UINPUT_SOCKET, and
 // Wolf does the mknod + fake-udev on the host via the same path it uses for its own virtual pads.
 // So the container needs no privilege, not even CAP_MKNOD.
 //
 // Wolf sets these in the container's env:
-//   WOLF_SOCKET_PATH  - the wolf.sock control API
+//   WOLF_FAKE_UINPUT_SOCKET - Wolf's restricted device plug/unplug socket
 //   WOLF_SESSION_ID   - identifies the session so Wolf injects into the right container
 //
 // Built 64- and 32-bit (Steam's client is 32-bit); both are LD_PRELOAD'd and the loader skips the
@@ -89,9 +89,9 @@ static std::string json_escape(const std::string &s) {
 // Minimal HTTP/1.1 POST over the AF_UNIX control socket. Returns the numeric status
 // (e.g. 200) or -1 on transport failure. Short timeouts so a wedged Wolf never blocks Steam.
 static int wolf_post(const std::string &path, const std::string &body) {
-  const char *sock = getenv("WOLF_SOCKET_PATH");
+  const char *sock = getenv("WOLF_FAKE_UINPUT_SOCKET");
   if (!sock || !*sock) {
-    logline("WARN WOLF_SOCKET_PATH unset; cannot notify Wolf");
+    logline("WARN WOLF_FAKE_UINPUT_SOCKET unset; cannot notify Wolf");
     return -1;
   }
   int fd = socket(AF_UNIX, SOCK_STREAM, 0);

--- a/src/fake-uinput/fake-uinput.cpp
+++ b/src/fake-uinput/fake-uinput.cpp
@@ -1,0 +1,207 @@
+// fake-uinput: an LD_PRELOAD shim that lets an app create its own uinput devices inside Wolf's
+// unprivileged session containers -- the typical case being Steam Input. It hooks only
+// ioctl(UI_DEV_CREATE / UI_DEV_DESTROY); everything else passes straight through, so Wolf's own
+// virtual controllers are untouched. It does no privileged work itself: on create/destroy it
+// notifies Wolf over the control socket (HTTP over the AF_UNIX socket at $WOLF_SOCKET_PATH), and
+// Wolf does the mknod + fake-udev on the host via the same path it uses for its own virtual pads.
+// So the container needs no privilege, not even CAP_MKNOD.
+//
+// Wolf sets these in the container's env:
+//   WOLF_SOCKET_PATH  - the wolf.sock control API
+//   WOLF_SESSION_ID   - identifies the session so Wolf injects into the right container
+//
+// Built 64- and 32-bit (Steam's client is 32-bit); both are LD_PRELOAD'd and the loader skips the
+// wrong-arch one. See docs/modules/dev/pages/fake-uinput.adoc.
+
+#include <cerrno>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <dlfcn.h>
+#include <linux/uinput.h>
+#include <string>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#define SYS_INPUT_DIR "/sys/devices/virtual/input/"
+#define PLUG_PATH "/api/v1/runtime/plug-udev-device"
+#define UNPLUG_PATH "/api/v1/runtime/unplug-udev-device"
+
+// Stamped on every device the shim creates so 85-wolf.rules can find them. The app picks the device
+// NAME (Steam Input calls its pad "Microsoft X-Box 360 pad"), so the "Wolf *virtual*" name rules do
+// not match these, and renaming is not an option: SDL looks controllers up by name to pick a button
+// mapping. phys is free for us to use, and udev matches it with ATTRS{phys}.
+#define SHIM_PHYS "wolf-fake-uinput/0"
+
+typedef int (*ioctl_t)(int, unsigned long, ...);
+static ioctl_t real_ioctl = nullptr;
+
+static bool load_library() {
+  real_ioctl = reinterpret_cast<ioctl_t>(dlsym(RTLD_NEXT, "ioctl"));
+  return real_ioctl != nullptr;
+}
+
+// pure C stdio -- safe from an LD_PRELOAD constructor (before libstdc++ iostreams exist)
+static void logline(const std::string &msg) {
+  char ts[32] = "?";
+  struct timespec tp {};
+  clock_gettime(CLOCK_REALTIME, &tp);
+  time_t t = tp.tv_sec;
+  struct tm tm {};
+  if (gmtime_r(&t, &tm))
+    strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm);
+  char comm[64] = "";
+  if (FILE *cf = fopen("/proc/self/comm", "r")) {
+    if (fgets(comm, sizeof(comm), cf)) {
+      size_t l = strlen(comm);
+      if (l && comm[l - 1] == '\n')
+        comm[l - 1] = '\0';
+    }
+    fclose(cf);
+  }
+  char hdr[160];
+  snprintf(hdr, sizeof(hdr), "%s [fake-uinput] pid=%d (%s) ", ts, (int)getpid(), comm);
+  // Always log to stderr (captured in the container logs). Optionally also append to a file when
+  // FAKE_UINPUT_LOG points at one -- useful for debugging, off by default (no hardcoded paths).
+  if (const char *lp = getenv("FAKE_UINPUT_LOG")) {
+    if (FILE *f = fopen(lp, "a")) {
+      fprintf(f, "%s%s\n", hdr, msg.c_str());
+      fclose(f);
+    }
+  }
+  fprintf(stderr, "%s%s\n", hdr, msg.c_str());
+}
+
+static std::string json_escape(const std::string &s) {
+  std::string o;
+  for (char c : s) {
+    if (c == '"' || c == '\\')
+      o += '\\';
+    o += c;
+  }
+  return o;
+}
+
+// Minimal HTTP/1.1 POST over the AF_UNIX control socket. Returns the numeric status
+// (e.g. 200) or -1 on transport failure. Short timeouts so a wedged Wolf never blocks Steam.
+static int wolf_post(const std::string &path, const std::string &body) {
+  const char *sock = getenv("WOLF_SOCKET_PATH");
+  if (!sock || !*sock) {
+    logline("WARN WOLF_SOCKET_PATH unset; cannot notify Wolf");
+    return -1;
+  }
+  int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0)
+    return -1;
+  struct timeval tv {};
+  tv.tv_sec = 2;
+  tv.tv_usec = 0;
+  setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+  setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+  struct sockaddr_un addr {};
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, sock, sizeof(addr.sun_path) - 1);
+  if (connect(fd, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) != 0) {
+    logline(std::string("WARN connect(") + sock + ") failed: " + strerror(errno));
+    close(fd);
+    return -1;
+  }
+
+  std::string req = "POST " + path +
+                    " HTTP/1.1\r\n"
+                    "Host: localhost\r\n"
+                    "Content-Type: application/json\r\n"
+                    "Content-Length: " +
+                    std::to_string(body.size()) +
+                    "\r\n"
+                    "Connection: close\r\n\r\n" +
+                    body;
+
+  size_t off = 0;
+  while (off < req.size()) {
+    ssize_t w = write(fd, req.data() + off, req.size() - off);
+    if (w <= 0) {
+      close(fd);
+      return -1;
+    }
+    off += (size_t)w;
+  }
+
+  // Parse just the status code from "HTTP/1.1 <code> ..."
+  char buf[256] = {0};
+  ssize_t n = read(fd, buf, sizeof(buf) - 1);
+  close(fd);
+  if (n <= 0)
+    return -1;
+  int code = -1;
+  if (strncmp(buf, "HTTP/1.", 7) == 0) {
+    const char *sp = strchr(buf, ' ');
+    if (sp)
+      code = atoi(sp + 1);
+  }
+  return code;
+}
+
+static void notify(const std::string &path, const std::string &sysname) {
+  const char *sid = getenv("WOLF_SESSION_ID");
+  std::string body = std::string("{\"session_id\":\"") + json_escape(sid ? sid : "") + "\",\"sysfs_name\":\"" +
+                     json_escape(sysname) + "\"}";
+  int code = wolf_post(path, body);
+  // Log failures always; a successful plug/unplug only under FAKE_UINPUT_DEBUG (Steam creates and
+  // tears down its pad on every focus change, so per-event logging would be very noisy otherwise).
+  const char *dbg = getenv("FAKE_UINPUT_DEBUG");
+  if (code != 200 || (dbg && dbg[0] == '1'))
+    logline(std::string(path == PLUG_PATH ? "plug" : "unplug") + " sysfs=" + sysname +
+            " session=" + (sid ? sid : "(unset)") + " -> wolf http=" + std::to_string(code));
+}
+
+static bool get_sysname(int fd, char *out, size_t cap) {
+  // out must be prefilled with SYS_INPUT_DIR; we append the sysname after it.
+  size_t pfx = strlen(SYS_INPUT_DIR);
+  return real_ioctl(fd, UI_GET_SYSNAME(cap - pfx), out + pfx) != -1;
+}
+
+extern "C" int ioctl(int fd, unsigned long request, ...) {
+  if (!real_ioctl && !load_library())
+    return -1;
+
+  va_list args;
+  va_start(args, request);
+  void *arg = va_arg(args, void *);
+  va_end(args);
+
+  // For DESTROY, resolve the sysname BEFORE the real ioctl (it's gone afterwards).
+  char destroy_buf[sizeof(SYS_INPUT_DIR) + 64] = SYS_INPUT_DIR;
+  bool have_destroy = false;
+  if (request == UI_DEV_DESTROY)
+    have_destroy = get_sysname(fd, destroy_buf, sizeof(destroy_buf));
+
+  // Has to happen before the device exists, so it is set here rather than after the create below.
+  // A failure is not fatal: the device still works, it just will not be caught by the udev rule.
+  if (request == UI_DEV_CREATE && real_ioctl(fd, UI_SET_PHYS, (void *)SHIM_PHYS) < 0)
+    logline(std::string("WARN UI_SET_PHYS failed: ") + strerror(errno));
+
+  int result = real_ioctl(fd, request, arg);
+
+  if (result >= 0 && request == UI_DEV_CREATE) {
+    char buf[sizeof(SYS_INPUT_DIR) + 64] = SYS_INPUT_DIR;
+    if (get_sysname(fd, buf, sizeof(buf)))
+      notify(PLUG_PATH, buf + strlen(SYS_INPUT_DIR));
+    else
+      logline("UI_DEV_CREATE but UI_GET_SYSNAME failed");
+  } else if (result >= 0 && request == UI_DEV_DESTROY && have_destroy) {
+    notify(UNPLUG_PATH, destroy_buf + strlen(SYS_INPUT_DIR));
+  }
+
+  return result;
+}
+
+__attribute__((constructor)) static void on_load() {
+  if (const char *d = getenv("FAKE_UINPUT_DEBUG"); d && d[0] == '1')
+    logline("shim loaded (wolf-native)");
+}

--- a/src/moonlight-server/api/api.cpp
+++ b/src/moonlight-server/api/api.cpp
@@ -5,6 +5,7 @@
 #include <helpers/utils.hpp>
 #include <memory>
 #include <rfl/json.hpp>
+#include <sys/stat.h>
 
 namespace wolf::api {
 
@@ -19,6 +20,20 @@ void start_server(std::string_view runtime_dir, immer::box<state::AppState> app_
   boost::asio::io_context io_context;
   UnixSocketServer server(io_context, socket_path, app_state);
   auto server_ptr = std::make_shared<UnixSocketServer>(server);
+
+  // Session containers get this one instead of wolf.sock: it only serves the device plug/unplug
+  // endpoints, so an app that can reach it still can't drive the rest of Wolf.
+  auto runtime_socket_path = std::filesystem::path(runtime_dir) / "wolf-runtime.sock";
+  ::unlink(runtime_socket_path.c_str());
+  logs::log(logs::info, "Starting Wolf session runtime API on {}", runtime_socket_path.string());
+  UnixSocketServer runtime_server(io_context, runtime_socket_path, app_state, ApiSurface::SessionRuntime);
+  // Session containers run as whatever run_uid the app is configured with, and connecting to a unix
+  // socket needs write permission on it. Wolf runs as root, so without this only root could reach
+  // it. Safe here in a way it wouldn't be for wolf.sock: this socket serves two endpoints, and both
+  // only act on devices. Same reasoning as the PulseAudio socket next to it.
+  if (::chmod(runtime_socket_path.c_str(), 0666) != 0) {
+    logs::log(logs::warning, "Unable to chmod {}: {}", runtime_socket_path.string(), strerror(errno));
+  }
 
   auto global_ev_handler = app_state->event_bus->register_global_handler([server_ptr](events::EventsVariant ev) {
     std::visit(

--- a/src/moonlight-server/api/api.cpp
+++ b/src/moonlight-server/api/api.cpp
@@ -29,6 +29,18 @@ void start_server(std::string_view runtime_dir, immer::box<state::AppState> app_
         ev);
   });
 
+  // Release any fake-uinput devices still recorded for a session or lobby that tears down, so an
+  // unplug that never arrives (app killed) doesn't leave entries behind.
+  auto stop_stream_handler = app_state->event_bus->register_handler<immer::box<events::StopStreamEvent>>(
+      [server_ptr](const immer::box<events::StopStreamEvent> &ev) {
+        server_ptr->purge_fake_uinput_devices(std::to_string(ev->session_id));
+      });
+
+  auto stop_lobby_handler = app_state->event_bus->register_handler<immer::box<events::StopLobbyEvent>>(
+      [server_ptr](const immer::box<events::StopLobbyEvent> &ev) {
+        server_ptr->purge_fake_uinput_devices(ev->lobby_id);
+      });
+
   io_context.run();
 }
 

--- a/src/moonlight-server/api/api.hpp
+++ b/src/moonlight-server/api/api.hpp
@@ -175,6 +175,15 @@ struct DockerPullImageResponse {
   bool success = true;
 };
 
+/**
+ * Request sent by the in-container fake-uinput shim when an app (e.g. Steam Input)
+ * creates or destroys a uinput device inside a session container.
+ */
+struct UdevDeviceRequest {
+  rfl::Description<"The Wolf session id this device belongs to (from $WOLF_SESSION_ID)", std::string> session_id;
+  rfl::Description<"The sysfs name of the created uinput device, e.g. 'input82'", std::string> sysfs_name;
+};
+
 struct UnixSocket {
   boost::asio::local::stream_protocol::socket socket;
   bool is_alive = true;
@@ -189,6 +198,10 @@ public:
   UnixSocketServer(const UnixSocketServer &) = default;
 
   void broadcast_event(const std::string &event_type, const std::string &event_json);
+
+  /// Drop any fake-uinput devices still recorded for a session/lobby that has torn down, so the
+  /// plugged_devices map can't grow unbounded when an unplug is never received (e.g. app killed).
+  void purge_fake_uinput_devices(const std::string &session_id);
 
 private:
   void endpoint_Events(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
@@ -226,6 +239,9 @@ private:
   void endpoint_DockerInspectImage(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_DockerPullImage(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
 
+  void endpoint_PlugUdevDevice(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
+  void endpoint_UnplugUdevDevice(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
+
   void sse_broadcast(const std::string &payload);
   void sse_keepalive(const boost::system::error_code &e);
 
@@ -255,6 +271,11 @@ private:
     std::vector<std::shared_ptr<UnixSocket>> sockets;
     HTTPServer<std::shared_ptr<UnixSocket>> http;
     boost::asio::steady_timer sse_keepalive_timer;
+
+    // Remembers uinput devices plugged on behalf of the in-container fake-uinput shim, so an
+    // unplug (when the device is already gone from sysfs) can replay the exact same udev nodes.
+    // Keyed by session id, then by sysfs name.
+    immer::atom<immer::map<std::string, immer::map<std::string, events::PlugDeviceEvent>>> plugged_devices;
   };
 
   std::shared_ptr<UnixSocketState> state_;

--- a/src/moonlight-server/api/api.hpp
+++ b/src/moonlight-server/api/api.hpp
@@ -189,11 +189,22 @@ struct UnixSocket {
   bool is_alive = true;
 };
 
+/**
+ * Which endpoints a server instance serves. Full is the control API on wolf.sock; SessionRuntime
+ * only serves what a session container needs, so an app that is given that socket can't reach the
+ * rest of the API.
+ */
+enum class ApiSurface {
+  Full,
+  SessionRuntime
+};
+
 class UnixSocketServer {
 public:
   UnixSocketServer(boost::asio::io_context &io_context,
                    const std::string &socket_path,
-                   immer::box<state::AppState> app_state);
+                   immer::box<state::AppState> app_state,
+                   ApiSurface surface = ApiSurface::Full);
 
   UnixSocketServer(const UnixSocketServer &) = default;
 
@@ -241,6 +252,7 @@ private:
 
   void endpoint_PlugUdevDevice(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
   void endpoint_UnplugUdevDevice(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket);
+  void register_fake_uinput_endpoints();
 
   void sse_broadcast(const std::string &payload);
   void sse_keepalive(const boost::system::error_code &e);

--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -1,12 +1,92 @@
 #include <api/api.hpp>
+#include <api/fake_uinput.hpp>
 #include <control/input_handler.hpp>
 #include <core/docker.hpp>
+#include <optional>
 #include <rtp/udp-ping.hpp>
 #include <state/config.hpp>
 #include <state/sessions.hpp>
 #include <state/utils.hpp>
 
 namespace wolf::api {
+
+// The pure sysfs-parsing / device-classification / PlugDeviceEvent-building helpers live in
+// api/fake_uinput.hpp so they can be unit-tested (tests/testFakeUinput.cpp).
+
+void UnixSocketServer::endpoint_PlugUdevDevice(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
+  auto parsed = rfl::json::read<UdevDeviceRequest>(req.body);
+  if (!parsed) {
+    send_http(socket, 400, rfl::json::write(GenericErrorResponse{.error = parsed.error().what()}));
+    return;
+  }
+  const auto &r = parsed.value();
+  auto ev = fake_uinput::build_plug_event(r.session_id.value(), r.sysfs_name.value());
+  if (!ev) {
+    logs::log(logs::warning, "[API] plug-udev-device: no input nodes under sysfs {}", r.sysfs_name.value());
+    send_http(socket, 500, rfl::json::write(GenericErrorResponse{.error = "device not found in sysfs"}));
+    return;
+  }
+  state_->plugged_devices.update([&](const auto &devices) {
+    const auto *session = devices.find(r.session_id.value());
+    auto updated = (session ? *session : immer::map<std::string, events::PlugDeviceEvent>{});
+    return devices.set(r.session_id.value(), updated.set(r.sysfs_name.value(), *ev));
+  });
+  logs::log(logs::info,
+            "[API] fake-uinput: plugging {} node(s) from {} into session {}",
+            ev->udev_events.size(),
+            r.sysfs_name.value(),
+            r.session_id.value());
+  // Route to the correct runner. wolf-ui launches apps as lobbies, whose runner reads
+  // lobby->plugged_devices_queue directly (keyed by lobby id == WOLF_SESSION_ID) -- the event-bus
+  // PlugDeviceEvent handlers only route by *connected Moonlight session*, not lobby id, so we push
+  // straight to the queue. A direct (non-lobby) Moonlight session instead routes through the bus,
+  // keyed by its numeric session id (which is also its WOLF_SESSION_ID).
+  if (auto lobby = state::get_lobby_by_id(state_->app_state->lobbies->load(), r.session_id.value())) {
+    lobby->plugged_devices_queue->push(immer::box<events::PlugDeviceEvent>(*ev));
+  } else {
+    state_->app_state->event_bus->fire_event(immer::box<events::PlugDeviceEvent>(*ev));
+  }
+  send_http(socket, 200, rfl::json::write(GenericSuccessResponse{.success = true}));
+}
+
+void UnixSocketServer::endpoint_UnplugUdevDevice(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
+  auto parsed = rfl::json::read<UdevDeviceRequest>(req.body);
+  if (!parsed) {
+    send_http(socket, 400, rfl::json::write(GenericErrorResponse{.error = parsed.error().what()}));
+    return;
+  }
+  const auto &r = parsed.value();
+  const auto devices = state_->plugged_devices.load();
+  const auto *session = devices->find(r.session_id.value());
+  const auto *stored = session ? session->find(r.sysfs_name.value()) : nullptr;
+  if (!stored) { // nothing recorded (already gone / never plugged) -> idempotent success
+    send_http(socket, 200, rfl::json::write(GenericSuccessResponse{.success = true}));
+    return;
+  }
+  state_->plugged_devices.update([&](const auto &all) {
+    const auto *current = all.find(r.session_id.value());
+    if (!current) {
+      return all;
+    }
+    auto remaining = current->erase(r.sysfs_name.value());
+    return remaining.empty() ? all.erase(r.session_id.value()) : all.set(r.session_id.value(), remaining);
+  });
+  // docker.cpp's UnplugDeviceEvent handler flips ACTION to "remove" itself, so replay verbatim.
+  events::UnplugDeviceEvent un{.session_id = stored->session_id,
+                               .udev_events = stored->udev_events,
+                               .udev_hw_db_entries = stored->udev_hw_db_entries};
+  logs::log(logs::info,
+            "[API] fake-uinput: unplugging {} node(s) ({}) from session {}",
+            un.udev_events.size(),
+            r.sysfs_name.value(),
+            r.session_id.value());
+  state_->app_state->event_bus->fire_event(immer::box<events::UnplugDeviceEvent>(un));
+  send_http(socket, 200, rfl::json::write(GenericSuccessResponse{.success = true}));
+}
+
+void UnixSocketServer::purge_fake_uinput_devices(const std::string &session_id) {
+  state_->plugged_devices.update([&](const auto &all) { return all.erase(session_id); });
+}
 
 void UnixSocketServer::endpoint_Events(const HTTPRequest &req, std::shared_ptr<UnixSocket> socket) {
   // curl -N --unix-socket /tmp/wolf.sock http://localhost/api/v1/events

--- a/src/moonlight-server/api/fake_uinput.hpp
+++ b/src/moonlight-server/api/fake_uinput.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <events/events.hpp>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+/**
+ * Helpers for the fake-uinput runtime device injection (see api/endpoints.cpp and
+ * src/fake-uinput). Turns a uinput device that an app created inside a container -- known to Wolf
+ * only by its sysfs name -- into the PlugDeviceEvent that the docker runner consumes to mknod the
+ * node and broadcast the udev event.
+ *
+ * Extracted into a header so the pure parsing/classification logic can be unit-tested
+ * (tests/testFakeUinput.cpp).
+ */
+namespace wolf::api::fake_uinput {
+
+using namespace wolf::core; // for events::
+
+// Read an evdev capabilities bitmask sysfs file (space-separated 64-bit hex words, high group
+// first). Returns the words little-end first, i.e. index 0 holds bits 0..63.
+inline std::vector<uint64_t> read_caps(const std::filesystem::path &p) {
+  std::ifstream f(p);
+  std::vector<uint64_t> words;
+  std::string tok;
+  while (f >> tok)
+    words.push_back(std::strtoull(tok.c_str(), nullptr, 16));
+  std::reverse(words.begin(), words.end());
+  return words;
+}
+
+inline bool has_bit(const std::vector<uint64_t> &words, unsigned bit) {
+  return (bit / 64) < words.size() && ((words[bit / 64] >> (bit % 64)) & 1ULL);
+}
+
+// Classify a device from its sysfs capabilities: the /dev node doesn't exist yet when we run, so we
+// can't use EVIOCGBIT. This is a small subset of udev's input_id builtin, enough to set the
+// ID_INPUT_* property SDL/Steam look for. Returns nullptr for a plain, unclassified input device.
+inline const char *classify(const std::filesystem::path &input_dir, const std::string &node_name) {
+  constexpr unsigned BTN_JOYSTICK = 0x120, BTN_GAMEPAD = 0x130, KEY_A = 30, KEY_Z = 44, REL_X = 0x00, BTN_LEFT = 0x110;
+  if (node_name.rfind("js", 0) == 0)
+    return "ID_INPUT_JOYSTICK"; // js* is joydev -> a joystick by definition
+  auto key = read_caps(input_dir / "capabilities" / "key");
+  if (has_bit(key, BTN_GAMEPAD) || has_bit(key, BTN_JOYSTICK))
+    return "ID_INPUT_JOYSTICK";
+  if (has_bit(key, KEY_A) && has_bit(key, KEY_Z))
+    return "ID_INPUT_KEYBOARD";
+  if (has_bit(read_caps(input_dir / "capabilities" / "rel"), REL_X) && has_bit(key, BTN_LEFT))
+    return "ID_INPUT_MOUSE";
+  return nullptr;
+}
+
+// Build a PlugDeviceEvent for every event*/js* node of the device at
+// /sys/devices/virtual/input/<sysfs_name>. The field set mirrors gen_udev_base_event (uinput.hpp);
+// we can't reuse it directly because it stat()s the /dev node for major:minor and that node doesn't
+// exist yet, so we read major:minor from sysfs instead. Returns nullopt if nothing is found.
+inline std::optional<events::PlugDeviceEvent> build_plug_event(const std::string &session_id,
+                                                               const std::string &sysfs_name) {
+  auto input_dir = std::filesystem::path("/sys/devices/virtual/input") / sysfs_name;
+  std::error_code ec;
+  if (!std::filesystem::exists(input_dir, ec))
+    return std::nullopt;
+
+  const auto now = std::chrono::system_clock::now();
+  const auto usec = std::to_string(std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count());
+
+  events::PlugDeviceEvent ev{.session_id = session_id};
+  for (const auto &child : std::filesystem::directory_iterator(input_dir, ec)) {
+    if (!child.is_directory())
+      continue;
+    const auto name = child.path().filename().string();
+    if (name.rfind("event", 0) != 0 && name.rfind("js", 0) != 0)
+      continue;
+    std::ifstream df(child.path() / "dev");
+    unsigned int major = 0, minor = 0;
+    char sep = ':';
+    df >> major >> sep >> minor;
+    if (!major)
+      continue;
+    const std::string devnode = "/dev/input/" + name;
+    std::string devpath = child.path().string();
+    if (devpath.rfind("/sys", 0) == 0)
+      devpath.erase(0, 4); // udev DEVPATH is the sysfs path without the /sys prefix
+    const char *cls = classify(input_dir, name);
+
+    std::map<std::string, std::string> uev = {{"ACTION", "add"},
+                                              {"SEQNUM", "7"},
+                                              {"USEC_INITIALIZED", usec},
+                                              {"SUBSYSTEM", "input"},
+                                              {"ID_INPUT", "1"},
+                                              {"ID_SERIAL", "noserial"},
+                                              {"TAGS", ":seat:uaccess:"},
+                                              {"CURRENT_TAGS", ":seat:uaccess:"},
+                                              {"DEVNAME", devnode},
+                                              {"DEVPATH", devpath},
+                                              {"MAJOR", std::to_string(major)},
+                                              {"MINOR", std::to_string(minor)}};
+    if (cls)
+      uev[cls] = "1";
+    ev.udev_events.push_back(uev);
+
+    std::vector<std::string> hw = {"E:ID_INPUT=1"};
+    if (cls)
+      hw.push_back(std::string("E:") + cls + "=1");
+    hw.push_back("G:seat");
+    hw.push_back("G:uaccess");
+    ev.udev_hw_db_entries.push_back({"c" + std::to_string(major) + ":" + std::to_string(minor), hw});
+  }
+  if (ev.udev_events.empty())
+    return std::nullopt;
+  return ev;
+}
+
+} // namespace wolf::api::fake_uinput

--- a/src/moonlight-server/api/unix_socket_server.cpp
+++ b/src/moonlight-server/api/unix_socket_server.cpp
@@ -16,9 +16,16 @@ std::string to_str(boost::asio::streambuf &streambuf, std::size_t end) {
 
 UnixSocketServer::UnixSocketServer(boost::asio::io_context &io_context,
                                    const std::string &socket_path,
-                                   immer::box<state::AppState> app_state) {
+                                   immer::box<state::AppState> app_state,
+                                   ApiSurface surface) {
 
   state_ = std::make_shared<UnixSocketState>(io_context, app_state, socket_path);
+
+  if (surface == ApiSurface::SessionRuntime) {
+    register_fake_uinput_endpoints();
+    start_accept();
+    return;
+  }
 
   state_->http.add(HTTPMethod::GET,
                    "/api/v1/events",
@@ -321,8 +328,20 @@ UnixSocketServer::UnixSocketServer(boost::asio::io_context &io_context,
        .handler = [this](auto req, auto socket) { endpoint_DockerPullImage(req, socket); }});
 
   /**
-   * Runtime device injection (fake-uinput shim)
+   * OpenAPI schema
    */
+
+  state_->http.add(HTTPMethod::GET,
+                   "/api/v1/openapi-schema",
+                   {.summary = "Return this OpenAPI schema as JSON", .handler = [this](auto req, auto socket) {
+                      send_http(socket, 200, state_->http.openapi_schema());
+                    }});
+
+  state_->sse_keepalive_timer.async_wait([this](auto e) { sse_keepalive(e); });
+  start_accept();
+}
+
+void UnixSocketServer::register_fake_uinput_endpoints() {
   state_->http.add(
       HTTPMethod::POST,
       "/api/v1/runtime/plug-udev-device",
@@ -346,19 +365,6 @@ UnixSocketServer::UnixSocketServer(boost::asio::io_context &io_context,
        .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
                                 {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
        .handler = [this](auto req, auto socket) { endpoint_UnplugUdevDevice(req, socket); }});
-
-  /**
-   * OpenAPI schema
-   */
-
-  state_->http.add(HTTPMethod::GET,
-                   "/api/v1/openapi-schema",
-                   {.summary = "Return this OpenAPI schema as JSON", .handler = [this](auto req, auto socket) {
-                      send_http(socket, 200, state_->http.openapi_schema());
-                    }});
-
-  state_->sse_keepalive_timer.async_wait([this](auto e) { sse_keepalive(e); });
-  start_accept();
 }
 
 void UnixSocketServer::sse_keepalive(const boost::system::error_code &e) {

--- a/src/moonlight-server/api/unix_socket_server.cpp
+++ b/src/moonlight-server/api/unix_socket_server.cpp
@@ -321,6 +321,33 @@ UnixSocketServer::UnixSocketServer(boost::asio::io_context &io_context,
        .handler = [this](auto req, auto socket) { endpoint_DockerPullImage(req, socket); }});
 
   /**
+   * Runtime device injection (fake-uinput shim)
+   */
+  state_->http.add(
+      HTTPMethod::POST,
+      "/api/v1/runtime/plug-udev-device",
+      {.summary = "Plug a uinput device created inside a session container",
+       .description = "Called by the in-container fake-uinput LD_PRELOAD shim when an app (e.g. Steam Input) "
+                      "creates a uinput device. Wolf reads the device from sysfs, then mknod's the node into the "
+                      "right session container and broadcasts the udev event using the same privileged host-side "
+                      "path as its own virtual pads. This lets the container stay fully unprivileged.",
+       .request_description = APIDescription{.json_schema = rfl::json::to_schema<UdevDeviceRequest>()},
+       .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+       .handler = [this](auto req, auto socket) { endpoint_PlugUdevDevice(req, socket); }});
+
+  state_->http.add(
+      HTTPMethod::POST,
+      "/api/v1/runtime/unplug-udev-device",
+      {.summary = "Unplug a previously plugged uinput device",
+       .description = "Called by the fake-uinput shim on UI_DEV_DESTROY; replays the recorded udev nodes as a "
+                      "removal.",
+       .request_description = APIDescription{.json_schema = rfl::json::to_schema<UdevDeviceRequest>()},
+       .response_description = {{200, {.json_schema = rfl::json::to_schema<GenericSuccessResponse>()}},
+                                {500, {.json_schema = rfl::json::to_schema<GenericErrorResponse>()}}},
+       .handler = [this](auto req, auto socket) { endpoint_UnplugUdevDevice(req, socket); }});
+
+  /**
    * OpenAPI schema
    */
 

--- a/src/moonlight-server/events/events.hpp
+++ b/src/moonlight-server/events/events.hpp
@@ -58,6 +58,12 @@ struct Runner {
                    std::string_view render_node) = 0;
 
   virtual RunnerTypes serialize() const = 0;
+
+  // Whether Wolf should inject the fake-uinput shim (+ /dev/uinput + control socket) into this
+  // runner's container. Opt-in per app; only the docker runner overrides it.
+  virtual bool needs_fake_uinput() const {
+    return false;
+  }
 };
 
 struct App {

--- a/src/moonlight-server/runners/docker.cpp
+++ b/src/moonlight-server/runners/docker.cpp
@@ -43,6 +43,17 @@ void RunDocker::run(std::string_view session_id,
   std::vector<std::string> full_env;
   full_env.insert(full_env.end(), this->container.env.begin(), this->container.env.end());
   for (const auto &env_var : env_variables) {
+    // LD_PRELOAD is additive: if the app image/config already sets one, append ours (colon
+    // separated) instead of clobbering it (Wolf auto-injects the fake-uinput shim via LD_PRELOAD).
+    if (env_var.first == "LD_PRELOAD") {
+      auto existing = std::find_if(full_env.begin(), full_env.end(), [](const std::string &e) {
+        return e.rfind("LD_PRELOAD=", 0) == 0;
+      });
+      if (existing != full_env.end()) {
+        *existing += ":" + env_var.second;
+        continue;
+      }
+    }
     full_env.push_back(fmt::format("{}={}", env_var.first, env_var.second));
   }
 
@@ -192,6 +203,15 @@ void RunDocker::run(std::string_view session_id,
   if (auto docker_container = docker_api.create(new_container, final_json_opts)) {
     auto container_id = docker_container->id;
     docker_api.start_by_id(container_id);
+
+    // Let the unprivileged run user open an injected /dev/uinput: chown it to PUID:PGID, mode 0660
+    // (not world-writable). No-op when uinput wasn't injected.
+    docker_api.exec(
+        container_id,
+        {"/bin/sh",
+         "-c",
+         "[ -e /dev/uinput ] && chown \"${PUID:-0}:${PGID:-0}\" /dev/uinput && chmod 0660 /dev/uinput || true"},
+        "root");
 
     logs::log(logs::info, "[DOCKER] Starting container: {}", docker_container->name);
     logs::log(logs::debug, "[DOCKER] Starting container: {}", *docker_container);

--- a/src/moonlight-server/runners/docker.hpp
+++ b/src/moonlight-server/runners/docker.hpp
@@ -106,6 +106,15 @@ public:
         .base_create_json = base_create_json};
   }
 
+  bool needs_fake_uinput() const override {
+    // Opt-in marker in the runner env. env (not a new field) so it round-trips through every client,
+    // including wolf-ui, which rebuilds the runner from a typed model and would drop an unknown field.
+    for (const auto &e : container.env)
+      if (e == "WOLF_FAKE_UINPUT=1")
+        return true;
+    return false;
+  }
+
 protected:
   RunDocker(std::shared_ptr<events::EventBusType> ev_bus,
             std::string base_create_json,

--- a/src/moonlight-server/sessions/common.cpp
+++ b/src/moonlight-server/sessions/common.cpp
@@ -88,9 +88,19 @@ void start_runner(std::shared_ptr<events::Runner> runner,
     if (std::filesystem::exists("/dev/uinput"))
       all_devices.push_back("/dev/uinput");
 
-    mounted_paths.push_back(
-        {std::filesystem::path(args->host->host_xdg_runtime_dir) / "wolf.sock", "/var/run/wolf/wolf.sock"});
-    full_env.set("WOLF_SOCKET_PATH", "/var/run/wolf/wolf.sock");
+    // The restricted socket, not wolf.sock: the shim only needs plug/unplug. Bind mounting a path
+    // that doesn't exist yet makes the runtime create a directory there instead (see wolf#462), so
+    // check first and leave it out rather than handing the app a directory named like a socket.
+    auto runtime_sock = std::filesystem::path(args->host->host_xdg_runtime_dir) / "wolf-runtime.sock";
+    if (std::filesystem::is_socket(runtime_sock)) {
+      mounted_paths.push_back({runtime_sock, "/var/run/wolf/wolf-runtime.sock"});
+      full_env.set("WOLF_FAKE_UINPUT_SOCKET", "/var/run/wolf/wolf-runtime.sock");
+    } else {
+      logs::log(logs::warning,
+                "[FAKE-UINPUT] {} is not a socket, skipping: apps in this session won't be able to "
+                "create their own virtual devices",
+                runtime_sock.string());
+    }
   }
 
   /* Finally run the app, this will stop here until over */

--- a/src/moonlight-server/sessions/common.cpp
+++ b/src/moonlight-server/sessions/common.cpp
@@ -71,6 +71,28 @@ void start_runner(std::shared_ptr<events::Runner> runner,
       {std::filesystem::path(args->host->host_base_state_folder) / "fake-udev", "/usr/bin/fake-udev"});
   mounted_paths.push_back({std::filesystem::path(args->app_host_state_folder) / "udev", "/run/udev/"});
 
+  // Apps that opt in (WOLF_FAKE_UINPUT=1, see runners/docker.cpp) can create their own uinput
+  // devices (e.g. Steam Input): give them the fake-uinput shim, the real /dev/uinput and the control
+  // socket. The shim asks Wolf to do the privileged mknod + fake-udev, so the container stays
+  // otherwise unprivileged. See xref dev/fake-uinput.
+  if (runner->needs_fake_uinput()) {
+    // Preload the shim by bare soname, dropping each build into the matching multiarch dir so the
+    // loader resolves it per-arch from its default search path (Steam spawns both 32- and 64-bit
+    // processes). Not via LD_LIBRARY_PATH on purpose: that would override the app's own and break
+    // Steam's runtime. startup.sh ships the libs under <state>/fake-uinput, like fake-udev above.
+    auto fu_dir = std::filesystem::path(args->host->host_base_state_folder) / "fake-uinput";
+    mounted_paths.push_back({fu_dir / "lib64/libfake-uinput.so", "/usr/lib/x86_64-linux-gnu/libfake-uinput.so"});
+    mounted_paths.push_back({fu_dir / "lib32/libfake-uinput.so", "/usr/lib/i386-linux-gnu/libfake-uinput.so"});
+    full_env.set("LD_PRELOAD", "libfake-uinput.so");
+
+    if (std::filesystem::exists("/dev/uinput"))
+      all_devices.push_back("/dev/uinput");
+
+    mounted_paths.push_back(
+        {std::filesystem::path(args->host->host_xdg_runtime_dir) / "wolf.sock", "/var/run/wolf/wolf.sock"});
+    full_env.set("WOLF_SOCKET_PATH", "/var/run/wolf/wolf.sock");
+  }
+
   /* Finally run the app, this will stop here until over */
   runner->run(args->session_id,
               args->app_local_state_folder,

--- a/src/moonlight-server/state/default/config.v7.toml
+++ b/src/moonlight-server/state/default/config.v7.toml
@@ -137,6 +137,10 @@ env = [
     "PROTON_LOG=1",
     "RUN_SWAY=true",
     "GOW_REQUIRED_DEVICES=/dev/input/* /dev/dri/* /dev/nvidia*",
+    # Uncomment to let Steam Input create its own controllers. This gives the container
+    # /dev/uinput, so read https://games-on-whales.github.io/wolf/stable/dev/fake-uinput.html
+    # first and make sure 85-wolf.rules on the host is current.
+    # "WOLF_FAKE_UINPUT=1",
 ]
 devices = []
 ports = []

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRC_LIST
         testMoonlight.cpp
         testRTSP.cpp
         testWolfAPI.cpp
+        testFakeUinput.cpp
         testBatchedSend.cpp)
 
 option(TEST_RUST_WAYLAND "Test our custom Rust wayland compositor" ON)

--- a/tests/testFakeUinput.cpp
+++ b/tests/testFakeUinput.cpp
@@ -1,0 +1,58 @@
+#include <api/fake_uinput.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <fstream>
+#include <unistd.h>
+
+using namespace wolf::api::fake_uinput;
+namespace fs = std::filesystem;
+
+// Build a throwaway sysfs-style input dir with capabilities/{key,rel} files.
+static fs::path make_input_dir(const std::string &key_caps, const std::string &rel_caps = "") {
+  static int n = 0;
+  auto dir = fs::temp_directory_path() / ("fu-test-" + std::to_string(::getpid()) + "-" + std::to_string(n++));
+  fs::create_directories(dir / "capabilities");
+  std::ofstream(dir / "capabilities" / "key") << key_caps;
+  if (!rel_caps.empty())
+    std::ofstream(dir / "capabilities" / "rel") << rel_caps;
+  return dir;
+}
+
+TEST_CASE("fake-uinput read_caps / has_bit parse hex bitmasks", "[fake-uinput]") {
+  // Space-separated 64-bit hex words, high group first. "1<<48" in the 5th word == bit 0x130.
+  auto dir = make_input_dir("1000000000000 0 0 0 0");
+  auto caps = read_caps(dir / "capabilities" / "key");
+  REQUIRE(has_bit(caps, 0x130)); // BTN_GAMEPAD
+  REQUIRE_FALSE(has_bit(caps, 0x131));
+  REQUIRE_FALSE(has_bit(caps, 9999)); // out of range must not read OOB
+  fs::remove_all(dir);
+}
+
+TEST_CASE("fake-uinput classify from sysfs capabilities", "[fake-uinput]") {
+  SECTION("js* nodes are always joysticks (joydev, no evdev caps)") {
+    auto dir = make_input_dir("0");
+    const char *c = classify(dir, "js0");
+    REQUIRE(c != nullptr);
+    REQUIRE(std::string(c) == "ID_INPUT_JOYSTICK");
+    fs::remove_all(dir);
+  }
+  SECTION("BTN_GAMEPAD -> joystick") {
+    auto dir = make_input_dir("1000000000000 0 0 0 0");
+    const char *c = classify(dir, "event5");
+    REQUIRE(c != nullptr);
+    REQUIRE(std::string(c) == "ID_INPUT_JOYSTICK");
+    fs::remove_all(dir);
+  }
+  SECTION("KEY_A + KEY_Z -> keyboard") {
+    auto dir = make_input_dir("100040000000"); // bits 30 (KEY_A) and 44 (KEY_Z)
+    const char *c = classify(dir, "event6");
+    REQUIRE(c != nullptr);
+    REQUIRE(std::string(c) == "ID_INPUT_KEYBOARD");
+    fs::remove_all(dir);
+  }
+  SECTION("no recognized capabilities -> unclassified") {
+    auto dir = make_input_dir("0");
+    REQUIRE(classify(dir, "event7") == nullptr);
+    fs::remove_all(dir);
+  }
+}


### PR DESCRIPTION
Implements #81, picking up from #88.

## How it works

An app opts in with `WOLF_FAKE_UINPUT=1` in its runner env. The default config ships that line commented out, since an opted in container gets the real `/dev/uinput`.

For an opted in app Wolf preloads a shim (`src/fake-uinput`) that intercepts `ioctl(UI_DEV_CREATE / UI_DEV_DESTROY)` and posts the device to `POST /api/v1/runtime/{plug,unplug}-udev-device`. Wolf reads it back from sysfs and does the `mknod` plus fake-udev over its existing `PlugDeviceEvent` path, so the container never needs `CAP_MKNOD`. Only devices this session's shim created reach this session's container.

An env var rather than a config field so it survives the round trip through wolf-ui lobbies, like `GOW_REQUIRED_DEVICES` and `RUN_SWAY`. Docs in `docs/modules/dev/pages/fake-uinput.adoc`.

## Isolation

Devices the shim creates land on the host kernel, where logind would ACL them to the desktop user. The name rules in `85-wolf.rules` can't catch them because the app picks the name, and Steam Input calls its pad `Microsoft X-Box 360 pad`. Renaming breaks SDL, which maps controllers by name. So the shim stamps `phys` with `wolf-fake-uinput/0` before the `UI_DEV_CREATE` it already intercepts, and the rules match on that to park the device on `seat9` and strip the ACL.

This narrows the exposure without closing it. The container holds the real `/dev/uinput` and could create a device by another route, carrying no marker.

## Testing

`wolftests` passes on both compilers with `BUILD_SHARED_LIBS` on and off, including aarch64. New coverage in `tests/testFakeUinput.cpp`. `scripts/wolf-input-diag.sh` reports a shim created pad as reachable by the desktop user without the rule and root only with it. Ran a session with Steam Input on, gyro and per game bindings work, and the streamed pad doesn't reach the host desktop.

The shim is x86 only, since Steam needs a 32 bit build of it and that uses `-m32`.