### PR TITLE
chore(vulkan): merge current stable into Vulkan image branch

### DIFF
--- a/85-wolf.rules
+++ b/85-wolf.rules
@@ -14,8 +14,8 @@ KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
 # the host desktop. See https://github.com/games-on-whales/wolf/issues/451
 #
 # We match on the "Wolf *virtual*" name glob: every device Wolf creates is named
-# "Wolf ... (virtual) ..." (or "Wolf mouse virtual device"), so this covers all
-# current and future sub-devices without matching unrelated "Wolf" hardware.
+# "Wolf ... (virtual) ...", so this covers all current and future sub-devices
+# without matching unrelated "Wolf" hardware.
 # We then (a) park them on the phantom seat9 and (b) strip the uaccess ACL. Both
 # the device's own name (ATTR, for uinput pads) and any ancestor's name (ATTRS,
 # for the uhid DualSense child devices and hidraw node) are matched.

--- a/85-wolf.rules
+++ b/85-wolf.rules
@@ -1,12 +1,8 @@
-# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad/keyboard/mouse)
+# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad)
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
 
 # Allows Wolf to access /dev/uhid (needed for DualSense emulation)
 KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
-
-# Move the virtual keyboard and mouse onto a phantom seat (seat9) so the host's
-# logged-in desktop user cannot read them.
-SUBSYSTEMS=="input", ATTRS{id/vendor}=="ab00", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9"
 
 # Wolf virtual controllers: the gamepads (Xbox / DualSense / Nintendo), the
 # DualSense's "Touchpad" and "Motion Sensors" child input devices, and the
