### PR TITLE
Update endpoints.cpp to randomly generate the client_cert instead of app_state_folder

### DIFF
--- a/src/moonlight-server/api/endpoints.cpp
+++ b/src/moonlight-server/api/endpoints.cpp
@@ -263,7 +263,7 @@ void UnixSocketServer::endpoint_StreamSessionAdd(const HTTPRequest &req, std::sh
       choosen_client = *client;
     } else {
       // Create a dummy client
-      choosen_client = {.client_cert = "", .app_state_folder = state::gen_uuid(), .settings = {}};
+      choosen_client = {.client_cert = state::gen_uuid(), .app_state_folder = "", .settings = {}};
     }
 
     choosen_client.settings = ss.client_settings.value_or(config::ClientSettings{});


### PR DESCRIPTION
This PR hopes to address https://github.com/games-on-whales/wolf/issues/484 to allow Fenrir to host multiple users at the same time, each user's session having a unique ID to join / leave lobbies with.  

comments:  
I think the `app_state_folder = state::gen_uuid()` might've previously been a dependency, but it appears to no longer be the case after I built and tested this locally.  