### PR TITLE
fix(hardware): own DRM descriptors by value

### DIFF
--- a/.github/workflows/linux-build-test.yml
+++ b/.github/workflows/linux-build-test.yml
@@ -202,7 +202,13 @@ jobs:
 
       - name: Build tests + lib
         working-directory: ${{runner.workspace}}/build
-        run: ninja -j $(nproc) wolftests
+        run: ninja -j $(nproc) wolftests wolf_drm_tests
+
+      - name: Run DRM descriptor ownership tests
+        working-directory: ${{runner.workspace}}/build/tests
+        env:
+          ASAN_OPTIONS: detect_stack_use_after_return=1
+        run: ./wolf_drm_tests
 
       - name: Run tests
         working-directory: ${{runner.workspace}}/build/tests

--- a/src/moonlight-server/platforms/hw_linux.cpp
+++ b/src/moonlight-server/platforms/hw_linux.cpp
@@ -94,13 +94,17 @@ std::optional<std::string> get_nvidia_node(std::string_view primary_node) {
  */
 std::shared_ptr<drmDevice> drm_open_device(std::string_view device) {
   auto render_node_fd = open(device.data(), O_RDWR | O_CLOEXEC);
+  if (render_node_fd < 0) {
+    throw std::runtime_error(fmt::format("Error opening DRM device {}, {}", device, strerror(errno)));
+  }
   drmDevice *dev = nullptr;
   auto ret = drmGetDevice2(render_node_fd, 0, &dev);
   if (ret < 0) {
+    close(render_node_fd);
     throw std::runtime_error(fmt::format("Error during drmGetDevice for {}, {}", device, strerror(-ret)));
   }
 
-  return {dev, [&render_node_fd](auto dev) {
+  return {dev, [render_node_fd](auto dev) {
             drmFreeDevice(&dev);
             close(render_node_fd);
           }};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,19 @@ FetchContent_MakeAvailable(Catch2)
 
 project(wolftests CXX C)
 
+# Keep the fake libdrm boundary out of the hardware-capable wolftests process.
+if (UNIX AND NOT APPLE AND LIBDRM_FOUND AND LIBPCI_FOUND)
+    add_executable(wolf_drm_tests
+            testDrmDevice.cpp
+            ../src/moonlight-server/platforms/hw_linux.cpp)
+    target_link_libraries(wolf_drm_tests PRIVATE wolf::runner)
+    target_compile_options(wolf_drm_tests PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(wolf_drm_tests PRIVATE -fsanitize=address)
+    add_test(NAME "DRM descriptor ownership" COMMAND wolf_drm_tests)
+    set_tests_properties("DRM descriptor ownership" PROPERTIES
+            ENVIRONMENT "ASAN_OPTIONS=detect_stack_use_after_return=1")
+endif ()
+
 # Tests need to be added as executables first
 add_executable(wolftests main.cpp)
 

--- a/tests/testDrmDevice.cpp
+++ b/tests/testDrmDevice.cpp
@@ -1,0 +1,98 @@
+#include <cerrno>
+#include <cstdint>
+#include <fcntl.h>
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+#include <string_view>
+#include <unistd.h>
+#include <xf86drm.h>
+
+std::shared_ptr<drmDevice> drm_open_device(std::string_view device);
+
+namespace {
+int lookup_result = 0;
+int lookup_count = 0;
+int opened_fd = -1;
+int free_count = 0;
+
+void require(bool condition, const char *message) {
+  if (!condition) {
+    throw std::runtime_error(message);
+  }
+}
+
+bool is_open(int fd) {
+  return fcntl(fd, F_GETFD) != -1;
+}
+} // namespace
+
+// Only libdrm is replaced. The production owner and POSIX descriptors run for real.
+extern "C" int drmGetDevice2(int fd, uint32_t, drmDevicePtr *device) {
+  opened_fd = fd;
+  ++lookup_count;
+  if (lookup_result < 0) {
+    return lookup_result;
+  }
+  *device = new drmDevice{};
+  return 0;
+}
+
+extern "C" void drmFreeDevice(drmDevicePtr *device) {
+  ++free_count;
+  delete *device;
+  *device = nullptr;
+}
+
+int main() {
+  try {
+    const int unrelated = fcntl(STDERR_FILENO, F_DUPFD_CLOEXEC, 3);
+    require(unrelated >= 0, "cannot open unrelated descriptor");
+    auto device = drm_open_device("/dev/null");
+    const int owned = opened_fd;
+    require(owned >= 0 && owned != unrelated && is_open(owned), "device must own an open descriptor");
+    auto retained = device;
+    device.reset();
+    require(is_open(owned) && free_count == 0, "a retained device must remain open");
+    retained.reset();
+    require(!is_open(owned) && errno == EBADF, "last owner must close the acquired descriptor");
+    require(is_open(unrelated) && free_count == 1, "cleanup must not close another descriptor");
+
+    lookup_result = -EINVAL;
+    bool failed = false;
+    try {
+      drm_open_device("/dev/null");
+    } catch (const std::runtime_error &) {
+      failed = true;
+    }
+    require(failed && !is_open(opened_fd), "failed lookup must close its acquired descriptor");
+    require(is_open(unrelated) && free_count == 1, "failed lookup must not release another device");
+
+    const int prior_lookups = lookup_count;
+    failed = false;
+    try {
+      drm_open_device("/dev/null/not-a-device");
+    } catch (const std::runtime_error &) {
+      failed = true;
+    }
+    require(failed && lookup_count == prior_lookups, "failed open must not call libdrm");
+
+    lookup_result = 0;
+    const int saved_stdin = fcntl(STDIN_FILENO, F_DUPFD_CLOEXEC, 3);
+    close(STDIN_FILENO);
+    device = drm_open_device("/dev/null");
+    require(opened_fd == 0 && is_open(0), "descriptor zero is a valid owned descriptor");
+    device.reset();
+    require(!is_open(0) && is_open(unrelated), "descriptor zero must close without affecting another descriptor");
+    if (saved_stdin >= 0) {
+      require(dup2(saved_stdin, STDIN_FILENO) == STDIN_FILENO, "cannot restore stdin");
+      close(saved_stdin);
+    }
+    close(unrelated);
+    std::cout << "DRM descriptor ownership checks passed\n";
+    return 0;
+  } catch (const std::exception &error) {
+    std::cerr << error.what() << '\n';
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary
Wolf can close an unrelated file descriptor because a DRM device deleter captures a stack variable by reference; this owns the descriptor by value and tests its full lifetime under AddressSanitizer.

## Why This Exists
`drm_open_device` returns a shared owner whose deleter can outlive the function call. Capturing the local descriptor variable by reference leaves that deleter with dangling stack storage. A later cleanup can therefore close whichever descriptor value happens to occupy that memory. Failed `open` and `drmGetDevice2` paths also need deterministic descriptor cleanup.

## Resolution
Capture the acquired descriptor by value, reject failed opens before calling libdrm, and close the descriptor when device lookup fails. A Linux-only test executable replaces only the libdrm boundary while exercising real POSIX descriptors and the production owner.

## Reviewer Considerations
- The test is separate from `wolftests` so fake libdrm symbols do not enter the hardware-capable test process.
- AddressSanitizer's stack-use-after-return mode protects the original dangling-reference failure mode.
- The test covers shared ownership, failed lookup, failed open, descriptor zero, and an unrelated descriptor.

## Behavior Changes
DRM discovery now fails immediately when a render node cannot be opened and always releases descriptors on lookup failure or final owner destruction.

## Implementation Summary
- Validate `open` before calling `drmGetDevice2`.
- Capture the render-node descriptor by value in the shared deleter.
- Add the focused Linux/ASAN regression target to the existing CI matrix.

## Verification
- The production owner test passed under AddressSanitizer in the Linux/amd64 Wolf image build.
- The complete Wolf image regression suite passed with this change applied.
- Changed C++ sources pass `clang-format --dry-run --Werror` with clang-format 21.1.8.
- GitHub's fork workflows are awaiting maintainer approval; they have not reported a test failure.

## Risk
Low; the runtime change is confined to descriptor ownership and error cleanup, with the former behavior covered directly by the new test.
