### PR TITLE
fix(config): replace serialized state atomically

### DIFF
--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -2,9 +2,9 @@
 #include <events/reflectors.hpp>
 #include <filesystem>
 #include <fstream>
-#include <mutex>
 #include <gst/gstelementfactory.h>
 #include <gst/gstregistry.h>
+#include <mutex>
 #include <platforms/hw.hpp>
 #include <range/v3/view.hpp>
 #include <rfl/toml.hpp>
@@ -102,8 +102,7 @@ void save_config_locked(const std::string &source, const WolfConfig &config) {
   }
 }
 
-template <typename Mutation>
-void update_config_file(const std::string &source, Mutation mutation) {
+template <typename Mutation> void update_config_file(const std::string &source, Mutation mutation) {
   std::scoped_lock lock(config_file_mutex);
   auto config = rfl::toml::load<WolfConfig, rfl::DefaultIfMissing>(source).value();
   mutation(config);

--- a/src/moonlight-server/state/configTOML.cpp
+++ b/src/moonlight-server/state/configTOML.cpp
@@ -1,6 +1,8 @@
 #include <events/events.hpp>
 #include <events/reflectors.hpp>
+#include <filesystem>
 #include <fstream>
+#include <mutex>
 #include <gst/gstelementfactory.h>
 #include <gst/gstregistry.h>
 #include <platforms/hw.hpp>
@@ -20,6 +22,131 @@ constexpr char const *default_toml =
 
 using namespace std::literals;
 using namespace wolf::config;
+
+void create_default(const std::string &source);
+
+namespace {
+
+std::mutex config_file_mutex;
+
+std::filesystem::path unique_sibling(const std::string &source, std::string_view suffix) {
+  return std::filesystem::path(source + "." + std::string(suffix) + "-" + gen_uuid());
+}
+
+bool is_valid_config(const std::filesystem::path &source) {
+  try {
+    rfl::toml::load<WolfConfig, rfl::DefaultIfMissing>(source.string()).value();
+    return true;
+  } catch (const std::exception &) {
+    return false;
+  }
+}
+
+bool looks_like_stale_tail_corruption(const std::string &source) {
+  std::ifstream input(source);
+  if (!input.is_open()) {
+    return false;
+  }
+
+  const std::string contents{std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+  for (const auto codec : {"av1", "hevc", "h264"}) {
+    const auto empty_array = std::string(codec) + "_encoders = []";
+    const auto array_table = "[[gstreamer.video." + std::string(codec) + "_encoders]]";
+    if (contents.find(empty_array) != std::string::npos && contents.find(array_table) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void atomic_copy(const std::filesystem::path &source, const std::filesystem::path &destination) {
+  const auto temporary = unique_sibling(destination.string(), "tmp");
+  try {
+    std::filesystem::copy_file(source, temporary, std::filesystem::copy_options::overwrite_existing);
+    std::filesystem::rename(temporary, destination);
+  } catch (...) {
+    std::error_code ignored;
+    std::filesystem::remove(temporary, ignored);
+    throw;
+  }
+}
+
+void save_config_locked(const std::string &source, const WolfConfig &config) {
+  const auto temporary = unique_sibling(source, "tmp");
+  const auto backup = std::filesystem::path(source + ".last-good");
+
+  try {
+    // reflection-cpp opens an existing destination without truncating it. Always
+    // serialise to a new inode, validate it, and publish it with one rename.
+    rfl::toml::save(temporary.string(), config);
+    rfl::toml::load<WolfConfig, rfl::DefaultIfMissing>(temporary.string()).value();
+
+    if (std::filesystem::exists(source)) {
+      std::error_code ignored;
+      const auto permissions = std::filesystem::status(source, ignored).permissions();
+      if (!ignored) {
+        std::filesystem::permissions(temporary, permissions, ignored);
+      }
+
+      // Never replace a usable backup with a corrupt current file.
+      if (is_valid_config(source)) {
+        atomic_copy(source, backup);
+      }
+    }
+
+    std::filesystem::rename(temporary, source);
+  } catch (...) {
+    std::error_code ignored;
+    std::filesystem::remove(temporary, ignored);
+    throw;
+  }
+}
+
+template <typename Mutation>
+void update_config_file(const std::string &source, Mutation mutation) {
+  std::scoped_lock lock(config_file_mutex);
+  auto config = rfl::toml::load<WolfConfig, rfl::DefaultIfMissing>(source).value();
+  mutation(config);
+  save_config_locked(source, config);
+}
+
+void recover_stale_tail_if_needed(const std::string &source) {
+  try {
+    rfl::toml::load<BaseConfig, rfl::DefaultIfMissing>(source).value();
+    return;
+  } catch (const std::exception &) {
+    if (!looks_like_stale_tail_corruption(source)) {
+      throw;
+    }
+  }
+
+  const auto corrupt = unique_sibling(source, "corrupt");
+  const auto backup = std::filesystem::path(source + ".last-good");
+  std::filesystem::rename(source, corrupt);
+
+  try {
+    if (std::filesystem::exists(backup) && is_valid_config(backup)) {
+      atomic_copy(backup, source);
+      logs::log(logs::warning,
+                "Recovered config file {} from last-known-good backup; preserved damaged file at {}",
+                source,
+                corrupt.string());
+    } else {
+      create_default(source);
+      logs::log(logs::warning,
+                "Recovered stale-tail corruption in {} with defaults; preserved damaged file at {}",
+                source,
+                corrupt.string());
+    }
+  } catch (...) {
+    std::error_code ignored;
+    std::filesystem::remove(source, ignored);
+    std::filesystem::rename(corrupt, source, ignored);
+    throw;
+  }
+}
+
+} // namespace
 
 void create_default(const std::string &source) {
   std::ofstream out_file;
@@ -212,6 +339,11 @@ Config load_or_default(const std::string &source,
   if (!file_exist(source)) {
     logs::log(logs::warning, "Unable to open config file: {}, creating one using defaults", source);
     create_default(source);
+  }
+
+  {
+    std::scoped_lock lock(config_file_mutex);
+    recover_stale_tail_if_needed(source);
   }
 
   // First check the version of the config file
@@ -420,9 +552,7 @@ void pair(const Config &cfg, const PairedClient &client) {
   });
 
   // Update TOML
-  auto tml = rfl::toml::load<WolfConfig, rfl::DefaultIfMissing>(cfg.config_source).value();
-  tml.paired_clients.push_back(client);
-  rfl::toml::save(cfg.config_source, tml);
+  update_config_file(cfg.config_source, [&client](WolfConfig &tml) { tml.paired_clients.push_back(client); });
 }
 
 void unpair(const Config &cfg, const PairedClient &client) {
@@ -436,12 +566,12 @@ void unpair(const Config &cfg, const PairedClient &client) {
   });
 
   // Update TOML
-  auto tml = rfl::toml::load<WolfConfig, rfl::DefaultIfMissing>(cfg.config_source).value();
-  tml.paired_clients.erase(std::remove_if(tml.paired_clients.begin(),
-                                          tml.paired_clients.end(),
-                                          [&client](const auto &v) { return v.client_cert == client.client_cert; }),
-                           tml.paired_clients.end());
-  rfl::toml::save(cfg.config_source, tml);
+  update_config_file(cfg.config_source, [&client](WolfConfig &tml) {
+    tml.paired_clients.erase(std::remove_if(tml.paired_clients.begin(),
+                                            tml.paired_clients.end(),
+                                            [&client](const auto &v) { return v.client_cert == client.client_cert; }),
+                             tml.paired_clients.end());
+  });
 }
 
 void update_client_settings(const Config &cfg, std::size_t client_id, const PairedClient &updated_client) {
@@ -460,41 +590,38 @@ void update_client_settings(const Config &cfg, std::size_t client_id, const Pair
   });
 
   // Update the TOML file
-  auto tml = rfl::toml::load<WolfConfig, rfl::DefaultIfMissing>(cfg.config_source).value();
-
-  tml.paired_clients = tml.paired_clients |                         //
-                       ranges::views::transform(update_client_fn) | //
-                       ranges::to<std::vector<PairedClient>>();
-
-  // Save back to file
-  rfl::toml::save(cfg.config_source, tml);
+  update_config_file(cfg.config_source, [&](WolfConfig &tml) {
+    tml.paired_clients = tml.paired_clients |                         //
+                         ranges::views::transform(update_client_fn) | //
+                         ranges::to<std::vector<PairedClient>>();
+  });
 }
 
 void update_profiles(const Config &cfg, const ProfilesList &profiles) {
   cfg.profiles->store(profiles);
 
-  auto tml = rfl::toml::load<WolfConfig, rfl::DefaultIfMissing>(cfg.config_source).value();
-  tml.profiles = profiles | //
-                 ranges::views::transform([](const immer::box<events::Profile> &p) {
-                   return Profile{
-                       .id = p->id,
-                       .name = p->name,
-                       .icon_png_path = p->icon_png_path,
-                       .pin = p->pin,
-                       .apps = p->apps->load().get() | //
-                               ranges::views::transform([](const immer::box<events::App> &app) {
-                                 return BaseApp{.title = app->base.title,
-                                                .icon_png_path = app->base.icon_png_path,
-                                                .render_node = app->render_node,
-                                                .start_virtual_compositor = app->start_virtual_compositor,
-                                                .start_audio_server = app->start_audio_server,
-                                                .runner = app->runner->serialize()};
-                               }) | //
-                               ranges::to_vector,
-                   };
-                 }) | //
-                 ranges::to_vector;
-  rfl::toml::save(cfg.config_source, tml);
+  update_config_file(cfg.config_source, [&profiles](WolfConfig &tml) {
+    tml.profiles = profiles | //
+                   ranges::views::transform([](const immer::box<events::Profile> &p) {
+                     return Profile{
+                         .id = p->id,
+                         .name = p->name,
+                         .icon_png_path = p->icon_png_path,
+                         .pin = p->pin,
+                         .apps = p->apps->load().get() | //
+                                 ranges::views::transform([](const immer::box<events::App> &app) {
+                                   return BaseApp{.title = app->base.title,
+                                                  .icon_png_path = app->base.icon_png_path,
+                                                  .render_node = app->render_node,
+                                                  .start_virtual_compositor = app->start_virtual_compositor,
+                                                  .start_audio_server = app->start_audio_server,
+                                                  .runner = app->runner->serialize()};
+                                 }) | //
+                                 ranges::to_vector,
+                     };
+                   }) | //
+                   ranges::to_vector;
+  });
 }
 
 } // namespace state

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRC_LIST
         testMoonlight.cpp
         testRTSP.cpp
         testWolfAPI.cpp
+        testConfigPersistence.cpp
         testBatchedSend.cpp)
 
 option(TEST_RUST_WAYLAND "Test our custom Rust wayland compositor" ON)

--- a/tests/testConfigPersistence.cpp
+++ b/tests/testConfigPersistence.cpp
@@ -1,0 +1,180 @@
+#include <catch2/catch_test_macros.hpp>
+#include <events/events.hpp>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <rfl/toml.hpp>
+#include <state/config.hpp>
+
+namespace {
+
+class TemporaryConfig {
+public:
+  TemporaryConfig()
+      : directory_(std::filesystem::temp_directory_path() / ("wolf-config-test-" + state::gen_uuid())),
+        path_(directory_ / "config.toml") {
+    std::filesystem::create_directories(directory_);
+    std::filesystem::copy_file("config.test.toml", path_);
+  }
+
+  ~TemporaryConfig() {
+    std::error_code ignored;
+    std::filesystem::remove_all(directory_, ignored);
+  }
+
+  const std::filesystem::path &path() const { return path_; }
+  const std::filesystem::path &directory() const { return directory_; }
+
+private:
+  std::filesystem::path directory_;
+  std::filesystem::path path_;
+};
+
+std::string read_file(const std::filesystem::path &path) {
+  std::ifstream input(path);
+  return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+void write_file(const std::filesystem::path &path, const std::string &contents) {
+  std::ofstream output(path, std::ios::binary | std::ios::trunc);
+  output << contents;
+}
+
+state::Config load_config(const std::filesystem::path &path) {
+  auto event_bus = std::make_shared<events::EventBusType>();
+  auto running_sessions = std::make_shared<immer::atom<immer::vector<events::StreamSession>>>();
+  return state::load_or_default(path.string(), event_bus, running_sessions);
+}
+
+std::vector<std::filesystem::path> matching_files(const std::filesystem::path &directory,
+                                                  const std::string &needle) {
+  std::vector<std::filesystem::path> matches;
+  for (const auto &entry : std::filesystem::directory_iterator(directory)) {
+    if (entry.path().filename().string().find(needle) != std::string::npos) {
+      matches.push_back(entry.path());
+    }
+  }
+  return matches;
+}
+
+constexpr std::string_view stale_tail_corruption = R"(config_version = 10
+hostname = 'wolf'
+uuid = 'test'
+
+[gstreamer.video]
+hevc_encoders = []
+
+[[gstreamer.video.hevc_encoders]]
+plugin_name = 'x265'
+)";
+
+} // namespace
+
+TEST_CASE("shorter config updates truncate the previous document", "[CONFIG][PERSISTENCE]") {
+  TemporaryConfig temporary;
+  auto config = load_config(temporary.path());
+  const auto original = read_file(temporary.path());
+  const auto original_size = std::filesystem::file_size(temporary.path());
+
+  state::update_profiles(config, {});
+
+  REQUIRE(std::filesystem::file_size(temporary.path()) < original_size);
+  REQUIRE_NOTHROW(
+      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value());
+  REQUIRE(read_file(temporary.path().string() + ".last-good") == original);
+  REQUIRE(matching_files(temporary.directory(), ".tmp-").empty());
+}
+
+TEST_CASE("config updates preserve source permissions", "[CONFIG][PERSISTENCE]") {
+  TemporaryConfig temporary;
+  std::filesystem::permissions(temporary.path(),
+                               std::filesystem::perms::owner_read | std::filesystem::perms::owner_write |
+                                   std::filesystem::perms::group_read);
+  const auto expected = std::filesystem::status(temporary.path()).permissions();
+  auto config = load_config(temporary.path());
+
+  state::update_profiles(config, {});
+
+  REQUIRE(std::filesystem::status(temporary.path()).permissions() == expected);
+}
+
+TEST_CASE("pairing mutations remain valid when the serialized document shrinks", "[CONFIG][PERSISTENCE]") {
+  TemporaryConfig temporary;
+  auto config = load_config(temporary.path());
+  const state::PairedClient client{
+      .client_cert = "persistence-test-client", .app_state_folder = "a-long-folder-name", .settings = {}};
+
+  state::pair(config, client);
+  state::unpair(config, client);
+
+  auto persisted =
+      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value();
+  REQUIRE(std::none_of(persisted.paired_clients.begin(), persisted.paired_clients.end(), [](const auto &candidate) {
+    return candidate.client_cert == "persistence-test-client";
+  }));
+  REQUIRE(matching_files(temporary.directory(), ".tmp-").empty());
+}
+
+TEST_CASE("concurrent config mutations do not lose persisted clients", "[CONFIG][PERSISTENCE]") {
+  TemporaryConfig temporary;
+  auto config = load_config(temporary.path());
+  const auto original_count =
+      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string())
+          .value()
+          .paired_clients.size();
+  std::vector<std::future<void>> mutations;
+
+  for (int id = 0; id < 8; ++id) {
+    mutations.emplace_back(std::async(std::launch::async, [&, id] {
+      state::pair(config,
+                  state::PairedClient{.client_cert = "concurrent-client-" + std::to_string(id),
+                                      .app_state_folder = "folder-" + std::to_string(id),
+                                      .settings = {}});
+    }));
+  }
+  for (auto &mutation : mutations) {
+    mutation.get();
+  }
+
+  auto persisted =
+      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value();
+  REQUIRE(persisted.paired_clients.size() == original_count + mutations.size());
+  REQUIRE(matching_files(temporary.directory(), ".tmp-").empty());
+}
+
+TEST_CASE("known stale-tail corruption restores the last-known-good config", "[CONFIG][RECOVERY]") {
+  TemporaryConfig temporary;
+  const auto original = read_file(temporary.path());
+  std::filesystem::copy_file(temporary.path(), temporary.path().string() + ".last-good");
+  write_file(temporary.path(), std::string(stale_tail_corruption));
+
+  REQUIRE_NOTHROW(load_config(temporary.path()));
+  REQUIRE(read_file(temporary.path()) == original);
+  REQUIRE(matching_files(temporary.directory(), ".corrupt-").size() == 1);
+  REQUIRE(read_file(matching_files(temporary.directory(), ".corrupt-").front()) == stale_tail_corruption);
+}
+
+TEST_CASE("known stale-tail corruption self-heals without a backup", "[CONFIG][RECOVERY]") {
+  TemporaryConfig temporary;
+  write_file(temporary.path(), std::string(stale_tail_corruption));
+
+  // A headless test worker may reject the recovered defaults later during
+  // hardware encoder selection. Recovery itself is complete before that gate.
+  try {
+    load_config(temporary.path());
+  } catch (const std::runtime_error &) {
+  }
+  REQUIRE_NOTHROW(
+      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value());
+  REQUIRE(matching_files(temporary.directory(), ".corrupt-").size() == 1);
+}
+
+TEST_CASE("unrecognized malformed configs fail closed without being replaced", "[CONFIG][RECOVERY]") {
+  TemporaryConfig temporary;
+  const std::string malformed = "this is not = [valid TOML";
+  write_file(temporary.path(), malformed);
+
+  REQUIRE_THROWS(load_config(temporary.path()));
+  REQUIRE(read_file(temporary.path()) == malformed);
+  REQUIRE(matching_files(temporary.directory(), ".corrupt-").empty());
+}

--- a/tests/testConfigPersistence.cpp
+++ b/tests/testConfigPersistence.cpp
@@ -22,8 +22,12 @@ public:
     std::filesystem::remove_all(directory_, ignored);
   }
 
