### PR TITLE
fix(lobby): Controller lost when joining a running lobby.

### DIFF
--- a/docker/wolf.Dockerfile
+++ b/docker/wolf.Dockerfile
@@ -112,7 +112,6 @@ COPY docker/supervisord.conf /etc/supervisord.conf
 ENV GST_PLUGIN_PATH=/usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/
 # Copying out our custom compositor from the build stage
 COPY --from=wolf-builder /usr/local/lib/x86_64-linux-gnu/gstreamer-1.0/* $GST_PLUGIN_PATH
-COPY --from=wolf-builder /usr/local/lib/liblibgstwaylanddisplay* /usr/local/lib/
 
 WORKDIR /wolf
 

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -205,6 +205,28 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
           return;
         }
 
+        // Migrate joypads BEFORE adding the session to connected_sessions, or the relayed unplug races the queued plug
+        events::JoypadList joypads = session->joypads->load();
+        for (auto [_joypad_nr, joypad] : joypads) {
+          events::PlugDeviceEvent plug_ev{.session_id = lobby->id};
+          std::visit(
+              [&plug_ev](auto &pad) {
+                plug_ev.udev_events = pad.get_udev_events();
+                plug_ev.udev_hw_db_entries = pad.get_udev_hw_db_entries();
+              },
+              *joypad);
+          // Unplug it from the current session's runner
+          app_state->event_bus->fire_event(immer::box<events::UnplugDeviceEvent>{
+              events::UnplugDeviceEvent{.session_id = std::to_string(session->session_id),
+                                        .udev_events = plug_ev.udev_events,
+                                        .udev_hw_db_entries = plug_ev.udev_hw_db_entries}});
+
+          // Add it to the lobby runner's devices queue, addressed to the lobby id
+          // (same routing the PlugDeviceEvent relay performs for connected sessions)
+          lobby->plugged_devices_queue->push(immer::box<events::PlugDeviceEvent>{plug_ev});
+        }
+        // TODO: hotplug pen_tablet
+
         // Update the lobby with the new session
         lobby->connected_sessions->update([session](const immer::vector<immer::box<std::string>> &connected_sessions) {
           return connected_sessions.push_back({std::to_string(session->session_id)});
@@ -215,28 +237,6 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
         session->mouse->emplace(virtual_display::WaylandMouse(wl_state));
         session->keyboard->emplace(virtual_display::WaylandKeyboard(wl_state));
         session->touch_screen->emplace(virtual_display::WaylandTouchScreen(wl_state));
-
-        // Switch over all joypads present in the session into the lobby
-        events::JoypadList joypads = session->joypads->load();
-        for (auto [_joypad_nr, joypad] : joypads) {
-          events::PlugDeviceEvent plug_ev{.session_id = std::to_string(session->session_id)};
-          std::visit(
-              [&plug_ev](auto &pad) {
-                plug_ev.udev_events = pad.get_udev_events();
-                plug_ev.udev_hw_db_entries = pad.get_udev_hw_db_entries();
-              },
-              *joypad);
-          app_state->event_bus->fire_event(immer::box<events::PlugDeviceEvent>(plug_ev));
-          // Unplug it from the current session
-          app_state->event_bus->fire_event(immer::box<events::UnplugDeviceEvent>{
-              events::UnplugDeviceEvent{.session_id = std::to_string(session->session_id),
-                                        .udev_events = plug_ev.udev_events,
-                                        .udev_hw_db_entries = plug_ev.udev_hw_db_entries}});
-
-          // Add it to the current lobby devices queue
-          lobby->plugged_devices_queue->push(immer::box<events::PlugDeviceEvent>{plug_ev});
-        }
-        // TODO: hotplug pen_tablet
 
         // Switch audio/video gstreamer stream producers
         app_state->event_bus->fire_event(immer::box<events::SwitchStreamProducerEvents>{


### PR DESCRIPTION
Joining a lobby can leave the game container without a working controller. The pad still works in the Wolf UI session and first launches are always fine, but a few quit/rejoin cycles will reliably trigger it. The cause is that the join handler adds the session to connected_sessions before migrating its joypads, so the UnplugDeviceEvent meant for the old session's runner also gets relayed to the lobby runner, where it races the queued plug and can remove the device right after it was added.

I reordered the join to do what leave_lobby already does (migrate devices first, then register the session) and pointed the queued plug at the lobby id directly, which makes the old global plug event redundant.

The second commit fixes the runner stage COPY of liblibgstwaylanddisplay. cargo-c installs it into the libdir, not /usr/local/lib, so the build fails under podman/buildah. I needed that fix to build and test this locally.

Tested with 10 quit/rejoin cycles plus a force-close on the patched build, no failures. Stock loses the controller within a couple of joins (logs below).

**Logs:**

BEFORE (wolf:stable @ 7f416ec), same repro, two consecutive joins:

  join 1, controller survives (the relayed unplug happens to land before the queued plug):

    16:27:44.265185  [LOBBY] Unplug device for session 915...              // relayed unplug, misdirected at the lobby
    16:27:44.265911  [DOCKER] Plugging device from queue: 2c7fab99...      // plug lands last, pad works

  join 2, controller lost (queued plug drains first, the relay kills it 9ms later):

    16:28:28.511     [DOCKER] Plugging device from queue: 2c7fab99...      // pad plugged into lobby container
    16:28:28.520     [LOBBY] Unplug device for session 915...              // relayed unplug fires
    16:28:28.520     [DOCKER] Received UnplugDeviceEvent: 2c7fab99...      // pad removed from lobby container

AFTER (patched), every join looks like this:

    17:33:03.739     [LOBBY] Session 915... joining lobby d0df57f4...
    17:33:03.739     [DOCKER] Received UnplugDeviceEvent: 915...           // old session's container only
    17:33:03.852     [DOCKER] Plugging device from queue: d0df57f4...      // lobby plug, nothing racing it

11 joins total (10 quit/rejoin plus 1 extra where I force-closed the client). The "[LOBBY] Unplug device" relay line never shows up at join and the controller worked in game every time.