@@ -17,11 +13,12 @@ SUBSYSTEMS=="input", ATTRS{id/vendor}=="ab00", MODE="0660", GROUP="input", ENV{I
 # desktop user an ACL (uaccess) on them, so the streamed controller also drives
 # the host desktop. See https://github.com/games-on-whales/wolf/issues/451
 #
-# We match on the "Wolf " name prefix (glob) so every current and future
-# sub-device is covered regardless of the exact product name, then (a) park them
-# on the phantom seat9 and (b) strip the uaccess ACL. Both the device's own name
-# (ATTR, for uinput pads) and any ancestor's name (ATTRS, for the uhid DualSense
-# child devices and hidraw node) are matched.
-SUBSYSTEM=="input",  ATTR{name}=="Wolf *",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf *", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-KERNEL=="hidraw*",   ATTRS{name}=="Wolf *", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+# We match on the "Wolf *virtual*" name glob: every device Wolf creates is named
+# "Wolf ... (virtual) ..." (or "Wolf mouse virtual device"), so this covers all
+# current and future sub-devices without matching unrelated "Wolf" hardware.
+# We then (a) park them on the phantom seat9 and (b) strip the uaccess ACL. Both
+# the device's own name (ATTR, for uinput pads) and any ancestor's name (ATTRS,
+# for the uhid DualSense child devices and hidraw node) are matched.
+SUBSYSTEM=="input",  ATTR{name}=="Wolf *virtual*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+KERNEL=="hidraw*",   ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"

--- a/85-wolf.rules
+++ b/85-wolf.rules
@@ -1,14 +1,27 @@
-# Allows Wolf to access /dev/uinput
-KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"
+# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad/keyboard/mouse)
+KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
 
-# Allows Wolf to access /dev/uhid
-KERNEL=="uhid", TAG+="uaccess"
+# Allows Wolf to access /dev/uhid (needed for DualSense emulation)
+KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
 
-# Move virtual keyboard and mouse into a different seat
+# Move the virtual keyboard and mouse onto a phantom seat (seat9) so the host's
+# logged-in desktop user cannot read them.
 SUBSYSTEMS=="input", ATTRS{id/vendor}=="ab00", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9"
 
-# Joypads
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf X-Box One (virtual) pad", MODE="0660", GROUP="input"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf PS5 (virtual) pad", MODE="0660", GROUP="input"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf gamepad (virtual) motion sensors", MODE="0660", GROUP="input"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf Nintendo (virtual) pad", MODE="0660", GROUP="input"
+# Wolf virtual controllers: the gamepads (Xbox / DualSense / Nintendo), the
+# DualSense's "Touchpad" and "Motion Sensors" child input devices, and the
+# DualSense /dev/hidraw* node.
+#
+# These are created by Wolf inside its container but appear as real devices in
+# the HOST kernel. Without these rules, logind grants the host's active-seat
+# desktop user an ACL (uaccess) on them, so the streamed controller also drives
+# the host desktop. See https://github.com/games-on-whales/wolf/issues/451
+#
+# We match on the "Wolf " name prefix (glob) so every current and future
+# sub-device is covered regardless of the exact product name, then (a) park them
+# on the phantom seat9 and (b) strip the uaccess ACL. Both the device's own name
+# (ATTR, for uinput pads) and any ancestor's name (ATTRS, for the uhid DualSense
+# child devices and hidraw node) are matched.
+SUBSYSTEM=="input",  ATTR{name}=="Wolf *",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Wolf *", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+KERNEL=="hidraw*",   ATTRS{name}=="Wolf *", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,151 @@
+## What Wolf is
+
+Wolf is a low-latency streaming server for [Moonlight](https://moonlight-stream.org/) that lets multiple
+remote clients share a single Linux host to play games. Each client gets an on-demand virtual desktop
+(Wayland compositor, no physical monitor needed) whose apps run in isolated Docker/Podman containers.
+It implements the Moonlight protocol (pairing over HTTPS, RTSP handshake, ENet control channel, RTP
+video/audio) and hands video/audio off to GStreamer pipelines. Linux + Docker first; C++20.
+
+## Companion repositories
+
+Wolf is split across three repos; the other two are integral and pulled in at build time — when
+touching virtual input or virtual-display behavior, the real implementation often lives there:
+
+- **[games-on-whales/inputtino](https://github.com/games-on-whales/inputtino)** — virtual input device
+  library (`uinput`/`uhid`). Wolf uses it for gamepads (incl. gyro/accel) and pen/touch; mouse and
+  keyboard don't go through it (see Architecture). Surfaced via `src/core/.../input.hpp`.
+- **[games-on-whales/gst-wayland-display](https://github.com/games-on-whales/gst-wayland-display)** —
+  the custom micro Wayland compositor (Rust, built on [Smithay](https://github.com/Smithay/smithay);
+  we track a fork at [games-on-whales/smithay](https://github.com/games-on-whales/smithay)). Creates
+  on-demand desktops and exposes the raw framebuffer as a GStreamer plugin + C API. Installed as
+  `libgstwaylanddisplay` (surfaced via `src/core/.../virtual-display.hpp`); its `.so` must be on
+  `GST_PLUGIN_PATH` at runtime and to run the tests.
+
+Prebuilt guest-app containers live in [games-on-whales/gow](https://github.com/games-on-whales/gow).
+
+## Build & test
+
+Two supported paths, both documented in `docs/modules/dev/pages/manual_build.adoc`:
+
+- **Devcontainer (recommended)** — `docker/wolf.Dockerfile` target `wolf-builder` via `.devcontainer/`,
+  so you build in the exact environment of the official image with all deps preinstalled (VS Code:
+  *Dev Containers: Clone Repository in Container Volume*, pick the Clang kit).
+- **Manual host build** — build Wolf outside Docker (Docker must still be installed for Wolf to do
+  anything useful). The doc covers building GStreamer and `gst-wayland-display` from source, apt deps,
+  the required `LD_LIBRARY_PATH`/`PKG_CONFIG_PATH`/etc. env, and a `runwolf.sh` template of `WOLF_*`
+  runtime vars.
+
+Most C++ deps are fetched at configure time via CMake `FetchContent` (fmt, tomlplusplus, reflect-cpp,
+eventbus, Catch2, immer, boost via `BoostLoader`); system libs still needed include Boost, GStreamer,
+Wayland, libinput, libevdev, libudev, OpenSSL, PulseAudio, libdrm, libpci.
+
+```bash
+# Configure (matches CI). CI uses C++20; manual_build.adoc still shows 17 — prefer 20.
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=20 -DCATCH_DEVELOPMENT_BUILD=ON
+
+ninja -C build wolf         # server binary → build/src/moonlight-server/wolf
+ninja -C build wolftests    # test suite (Catch2)
+cd build/tests && ./wolftests
+```
+
+Run a single test / subset with Catch2 selectors: `./wolftests "test name"`, `-c "section"`,
+`"[tag]"`, or `--list-tests`. Tests need `HOST_APPS_STATE_FOLDER`, `GST_PLUGIN_PATH` (where
+`libgstwaylanddisplay` is installed), `XDG_RUNTIME_DIR`, and `RUST_LOG` set (see the `test` job in
+`.github/workflows/linux-build-test.yml`).
+
+Hardware/environment-dependent tests are gated by CMake options so CI can skip what a runner lacks:
+`TEST_DOCKER`, `TEST_NVIDIA`, `TEST_VIRTUAL_INPUT`, `TEST_UHID`, `TEST_RUST_WAYLAND`, `TEST_EXCEPTIONS`,
+`TEST_SDL`. CI runs a g++/clang matrix with `BUILD_SHARED_LIBS` both ON and OFF — keep both working.
+
+C++ is auto-formatted with clang-format (`.clang-format`, 120 col) and enforced in CI; run
+`clang-format -i` on changed files before committing. `.clang-tidy` is also present.
+
+## Architecture
+
+**Style (deliberate, per the original author):** functional — no global state, side effects avoided,
+immutable inputs → new outputs. Shared/persistent state lives in [immer](https://github.com/arximboldi/immer)
+persistent containers wrapped in `immer::atom<...>` (e.g. `SessionsAtoms`, `PairedClientList`): treat a
+snapshot as read-only and swap in a new one to update, never mutate in place. This is what makes Wolf's
+heavy concurrency (many simultaneous users) lock-free and safe. Prefer pure functions over shared
+mutable state, and keep protocol logic decoupled from the server runtime.
+
+**Coordination:** components talk through a shared **event bus** (`dp::event_bus`, `EventBusType` in
+`events/events.hpp`) rather than direct calls — `PairSignal`, `StreamSession`, `CreateLobbyEvent`,
+`StartRunner`, `PlugDeviceEvent`, docker lifecycle events, etc. For cross-component behavior, define/
+handle an event instead of adding a direct dependency. New events go in `events/events.hpp`;
+`reflectors.hpp` exposes them for serialization (all config/API/event serialization uses reflect-cpp —
+annotate types rather than hand-writing parsers).
+
+### How a stream works
+
+See `docs/modules/dev/pages/how-it-works.adoc` for the full picture.
+
+- **Virtual desktop** — `gst-wayland-display` creates a desktop on demand and feeds its raw framebuffer
+  into the encode pipeline. Our images run [Sway](https://swaywm.org/) (optionally
+  [Gamescope](https://github.com/ValveSoftware/gamescope)) as a Wayland client inside it. The
+  compositor has no XWayland; apps needing X (e.g. Steam) rely on Gamescope for it.
+- **Virtual audio** — by default PulseAudio runs **inside the Wolf container** under supervisord
+  (`docker/startup.sh` sets `WOLF_EMBED_PULSE=true`; Wolf waits for the PA socket before starting). With
+  an external `PULSE_SERVER`, or if `pulseaudio` isn't installed, Wolf falls back to the legacy
+  standalone `WolfPulseAudio` sidecar. Either way it uses `libpulse` for per-session virtual sinks.
+- **Virtual input** — mouse/keyboard events go **directly to the Wayland compositor** (no host device);
+  gamepads and pen/touch are real `uinput`/`uhid` devices created by `inputtino`. Those are visible on
+  the host, so `85-wolf.rules` restricts them to a group/seat for isolation. The virtual DualSense uses
+  `uhid` (plain `uinput` wasn't enough) — see the author's blog:
+  [1](https://abeltra.me/blog/inputtino-uhid-1/),
+  [2](https://abeltra.me/blog/inputtino-uhid-2/),
+  [3](https://abeltra.me/blog/inputtino-uhid-3/).
+- **Hotplug** — devices added mid-stream are injected into the running container via the `src/fake-udev`
+  CLI; see [Docker hotplug](https://abeltra.me/blog/docker-hotplug/) for how fake-udev achieves this.
+- **Guest apps** — run in containers. The Docker runner (`runners/docker.cpp`) builds the per-session
+  spec: mounts a per-app state folder, exposes the GPU render node (`/dev/dri/renderD*`), on NVIDIA adds
+  the driver (custom driver volume, or `--gpus all` + `NVIDIA_VISIBLE_DEVICES`/`_DRIVER_CAPABILITIES` +
+  the `nvidia` runtime), passes through Wolf's virtual input devices, sets `DeviceCgroupRules` for the
+  dynamic `hidraw`/`input` majors (needed for the virtual DualSense), and wires up fake-udev. It then
+  blocks for the container's lifetime plugging/unplugging devices via the event bus, and on exit
+  stops/removes it (`WOLF_STOP_CONTAINER_ON_EXIT`) and cleans up the udev scratch dir.
+- **Streaming** — GStreamer encodes video/audio (HW accel via CUDA/QuickSync/VAAPI; the whole pipeline
+  is a config-string in `config.toml`, overridable without code). Custom plugins in `gst-plugin/`
+  (`rtpmoonlightpay_video`/`_audio`) split, RTP-encode, and add FEC to Moonlight's format. The pipeline
+  is zero-copy from framebuffer to encoded frames — on by default, disable with `WOLF_USE_ZERO_COPY=FALSE`
+  (auto-falls back to legacy when an encoder can't support it); see
+  [The road to zero-copy in Wolf](https://abeltra.me/blog/road-to-zero-copy-in-wolf/).
+
+### Code map
+
+`CMakeLists.txt` composes these targets:
+
+- **`src/moonlight-protocol`** — platform-agnostic, mostly stateless Moonlight library: HTTP/S
+  `protocol.hpp`, control-packet `control.hpp`, Reed-Solomon `fec.hpp` (on
+  [nanors](https://github.com/sleepybishop/nanors)), and an RTSP parser built from a PEG grammar via
+  [cpp-peglib](https://github.com/yhirose/cpp-peglib). No server deps.
+- **`src/core`** (`wolf::core`) — reusable platform abstractions: `docker.hpp` (Docker/Podman REST over
+  libcurl + boost::json), `input.hpp` (inputtino), `virtual-display.hpp` (gst-wayland-display),
+  `audio.hpp` (libpulse), `gstreamer.hpp`. Split into `platforms/{all,linux,unknown}`; `unknown` holds
+  no-op stubs so non-Linux configs still compile — provide one when adding platform code.
+- **`src/gst-video-context`** — GStreamer video context helpers.
+- **`src/fake-udev`** — CLI (Linux only) that generates/injects udev events (hotplug, above).
+- **`src/moonlight-server`** (`wolf::runner` → the `wolf` binary) — the full server:
+  - `wolf.cpp` — `main`: loads config, sets up certs, starts servers, wires the event bus, runs the
+    boost::asio loop, graceful shutdown via a signal flag.
+  - `state/` — `AppState` + config model (TOML via `configTOML.cpp`, tomlplusplus + reflect-cpp; see
+    `tests/assets/config.test.toml`).
+  - `rest/` `control/` `rtsp/` `rtp/` — the Moonlight protocol stack: HTTPS pairing/REST, RTSP setup,
+    ENet control channel + input handling, RTP ping/transport.
+  - `streaming/` `gst-plugin/` `audio/` — GStreamer video/audio; `audio/pulse_router` bridges container
+    audio.
+  - `runners/` — `docker.cpp` (containers, default) and `process.cpp` (host process), fired by
+    `StartRunner`.
+  - `sessions/` — session/lobby lifecycle (`moonlight.cpp`, `lobbies.cpp`); a "lobby" lets clients
+    share/join a running desktop.
+  - `api/` — a separate control API over a Unix socket (`unix_socket_server.cpp`) with an OpenAPI spec
+    (`openapi.cpp`), used by external tools (e.g. wolf-ui). Distinct from the Moonlight-facing `rest/`.
+
+## Runtime configuration (env vars)
+
+Behavior is driven by `WOLF_*` env vars read via `utils::get_env` (full working set in `wolf.cpp` and
+`.devcontainer/devcontainer.json`): `WOLF_CFG_FILE`, `WOLF_PRIVATE_KEY_FILE`/`WOLF_PRIVATE_CERT_FILE`,
+`WOLF_LOG_LEVEL`, `WOLF_DOCKER_SOCKET`, `WOLF_RENDER_NODE`/`WOLF_ENCODER_NODE` (GPU DRI nodes),
+`WOLF_PULSE_IMAGE`, `WOLF_INTERNAL_IP`/`WOLF_INTERNAL_MAC`, `WOLF_USE_ZERO_COPY`,
+`WOLF_STOP_CONTAINER_ON_EXIT`. A few (e.g. `WOLF_EMBED_PULSE`, `PULSE_SERVER`) are set/consumed by
+`docker/startup.sh` + `supervisord.conf`, not by Wolf itself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -733,23 +733,21 @@ crw------- 1 root root 10, 223 Jan 17 09:08 /dev/uinput
 .Create `udev` rules under `/etc/udev/rules.d/85-wolf-virtual-inputs.rules`
 [source,bash]
 ....
-# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad/keyboard/mouse)
+# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad)
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
 
 # Allows Wolf to access /dev/uhid (needed for DualSense emulation)
 KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
 
-# Move the virtual keyboard and mouse onto a phantom seat (seat9)
-SUBSYSTEMS=="input", ATTRS{id/vendor}=="ab00", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9"
-
 # Wolf virtual controllers: the gamepads plus, for the DualSense, its "Touchpad"
 # and "Motion Sensors" child devices and its /dev/hidraw* node. Matching the
-# "Wolf " name prefix (glob) covers every current and future sub-device, then
-# parks them on seat9 and strips the uaccess ACL so the host desktop user can't
-# read them. See https://github.com/games-on-whales/wolf/issues/451
-SUBSYSTEM=="input",  ATTR{name}=="Wolf *",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf *", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-KERNEL=="hidraw*",   ATTRS{name}=="Wolf *", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+# "Wolf *virtual*" name glob covers every current and future sub-device (they are
+# all named "Wolf ... (virtual) ...") without matching unrelated "Wolf" hardware,
+# then parks them on seat9 and strips the uaccess ACL so the host desktop user
+# can't read them. See https://github.com/games-on-whales/wolf/issues/451
+SUBSYSTEM=="input",  ATTR{name}=="Wolf *virtual*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+KERNEL=="hidraw*",   ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
 ....
 
 Reload the udev rules either by rebooting or run:

--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -733,18 +733,23 @@ crw------- 1 root root 10, 223 Jan 17 09:08 /dev/uinput
 .Create `udev` rules under `/etc/udev/rules.d/85-wolf-virtual-inputs.rules`
 [source,bash]
 ....
-# Allows Wolf to acces /dev/uinput (only needed for joypad support)
+# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad/keyboard/mouse)
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
 
-# Allows Wolf to access /dev/uhid (only needed for DualSense emulation)
-KERNEL=="uhid", GROUP="input", MODE="0660", TAG+="uaccess"
+# Allows Wolf to access /dev/uhid (needed for DualSense emulation)
+KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
 
-# Joypads
-KERNEL=="hidraw*",   ATTRS{name}=="Wolf PS5 (virtual) pad", GROUP="root", MODE="0660", ENV{ID_SEAT}="seat9"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf X-Box One (virtual) pad", GROUP="root", MODE="0660", ENV{ID_SEAT}="seat9"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf PS5 (virtual) pad", GROUP="root", MODE="0660", ENV{ID_SEAT}="seat9"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf gamepad (virtual) motion sensors", GROUP="root", MODE="0660", ENV{ID_SEAT}="seat9"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf Nintendo (virtual) pad", GROUP="root", MODE="0660", ENV{ID_SEAT}="seat9"
+# Move the virtual keyboard and mouse onto a phantom seat (seat9)
+SUBSYSTEMS=="input", ATTRS{id/vendor}=="ab00", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9"
+
+# Wolf virtual controllers: the gamepads plus, for the DualSense, its "Touchpad"
+# and "Motion Sensors" child devices and its /dev/hidraw* node. Matching the
+# "Wolf " name prefix (glob) covers every current and future sub-device, then
+# parks them on seat9 and strips the uaccess ACL so the host desktop user can't
+# read them. See https://github.com/games-on-whales/wolf/issues/451
+SUBSYSTEM=="input",  ATTR{name}=="Wolf *",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+SUBSYSTEMS=="input", ATTRS{name}=="Wolf *", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+KERNEL=="hidraw*",   ATTRS{name}=="Wolf *", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
 ....
 
 Reload the udev rules either by rebooting or run:

--- a/docs/modules/user/pages/quickstart.adoc
+++ b/docs/modules/user/pages/quickstart.adoc
@@ -730,25 +730,21 @@ ls -la /dev/uinput
 crw------- 1 root root 10, 223 Jan 17 09:08 /dev/uinput
 ....
 
-.Create `udev` rules under `/etc/udev/rules.d/85-wolf-virtual-inputs.rules`
+The `udev` rules live in
+https://github.com/games-on-whales/wolf/blob/stable/85-wolf.rules[`85-wolf.rules`]
+in the Wolf repository; that file is the single source of truth, so install it
+directly rather than copying the rules by hand:
+
 [source,bash]
 ....
-# Allows Wolf to access /dev/uinput (needed to create the virtual gamepad)
-KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput", TAG+="uaccess"
-
-# Allows Wolf to access /dev/uhid (needed for DualSense emulation)
-KERNEL=="uhid", MODE="0660", GROUP="input", TAG+="uaccess"
-
-# Wolf virtual controllers: the gamepads plus, for the DualSense, its "Touchpad"
-# and "Motion Sensors" child devices and its /dev/hidraw* node. Matching the
-# "Wolf *virtual*" name glob covers every current and future sub-device (they are
-# all named "Wolf ... (virtual) ...") without matching unrelated "Wolf" hardware,
-# then parks them on seat9 and strips the uaccess ACL so the host desktop user
-# can't read them. See https://github.com/games-on-whales/wolf/issues/451
-SUBSYSTEM=="input",  ATTR{name}=="Wolf *virtual*",  MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-SUBSYSTEMS=="input", ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
-KERNEL=="hidraw*",   ATTRS{name}=="Wolf *virtual*", MODE="0660", GROUP="input", ENV{ID_SEAT}="seat9", TAG-="uaccess"
+curl -fsSL https://raw.githubusercontent.com/games-on-whales/wolf/stable/85-wolf.rules \
+  -o /etc/udev/rules.d/85-wolf.rules
 ....
+
+They grant Wolf access to `/dev/uinput` and `/dev/uhid` (needed to create the
+virtual gamepads and to emulate the DualSense), and they keep the virtual
+controllers off the host's active seat so a streamed controller can't also drive
+the host desktop -- see https://github.com/games-on-whales/wolf/issues/451.
 
 Reload the udev rules either by rebooting or run:
 

--- a/docs/modules/user/pages/troubleshooting.adoc
+++ b/docs/modules/user/pages/troubleshooting.adoc
@@ -164,9 +164,9 @@ sudo udevadm control --reload-rules && sudo udevadm trigger
 
 [TIP]
 ====
-The bundled rules match every Wolf device by its `Wolf ` name prefix, so they
-keep working even if a controller's exact product name changes. If you maintain
-your own rules, prefer the prefix glob over hard-coded names — an out-of-date
+The bundled rules match every Wolf device by the `Wolf *virtual*` name glob, so
+they keep working even if a controller's exact product name changes. If you
+maintain your own rules, prefer the glob over hard-coded names — an out-of-date
 name (e.g. `Wolf PS5 (virtual) pad` after it was renamed to
 `Wolf DualSense (virtual) pad`) silently stops isolating that device.
 ====

--- a/docs/modules/user/pages/troubleshooting.adoc
+++ b/docs/modules/user/pages/troubleshooting.adoc
@@ -128,6 +128,49 @@ This can be easily fixed by adding `uhid` to `/etc/module` to load the module du
 echo 'uhid' | sudo tee /etc/modules-load.d/uhid.conf
 ....
 
+== Controller input also controls the host desktop
+
+If your controller works inside the streamed game *but also* moves the host's
+mouse pointer / presses buttons on the host desktop (for example a DualSense
+touchpad moving the host cursor), the virtual devices Wolf created are not
+isolated from your logged-in host session.
+
+This is almost always because the udev rules from the
+xref:user:quickstart.adoc#_virtual_devices_support[Virtual devices support]
+section are missing, out of date, or don't match your controller. Wolf's
+virtual pads appear as real devices in the *host* kernel, and without the rules
+`systemd-logind` grants your desktop user access to them (`uaccess`).
+
+To confirm which devices are leaking, run the input diagnostic on the host while
+a client + controller are connected:
+
+[source,bash]
+....
+sudo ./scripts/wolf-input-diag.sh host
+....
+
+It lists every `Wolf …` virtual device on the host and flags any that a non-root
+user can read, plus any device name not covered by your rules file. Any line
+marked `LEAK` is reachable by the host desktop.
+
+To fix it, (re)install the rules from the
+xref:user:quickstart.adoc#_virtual_devices_support[Virtual devices support]
+section, then reload them and re-plug the controller:
+
+[source,bash]
+....
+sudo udevadm control --reload-rules && sudo udevadm trigger
+....
+
+[TIP]
+====
+The bundled rules match every Wolf device by its `Wolf ` name prefix, so they
+keep working even if a controller's exact product name changes. If you maintain
+your own rules, prefer the prefix glob over hard-coded names — an out-of-date
+name (e.g. `Wolf PS5 (virtual) pad` after it was renamed to
+`Wolf DualSense (virtual) pad`) silently stops isolating that device.
+====
+
 == Recreating the Nvidia Driver Volume
 
 Anytime you update the Nvidia drivers on your host you'll have to re-created the driver volume as described in xref:user:quickstart.adoc[the quickstart guide]. +

--- a/scripts/README.adoc
+++ b/scripts/README.adoc
@@ -1,0 +1,40 @@
+= Wolf helper scripts
+
+== wolf-input-diag.sh
+
+Host-side diagnostic that validates controller/input passthrough for Wolf. It
+answers two questions:
+
+* *Isolation* — is a session's controller input leaking somewhere it shouldn't
+  (into the host desktop, or into another container such as the Wolf UI while
+  you play an app)?
+* *Delivery* — is the controller actually producing events inside the container
+  it's supposed to be in?
+
+Run it on the *host* (needs `bash`, `docker`/`podman`, coreutils; the host audit
+also uses `getfacl`/`udevadm`/`stat`). All reads are non-destructive — it never
+grabs a device, so it can't steal input from a running game.
+
+[source,bash]
+....
+# Audit host-side isolation (catches "controller drives the host desktop"):
+sudo ./scripts/wolf-input-diag.sh host
+
+# List Wolf containers and the input devices mounted in each:
+./scripts/wolf-input-diag.sh discover
+
+# Fail if any device node is shared across containers:
+./scripts/wolf-input-diag.sh static
+
+# Live: press pads and watch which container(s) register input:
+./scripts/wolf-input-diag.sh monitor
+
+# Targeted pass/fail for one container (delivery + isolation):
+./scripts/wolf-input-diag.sh live <container-name>
+
+# Everything (host + discover + static):
+./scripts/wolf-input-diag.sh all
+....
+
+Use `DOCKER=podman` and/or `RULES_FILE=/path/to/85-wolf.rules` to override
+defaults.

--- a/scripts/wolf-input-diag.sh
+++ b/scripts/wolf-input-diag.sh
@@ -160,7 +160,18 @@ node_nonroot_access() {
 rule_matches_name() {
   local name="$1"
   [ -r "$RULES_FILE" ] || return 2
-  grep -qF "\"$name\"" "$RULES_FILE"
+  # Pull every ATTR{name}/ATTRS{name} match pattern out of the rules file and
+  # test each against the device name as a shell glob. This handles both exact
+  # names and globs like "Wolf *virtual*", so coverage stays correct regardless
+  # of how the rules are written.
+  local pat
+  while IFS= read -r pat; do
+    # shellcheck disable=SC2254
+    case "$name" in
+      $pat) return 0 ;;
+    esac
+  done < <(grep -oE 'ATTRS?\{name\}=="[^"]*"' "$RULES_FILE" | sed -E 's/.*=="([^"]*)"/\1/')
+  return 1
 }
 
 cmd_host() {
@@ -196,8 +207,8 @@ cmd_host() {
   fi
   if [ "$leaks" -gt 0 ]; then
     bad "$leaks device(s) readable by the host desktop user — controller input is LEAKING to the host."
-    echo  "     Fix: ensure $RULES_FILE has a MODE=\"0660\",GROUP=\"input\" rule matching each name above"
-    echo  "     (note: DualSense pad name is \"Wolf DualSense (virtual) pad\", and its touchpad node needs its own rule),"
+    echo  "     Fix: (re)install the shipped 85-wolf.rules into $RULES_FILE — its \"Wolf *virtual*\""
+    echo  "     glob covers every name above (pads, the DualSense touchpad/motion child nodes, and hidraw),"
     echo  "     then: sudo udevadm control --reload-rules && sudo udevadm trigger, and re-plug the controller."
     return 1
   elif [ "$uncovered" -gt 0 ]; then

--- a/scripts/wolf-input-diag.sh
+++ b/scripts/wolf-input-diag.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+#
+# wolf-input-diag.sh — validate controller/input passthrough into Wolf containers.
+#
+# Answers two questions the operator actually cares about:
+#   (A) ISOLATION  — is one session's controller input leaking into another
+#                    container (e.g. a Steam app's pad also driving the Wolf UI)?
+#   (B) DELIVERY   — is the controller actually producing events inside the
+#                    container it is *supposed* to be in?
+#
+# How it works (black-box, host-side — no Wolf source or API needed):
+#   * Wolf builds each session's virtual gamepad/mouse/keyboard as a distinct
+#     evdev/uhid device with a unique MAJOR:MINOR, and mknod's it into ONLY the
+#     matching session_id's container. So:
+#       - the SAME major:minor visible in >1 container  => structural leak  (A)
+#       - actuating one pad and seeing events land in a NON-active container
+#                                                       => runtime leak     (A)
+#       - actuating and seeing NO events in the active container
+#                                                       => delivery failure (B)
+#   * Device *identity* (name) is read from the host kernel via /sys/class/input,
+#     joined to per-container nodes by major:minor.
+#   * Reads are non-destructive: we never EVIOCGRAB, so the game keeps its input.
+#
+# Requirements on the Wolf HOST: bash, docker (or set DOCKER=podman), coreutils.
+# No evtest / jq / evemu needed.
+#
+# Usage:
+#   wolf-input-diag.sh host                  # HOST-LEAK audit: are Wolf pads reachable by the desktop user?
+#   wolf-input-diag.sh discover              # list Wolf containers + their input devices
+#   wolf-input-diag.sh static                # isolation check: any node shared across containers?
+#   wolf-input-diag.sh monitor [SECS]        # live: press pads, watch which container lights up
+#   wolf-input-diag.sh live <container> [SECS]   # targeted A+B test against one container
+#   wolf-input-diag.sh all                   # host + discover + static, then hint at live tests
+#
+# The `host` audit is the one that catches the real-world "DualSense input leaks
+# into host" class of bug (games-on-whales/wolf#451): a Wolf virtual device whose
+# name is NOT matched by /etc/udev/rules.d/85-wolf.rules keeps logind's default
+# `uaccess` ACL, so the host's logged-in desktop user can read the controller.
+#
+set -euo pipefail
+
+DOCKER="${DOCKER:-docker}"
+RULES_FILE="${RULES_FILE:-/etc/udev/rules.d/85-wolf.rules}"
+DUR_DEFAULT=6
+
+die()  { printf '\033[31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+info() { printf '\033[36m%s\033[0m\n' "$*"; }
+ok()   { printf '  \033[32m✓ %s\033[0m\n' "$*"; }
+warn() { printf '  \033[33m! %s\033[0m\n' "$*"; }
+bad()  { printf '  \033[31m✗ %s\033[0m\n' "$*"; }
+
+need_docker() { command -v "$DOCKER" >/dev/null 2>&1 || die "'$DOCKER' not found. Run this on the Wolf host (set DOCKER=podman if needed)."; }
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+# Print "CONTAINER_ID\tNAME\tWOLF_SESSION_ID" for every running container that
+# looks Wolf-managed (has a WOLF_SESSION_ID env var). The Wolf server container
+# itself has no session id; include it too, tagged "server", since it is where
+# the virtual devices are actually created.
+discover_containers() {
+  local id name env sid role
+  while read -r id; do
+    [ -n "$id" ] || continue
+    name=$("$DOCKER" inspect -f '{{.Name}}' "$id" 2>/dev/null | sed 's#^/##')
+    env=$("$DOCKER" inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$id" 2>/dev/null || true)
+    sid=$(printf '%s\n' "$env" | sed -n 's/^WOLF_SESSION_ID=//p' | head -n1)
+    if printf '%s\n' "$env" | grep -q '^WOLF_'; then
+      role="session"; [ -n "$sid" ] || { sid="-"; role="server"; }
+      printf '%s\t%s\t%s\t%s\n' "$id" "$name" "$sid" "$role"
+    fi
+  done < <("$DOCKER" ps -q)
+}
+
+# List input device nodes inside a container as "PATH MAJOR:MINOR".
+# Parses `ls -l` so it works under busybox (no stat/--printf assumptions).
+nodes_in_container() {
+  local id="$1"
+  "$DOCKER" exec "$id" sh -c '
+    for n in /dev/input/event* /dev/input/js* /dev/hidraw*; do
+      [ -c "$n" ] || continue
+      set -- $(ls -l "$n")
+      maj=$5; min=$6; maj=${maj%,}
+      printf "%s %s:%s\n" "$n" "$maj" "$min"
+    done 2>/dev/null' 2>/dev/null || true
+}
+
+# Resolve a major:minor to a human name using the HOST kernel view.
+# evdev -> /sys/class/input/eventN/{dev,device/name}
+# hidraw -> /sys/class/hidraw/hidrawN/{dev, device/uevent:HID_NAME}
+host_name_for() {
+  local target="$1" d dev
+  for d in /sys/class/input/event*; do
+    [ -r "$d/dev" ] || continue
+    read -r dev < "$d/dev"
+    if [ "$dev" = "$target" ]; then
+      [ -r "$d/device/name" ] && { cat "$d/device/name"; return; }
+    fi
+  done
+  for d in /sys/class/hidraw/hidraw*; do
+    [ -r "$d/dev" ] || continue
+    read -r dev < "$d/dev"
+    if [ "$dev" = "$target" ]; then
+      sed -n 's/^HID_NAME=//p' "$d/device/uevent" 2>/dev/null && return
+    fi
+  done
+  echo "(unknown)"
+}
+
+# ---------------------------------------------------------------------------
+# HOST-LEAK audit (the wolf#451 class): can the desktop user reach a Wolf pad?
+# ---------------------------------------------------------------------------
+
+# List every host input/hidraw device that Wolf created (name starts with "Wolf").
+# Emits: NODE<TAB>MAJ:MIN<TAB>NAME<TAB>IS_TOUCHPAD(0/1)
+host_wolf_devices() {
+  local d dev name tp node
+  for d in /sys/class/input/event* /sys/class/hidraw/hidraw*; do
+    [ -r "$d/dev" ] || continue
+    name=""
+    if [ -r "$d/device/name" ]; then name=$(cat "$d/device/name"); fi
+    if [ -z "$name" ] && [ -r "$d/device/uevent" ]; then
+      name=$(sed -n 's/^HID_NAME=//p' "$d/device/uevent")
+    fi
+    case "$name" in Wolf*) ;; *) continue ;; esac
+    read -r dev < "$d/dev"
+    case "$d" in
+      */class/input/*)  node="/dev/input/$(basename "$d")" ;;
+      */class/hidraw/*) node="/dev/$(basename "$d")" ;;
+      *) continue ;;
+    esac
+    tp=0
+    if command -v udevadm >/dev/null 2>&1; then
+      udevadm info --query=property --name="$node" 2>/dev/null | grep -q '^ID_INPUT_TOUCHPAD=1' && tp=1
+    fi
+    printf '%s\t%s\t%s\t%s\n' "$node" "$dev" "$name" "$tp"
+  done
+}
+
+# Is this device reachable by a non-root user? Returns the offending grantees, or "".
+node_nonroot_access() {
+  local node="$1" out=""
+  # (1) named ACL entries = logind uaccess granted the active-seat desktop user
+  if command -v getfacl >/dev/null 2>&1; then
+    out=$(getfacl -pE "$node" 2>/dev/null \
+          | grep -E '^(user|group):[a-zA-Z0-9]' \
+          | grep -vE ':[[:space:]]*---$' || true)
+  fi
+  # (2) world (other) read/write bit set — chars 7-9 of e.g. "crw-rw----"
+  local operm; operm=$(stat -c '%A' "$node" 2>/dev/null || echo '----------')
+  local other="${operm:7:3}"
+  if [ -n "$other" ] && [ "${other//-/}" != "" ]; then
+    out="${out}${out:+; }other=${other}"
+  fi
+  printf '%s' "$out"
+}
+
+# Does 85-wolf.rules contain a rule matching this exact device name?
+rule_matches_name() {
+  local name="$1"
+  [ -r "$RULES_FILE" ] || return 2
+  grep -qF "\"$name\"" "$RULES_FILE"
+}
+
+cmd_host() {
+  info "== Host-leak audit: are Wolf virtual devices isolated from the host desktop? =="
+  echo "   Rules file: $RULES_FILE"
+  [ -r "$RULES_FILE" ] || warn "rules file not readable — cannot cross-check name coverage."
+  echo
+  local any=0 leaks=0 uncovered=0
+  while IFS=$'\t' read -r node mm name tp; do
+    [ -n "$node" ] || continue
+    any=1
+    local label="$name"; [ "$tp" = 1 ] && label="$name [TOUCHPAD pointer]"
+    local access; access=$(node_nonroot_access "$node")
+    local covered="?"; if rule_matches_name "$name"; then covered="yes"; else covered="no"; fi
+
+    if [ -n "$access" ]; then
+      leaks=$((leaks+1))
+      bad "LEAK  $node ($mm) '$label'"
+      printf '          reachable by non-root: %s\n' "$access"
+      [ "$covered" = "no" ] && printf '          → no rule in %s matches name \"%s\"\n' "$RULES_FILE" "$name"
+    elif [ "$covered" = "no" ]; then
+      uncovered=$((uncovered+1))
+      warn "UNCOVERED $node ($mm) '$label' — locked now, but no rule matches \"$name\" (fragile)."
+    else
+      ok "$node ($mm) '$label' — root-only, rule-covered."
+    fi
+  done < <(host_wolf_devices)
+
+  echo
+  if [ "$any" = 0 ]; then
+    warn "No 'Wolf …' virtual devices found on the host. Connect a client + controller first."
+    return 0
+  fi
+  if [ "$leaks" -gt 0 ]; then
+    bad "$leaks device(s) readable by the host desktop user — controller input is LEAKING to the host."
+    echo  "     Fix: ensure $RULES_FILE has a MODE=\"0660\",GROUP=\"input\" rule matching each name above"
+    echo  "     (note: DualSense pad name is \"Wolf DualSense (virtual) pad\", and its touchpad node needs its own rule),"
+    echo  "     then: sudo udevadm control --reload-rules && sudo udevadm trigger, and re-plug the controller."
+    return 1
+  elif [ "$uncovered" -gt 0 ]; then
+    warn "$uncovered device(s) are locked but not explicitly rule-covered — update 85-wolf.rules to be safe."
+  else
+    ok "All Wolf devices are root-only and rule-covered. No host leak."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Container isolation commands
+# ---------------------------------------------------------------------------
+
+cmd_discover() {
+  need_docker
+  info "== Wolf containers and their input devices =="
+  local any=0
+  while IFS=$'\t' read -r id name sid role; do
+    any=1
+    printf '\n\033[1m%s\033[0m  (%s, session=%s)\n' "$name" "$role" "$sid"
+    local nodes; nodes=$(nodes_in_container "$id")
+    if [ -z "$nodes" ]; then
+      warn "no /dev/input or /dev/hidraw nodes present"
+      continue
+    fi
+    while read -r path mm; do
+      [ -n "$path" ] || continue
+      printf '    %-22s %-8s %s\n' "$path" "$mm" "$(host_name_for "$mm")"
+    done <<< "$nodes"
+  done < <(discover_containers)
+  [ "$any" = 1 ] || warn "No Wolf-managed containers found (are any sessions running?)."
+}
+
+# STATIC isolation check (A): fail if any major:minor exists in >1 container.
+cmd_static() {
+  need_docker
+  info "== Static isolation check: is any device node shared across containers? =="
+  declare -A owners   # "maj:min" -> "name1|name2|..."
+  declare -A dname    # "maj:min" -> device name
+  while IFS=$'\t' read -r id name sid role; do
+    while read -r path mm; do
+      [ -n "$mm" ] || continue
+      owners["$mm"]="${owners[$mm]:+${owners[$mm]}|}$name"
+      dname["$mm"]="$(host_name_for "$mm")"
+    done < <(nodes_in_container "$id")
+  done < <(discover_containers)
+
+  local leaks=0 total=0
+  for mm in "${!owners[@]}"; do
+    total=$((total+1))
+    local list="${owners[$mm]}"
+    if [[ "$list" == *"|"* ]]; then
+      leaks=$((leaks+1))
+      bad "LEAK: $mm '${dname[$mm]}' present in multiple containers: ${list//|/, }"
+    fi
+  done
+  echo
+  if [ "$total" = 0 ]; then
+    warn "No input nodes found in any container."
+  elif [ "$leaks" = 0 ]; then
+    ok "$total device node(s) checked — each belongs to exactly one container. Isolation intact."
+  else
+    bad "$leaks shared node(s) detected — input CAN cross containers. See above."
+    return 1
+  fi
+}
+
+# Read one container's event nodes for DUR seconds; echo which nodes saw traffic.
+# Non-blocking on our side, non-destructive (no grab). Prints "PATH" per active node.
+_watch_container() {
+  local id="$1" dur="$2"
+  "$DOCKER" exec "$id" sh -c '
+    dur='"$dur"'
+    for n in /dev/input/event*; do
+      [ -c "$n" ] || continue
+      ( if timeout "$dur" sh -c "cat \"$n\" | head -c1 >/dev/null 2>&1"; then echo "$n"; fi ) &
+    done
+    wait
+  ' 2>/dev/null || true
+}
+
+# MONITOR (A, exploratory): watch ALL containers at once. Operator presses pads;
+# each container that sees activity is printed. Anything unexpected = a leak.
+cmd_monitor() {
+  need_docker
+  local dur="${1:-$DUR_DEFAULT}"
+  info "== Live monitor: press buttons on your controller(s) now (${dur}s window) =="
+  echo "   Each container that registers input will be listed. A container you are"
+  echo "   NOT actively using showing up here means input is leaking into it."
+  echo
+  local tmp; tmp=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" RETURN
+  while IFS=$'\t' read -r id name sid role; do
+    ( active=$(_watch_container "$id" "$dur")
+      [ -n "$active" ] && printf '%s\t%s\n' "$name" "$(echo "$active" | tr '\n' ' ')" >> "$tmp/hits"
+    ) &
+  done < <(discover_containers)
+  wait
+  echo
+  if [ -s "$tmp/hits" ]; then
+    info "Containers that saw input:"
+    while IFS=$'\t' read -r name nodes; do printf '  %-24s %s\n' "$name" "$nodes"; done < "$tmp/hits"
+  else
+    warn "No input seen anywhere. Did you press a button? Is a client connected?"
+  fi
+}
+
+# LIVE targeted test (A+B): name the container you are ACTIVELY using; press its
+# pad; we confirm it received input (B) and that no OTHER container did (A).
+cmd_live() {
+  need_docker
+  local target="${1:?usage: live <container-name> [secs]}"; local dur="${2:-$DUR_DEFAULT}"
+  # verify target exists
+  discover_containers | cut -f2 | grep -qx "$target" || die "'$target' is not a running Wolf container (see: $0 discover)."
+  info "== Targeted test against '$target' =="
+  echo "   Actuate the controller for THIS session for ${dur}s now..."
+  echo
+  local tmp; tmp=$(mktemp -d); trap "rm -rf '$tmp'" RETURN
+  local target_id=""
+  while IFS=$'\t' read -r id name sid role; do
+    [ "$name" = "$target" ] && target_id="$id"
+    ( active=$(_watch_container "$id" "$dur")
+      [ -n "$active" ] && printf '%s\n' "$name" >> "$tmp/hits"
+    ) &
+  done < <(discover_containers)
+  wait
+
+  echo
+  local hit_target=0 leaked=""
+  if [ -f "$tmp/hits" ]; then
+    grep -qx "$target" "$tmp/hits" && hit_target=1
+    leaked=$(grep -vx "$target" "$tmp/hits" | sort -u | tr '\n' ' ')
+  fi
+
+  # (B) delivery
+  if [ "$hit_target" = 1 ]; then ok "(B) DELIVERY: '$target' received controller input."
+  else bad "(B) DELIVERY: '$target' saw NO input — passthrough is broken for this container."; fi
+  # (A) isolation
+  if [ -z "$leaked" ]; then ok "(A) ISOLATION: no other container saw this controller's input."
+  else bad "(A) ISOLATION: input LEAKED into: $leaked"; fi
+
+  [ "$hit_target" = 1 ] && [ -z "$leaked" ]
+}
+
+cmd_all() {
+  cmd_host || true; echo
+  cmd_discover; echo
+  cmd_static || true; echo
+  info "Next: run a live test while a client is connected and pressing a pad:"
+  echo "   $0 monitor            # eyeball which containers light up"
+  echo "   $0 live <container>   # pass/fail A+B for the container you're using"
+}
+
+case "${1:-all}" in
+  host)     cmd_host ;;
+  discover) cmd_discover ;;
+  static)   cmd_static ;;
+  monitor)  shift; cmd_monitor "$@" ;;
+  live)     shift; cmd_live "$@" ;;
+  all)      cmd_all ;;
+  *) die "unknown command '$1' (host|discover|static|monitor|live|all)" ;;
+esac

--- a/src/moonlight-protocol/moonlight/control.hpp
+++ b/src/moonlight-protocol/moonlight/control.hpp
@@ -266,7 +266,9 @@ enum MOTION_TYPE : uint8_t {
 
 constexpr uint8_t BATTERY_PERCENTAGE_UNKNOWN = 0xFF;
 
-enum BATTERY_STATE : unsigned short {
+// One byte on the wire -- must stay uint8_t, otherwise it eats the following battery_percentage
+// byte in CONTROLLER_BATTERY_PACKET and the percentage is always read as the trailing zero (0%).
+enum BATTERY_STATE : uint8_t {
   BATTERY_STATE_UNKNOWN = 0x0,
   BATTERY_NOT_PRESENT = 0x1,
   BATTERY_DISCHARGHING = 0x2,

--- a/src/moonlight-server/events/reflectors.hpp
+++ b/src/moonlight-server/events/reflectors.hpp
@@ -85,6 +85,7 @@ template <> struct Reflector<events::App> {
         .render_node = app.render_node,
         .opus_gst_pipeline = app.opus_gst_pipeline,
         .start_virtual_compositor = app.start_virtual_compositor,
+        .start_audio_server = app.start_audio_server,
         .runner = runner,
     };
   }

--- a/src/moonlight-server/sessions/lobbies.cpp
+++ b/src/moonlight-server/sessions/lobbies.cpp
@@ -313,10 +313,10 @@ setup_lobbies_handlers(const immer::box<state::AppState> &app_state,
         immer::vector<events::Lobby> lobbies = app_state->lobbies->load();
         if (auto lobby = state::get_lobby_by_connected_session(lobbies, unplug_device_event->session_id)) {
           logs::log(logs::debug, "[LOBBY] Unplug device for session {}", unplug_device_event->session_id);
-          app_state->event_bus->fire_event(
+          app_state->event_bus->fire_event(immer::box<events::UnplugDeviceEvent>{
               events::UnplugDeviceEvent{.session_id = lobby->id,
                                         .udev_events = unplug_device_event->udev_events,
-                                        .udev_hw_db_entries = unplug_device_event->udev_hw_db_entries});
+                                        .udev_hw_db_entries = unplug_device_event->udev_hw_db_entries}});
         }
       }));
 

--- a/tests/testWolfAPI.cpp
+++ b/tests/testWolfAPI.cpp
@@ -495,6 +495,48 @@ TEST_CASE("Session APIs without app_id or client_id", "[API]") {
   REQUIRE(sessions2.sessions.size() == 1);
 }
 
+// A device unplugged while its session is inside a lobby must be relayed to the lobby's runner.
+TEST_CASE("Lobby relays a device unplug to its runner", "[API]") {
+  auto event_bus = std::make_shared<events::EventBusType>();
+  auto running_sessions = std::make_shared<immer::atom<immer::vector<events::StreamSession>>>();
+  auto config = immer::box<state::Config>(state::load_or_default("config.test.toml", event_bus, running_sessions));
+  auto app_state = immer::box<state::AppState>(state::AppState{
+      .config = config,
+      .pairing_cache = std::make_shared<immer::atom<immer::map<std::string, state::PairCache>>>(),
+      .pairing_atom = std::make_shared<immer::atom<immer::map<std::string, immer::box<events::PairSignal>>>>(),
+      .event_bus = event_bus,
+      .lobbies = std::make_shared<immer::atom<immer::vector<events::Lobby>>>(),
+      .running_sessions = running_sessions});
+
+  // A lobby with one connected Moonlight session, added straight to state (no compositor).
+  const std::string lobby_id = "lobby-under-test";
+  const std::string moonlight_session_id = "1234";
+  events::Lobby lobby{.id = lobby_id,
+                      .name = "test_lobby",
+                      .started_by_profile_id = "test_profile",
+                      .multi_user = false,
+                      .stop_when_everyone_leaves = false};
+  lobby.connected_sessions->update([&](const immer::vector<immer::box<std::string>> &connected) {
+    return connected.push_back(immer::box<std::string>{moonlight_session_id});
+  });
+  app_state->lobbies->update([&](const immer::vector<events::Lobby> &lobbies) { return lobbies.push_back(lobby); });
+
+  auto lobbies_handlers = sessions::setup_lobbies_handlers(app_state, api_runtime_dir(), {});
+
+  int relayed_to_lobby = 0;
+  auto observer = event_bus->register_handler<immer::box<events::UnplugDeviceEvent>>(
+      [&](const immer::box<events::UnplugDeviceEvent> &ev) {
+        if (ev->session_id == lobby_id) {
+          relayed_to_lobby++;
+        }
+      });
+
+  event_bus->fire_event(
+      immer::box<events::UnplugDeviceEvent>{events::UnplugDeviceEvent{.session_id = moonlight_session_id}});
+
+  REQUIRE(relayed_to_lobby == 1);
+}
+
 TEST_CASE("Lobbies APIs", "[API]") {
   auto event_bus = std::make_shared<events::EventBusType>();
   auto running_sessions = std::make_shared<immer::atom<immer::vector<events::StreamSession>>>();


### PR DESCRIPTION
## Summary

Bring the current `stable` line into `feat/vulkan-image` without replacing the Vulkan image or its native encode path.

This merges `stable` commit `7f416ec0` into Vulkan commit `21ba3ecb`, producing `b03cf505` with both histories intact.

## Why

The Vulkan branch predates recent stable work for controller hotplug, virtual host-input isolation, DualSense battery handling, app audio preservation, and newer diagnostics and repository guidance. Consumers that require the Vulkan image currently have to choose between those fixes and Vulkan support.

## Resolution

Merge `stable` into `feat/vulkan-image` and retain `docker/wolf.vulkan.Dockerfile` unchanged. The only manual merge resolution removed duplicate controller-unplug relay and test content because `stable` now provides the equivalent behavior.

## Reviewer considerations

- This is deliberately a merge commit so the stable and Vulkan ancestry remains visible.
- No non-Vulkan Dockerfile replaces the Vulkan image.
- Unraid Beam's 43-patch downstream queue was refreshed against this exact commit and remains at 43 patches.
- Beam is temporarily consuming `refs/pull/491/head` as an immutable pin while this PR is under review.

## Verification

Run on Unraid's devgen Linux/amd64 Docker builder:

- The full 43-patch Beam queue applies cleanly, producing patch head `978b2314292108b538b3f2af772fa2c02db44467`.
- The paired GStreamer Vulkan image built successfully.
- The Wolf Vulkan image built successfully.
- The focused Wolf regression suite passed, including config persistence, controller unplug, and DRM descriptor lifetime under AddressSanitizer.
- Runtime RPM/library checks and detached debug-symbol checks passed.
- Built image provenance reports Wolf revision `b03cf50561cc3b0dc316629471373f77beb66f15`.

## Risk

Moderate. The merge advances a branch with different image and encode behavior, but it preserves that branch's Dockerfile and passed the downstream consumer's complete materialization and image-build gates.