-  const std::filesystem::path &path() const { return path_; }
-  const std::filesystem::path &directory() const { return directory_; }
+  const std::filesystem::path &path() const {
+    return path_;
+  }
+  const std::filesystem::path &directory() const {
+    return directory_;
+  }
 
 private:
   std::filesystem::path directory_;
@@ -46,8 +50,7 @@ state::Config load_config(const std::filesystem::path &path) {
   return state::load_or_default(path.string(), event_bus, running_sessions);
 }
 
-std::vector<std::filesystem::path> matching_files(const std::filesystem::path &directory,
-                                                  const std::string &needle) {
+std::vector<std::filesystem::path> matching_files(const std::filesystem::path &directory, const std::string &needle) {
   std::vector<std::filesystem::path> matches;
   for (const auto &entry : std::filesystem::directory_iterator(directory)) {
     if (entry.path().filename().string().find(needle) != std::string::npos) {
@@ -79,17 +82,16 @@ TEST_CASE("shorter config updates truncate the previous document", "[CONFIG][PER
   state::update_profiles(config, {});
 
   REQUIRE(std::filesystem::file_size(temporary.path()) < original_size);
-  REQUIRE_NOTHROW(
-      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value());
+  REQUIRE_NOTHROW(rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value());
   REQUIRE(read_file(temporary.path().string() + ".last-good") == original);
   REQUIRE(matching_files(temporary.directory(), ".tmp-").empty());
 }
 
 TEST_CASE("config updates preserve source permissions", "[CONFIG][PERSISTENCE]") {
   TemporaryConfig temporary;
-  std::filesystem::permissions(temporary.path(),
-                               std::filesystem::perms::owner_read | std::filesystem::perms::owner_write |
-                                   std::filesystem::perms::group_read);
+  std::filesystem::permissions(
+      temporary.path(),
+      std::filesystem::perms::owner_read | std::filesystem::perms::owner_write | std::filesystem::perms::group_read);
   const auto expected = std::filesystem::status(temporary.path()).permissions();
   auto config = load_config(temporary.path());
 
@@ -101,14 +103,14 @@ TEST_CASE("config updates preserve source permissions", "[CONFIG][PERSISTENCE]")
 TEST_CASE("pairing mutations remain valid when the serialized document shrinks", "[CONFIG][PERSISTENCE]") {
   TemporaryConfig temporary;
   auto config = load_config(temporary.path());
-  const state::PairedClient client{
-      .client_cert = "persistence-test-client", .app_state_folder = "a-long-folder-name", .settings = {}};
+  const state::PairedClient client{.client_cert = "persistence-test-client",
+                                   .app_state_folder = "a-long-folder-name",
+                                   .settings = {}};
 
   state::pair(config, client);
   state::unpair(config, client);
 
-  auto persisted =
-      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value();
+  auto persisted = rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value();
   REQUIRE(std::none_of(persisted.paired_clients.begin(), persisted.paired_clients.end(), [](const auto &candidate) {
     return candidate.client_cert == "persistence-test-client";
   }));
@@ -136,8 +138,7 @@ TEST_CASE("concurrent config mutations do not lose persisted clients", "[CONFIG]
     mutation.get();
   }
 
-  auto persisted =
-      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value();
+  auto persisted = rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value();
   REQUIRE(persisted.paired_clients.size() == original_count + mutations.size());
   REQUIRE(matching_files(temporary.directory(), ".tmp-").empty());
 }
@@ -164,8 +165,7 @@ TEST_CASE("known stale-tail corruption self-heals without a backup", "[CONFIG][R
     load_config(temporary.path());
   } catch (const std::runtime_error &) {
   }
-  REQUIRE_NOTHROW(
-      rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value());
+  REQUIRE_NOTHROW(rfl::toml::load<wolf::config::WolfConfig, rfl::DefaultIfMissing>(temporary.path().string()).value());
   REQUIRE(matching_files(temporary.directory(), ".corrupt-").size() == 1);
 }
 


### PR DESCRIPTION
## Summary
Wolf config updates can leave stale TOML data or lose concurrent mutations; this serializes updates and publishes validated replacement files atomically.

## Why This Exists
The current serializer writes to an existing destination without reliably truncating a longer previous document. When a config shrinks, stale array-table data can remain at the tail and make the next startup fail. Independent read-modify-write calls can also race and silently discard a pairing or profile update.

## Resolution
Serialize each mutation under one process-local mutex, write to a unique sibling file, parse the completed file before publishing it, preserve permissions, retain a last-known-good copy, and replace the live config with one same-directory rename. Startup recovery is deliberately limited to the known stale-tail signature; unrelated malformed files still fail closed and remain untouched.

## Reviewer Considerations
- Atomic replacement relies on source and temporary files sharing a directory and filesystem.
- The backup is refreshed only from a config that parses successfully, so a damaged live file cannot overwrite the recovery point.
- Recovery preserves the damaged file for diagnosis and does not attempt to repair unrecognized TOML failures.
- The mutex coordinates writers inside one Wolf process; it is not an inter-process lock.

## Behavior Changes
Pairing, unpairing, client-setting, and profile updates no longer expose partially written files or lose same-process concurrent mutations. A config damaged by the known stale-tail bug is restored from its last-known-good copy, or regenerated from defaults when no valid backup exists.

## Implementation Summary
- Route all config mutations through a locked read-modify-validate-replace helper.
- Preserve existing permissions and a validated `.last-good` sibling.
- Add narrow startup recovery for stale encoder array tails.
- Add focused persistence, concurrency, permission, backup, and recovery tests.

## Verification
- The complete `[CONFIG]` persistence and recovery suite passed in the Linux/amd64 Wolf image build.
- The complete Wolf image regression suite passed with this change applied.
- Changed C++ sources pass `clang-format --dry-run --Werror` with clang-format 21.1.8.
- GitHub's fork workflows are awaiting maintainer approval; they have not reported a test failure.

## Risk
Moderate; this changes persistence and recovery behavior, but each write is validated before publication and unrecognized corruption remains fail-closed.
